### PR TITLE
Route for the chase vehicle: direct, major roads, towing and low bridges

### DIFF
--- a/apps/mobile/lib/app/balloon_crumbs_app.dart
+++ b/apps/mobile/lib/app/balloon_crumbs_app.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../controllers/chase_vehicle_controller.dart';
 import '../controllers/distance_unit_controller.dart';
 import '../controllers/completed_rides_controller.dart';
 import '../controllers/map_style_mode_controller.dart';
@@ -33,6 +34,7 @@ class BalloonCrumbsApp extends StatelessWidget {
     required this.riderProfile,
     required this.sharedRoutes,
     required this.speedLimitDisplay,
+    this.chaseVehicle,
     this.routeProgressDisplay,
     required this.recordedRoutes,
     required this.completedRides,
@@ -54,6 +56,7 @@ class BalloonCrumbsApp extends StatelessWidget {
   final RiderProfileController riderProfile;
   final SharedRouteController sharedRoutes;
   final SpeedLimitDisplayController speedLimitDisplay;
+  final ChaseVehicleController? chaseVehicle;
   final RouteProgressDisplayController? routeProgressDisplay;
   final RecordedRouteStore recordedRoutes;
   final CompletedRidesController completedRides;
@@ -112,6 +115,7 @@ class BalloonCrumbsApp extends StatelessWidget {
         sharedRoutes,
         riderProfile,
         speedLimitDisplay,
+        ?chaseVehicle,
         ?routeProgressDisplay,
       ]),
       builder: (context, _) {
@@ -127,6 +131,7 @@ class BalloonCrumbsApp extends StatelessWidget {
             riderProfile: riderProfile,
             sharedRoutes: sharedRoutes,
             speedLimitDisplay: speedLimitDisplay,
+            chaseVehicle: chaseVehicle,
             routeProgressDisplay: routeProgressDisplay,
             recordedRoutes: recordedRoutes,
             completedRides: completedRides,
@@ -155,6 +160,7 @@ class BalloonCrumbsApp extends StatelessWidget {
             riderProfile: riderProfile,
             sharedRoutes: sharedRoutes,
             speedLimitDisplay: speedLimitDisplay,
+            chaseVehicle: chaseVehicle,
             routeProgressDisplay: routeProgressDisplay,
             completedRideStore: completedRides,
             testControl: testControl,
@@ -175,6 +181,7 @@ class BalloonCrumbsApp extends StatelessWidget {
           riderProfile: riderProfile,
           sharedRoutes: sharedRoutes,
           speedLimitDisplay: speedLimitDisplay,
+          chaseVehicle: chaseVehicle,
           routeProgressDisplay: routeProgressDisplay,
           recordedRoutes: recordedRoutes,
           completedRides: completedRides,

--- a/apps/mobile/lib/controllers/chase_vehicle_controller.dart
+++ b/apps/mobile/lib/controllers/chase_vehicle_controller.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../domain/chase_vehicle.dart';
+
+/// Remembers the crew's own vehicle across flights.
+///
+/// Deliberately a stored device preference rather than a question at the start
+/// of each flight. The same Land Rover tows the same trailer next weekend, and
+/// the person who would have to answer is about to start driving — a form
+/// between them and a launch is a form that gets dismissed, which would leave
+/// the height blank exactly when the crew believed they had set it.
+///
+/// Stored as JSON under one key so [ChaseVehicle]'s own degrading parse handles
+/// anything unexpected, and so adding a dimension later does not need a
+/// migration or a second key.
+class ChaseVehicleController extends ChangeNotifier {
+  ChaseVehicleController._(this._preferences, this._vehicle);
+
+  static const preferenceKey = 'chase-vehicle-v1';
+
+  final SharedPreferences? _preferences;
+  ChaseVehicle _vehicle;
+
+  ChaseVehicle get vehicle => _vehicle;
+
+  static Future<ChaseVehicleController> load() async {
+    final preferences = await SharedPreferences.getInstance();
+    return ChaseVehicleController._(
+      preferences,
+      _read(preferences.getString(preferenceKey)),
+    );
+  }
+
+  @visibleForTesting
+  factory ChaseVehicleController.memory({
+    ChaseVehicle vehicle = ChaseVehicle.unspecified,
+  }) => ChaseVehicleController._(null, vehicle);
+
+  Future<void> set(ChaseVehicle vehicle) async {
+    if (_vehicle == vehicle) return;
+    _vehicle = vehicle;
+    // Nothing specified is stored as nothing at all, not as an empty object, so
+    // "never told us" and "told us and then cleared it" read back the same. They
+    // mean the same thing and must not diverge.
+    if (vehicle.isSpecified) {
+      await _preferences?.setString(
+        preferenceKey,
+        jsonEncode(vehicle.toJson()),
+      );
+    } else {
+      await _preferences?.remove(preferenceKey);
+    }
+    notifyListeners();
+  }
+
+  /// A stored vehicle that cannot be read degrades to unspecified rather than
+  /// throwing. The cost of that is a crew re-entering four numbers; the cost of
+  /// throwing is an app that will not open.
+  static ChaseVehicle _read(String? stored) {
+    if (stored == null || stored.isEmpty) return ChaseVehicle.unspecified;
+    try {
+      final decoded = jsonDecode(stored);
+      if (decoded is! Map) return ChaseVehicle.unspecified;
+      return ChaseVehicle.fromJson(
+        decoded.map((key, value) => MapEntry(key.toString(), value)),
+      );
+    } on FormatException {
+      return ChaseVehicle.unspecified;
+    }
+  }
+}

--- a/apps/mobile/lib/domain/chase_vehicle.dart
+++ b/apps/mobile/lib/domain/chase_vehicle.dart
@@ -1,0 +1,198 @@
+/// The physical chase vehicle, as the crew described it.
+///
+/// There is no fixed chase vehicle to model and no list to choose from: it
+/// varies by crew and could be anything from a hatchback to a Land Rover towing
+/// a trailer with a basket on it. So every dimension here is *entered*, never
+/// inferred from a vehicle type.
+///
+/// Every field is nullable and empty by default, and that is load-bearing. A
+/// blank height means "nobody told us", not "assume it fits". The two must not
+/// be confused, because the second one is the sentence that drives a trailer
+/// into a bridge. Nothing is claimed on the crew's behalf: with nothing entered,
+/// routing behaves exactly as it did before this existed.
+///
+/// The vehicle belongs to the crew rather than to a flight. The same Land Rover
+/// tows the same trailer next weekend, so this is entered once and kept, not
+/// asked again at the start of every flight — the person who would answer is
+/// about to start driving.
+class ChaseVehicle {
+  const ChaseVehicle({
+    this.heightMetres,
+    this.widthMetres,
+    this.lengthMetres,
+    this.grossWeightTonnes,
+    this.towing = false,
+  });
+
+  /// Nothing entered. Routes as a car, which is what the app did before the
+  /// crew could describe their vehicle at all.
+  static const ChaseVehicle unspecified = ChaseVehicle();
+
+  /// Overall height including anything on the roof, in metres. The dimension
+  /// that low bridges care about.
+  final double? heightMetres;
+
+  /// Overall width excluding mirrors, in metres.
+  final double? widthMetres;
+
+  /// Overall length, in metres. Including the trailer when [towing], which is
+  /// usually the dimension towing changes most: a car and trailer is often
+  /// twice as long and no wider.
+  final double? lengthMetres;
+
+  /// The heaviest the vehicle and anything it is towing can legally be
+  /// *together*, in tonnes.
+  ///
+  /// Deliberately the combined figure and deliberately the maximum, because
+  /// this is checked against weight-restricted bridges and structures. A towbar
+  /// capacity or an unladen weight would be the wrong number in the dangerous
+  /// direction: it would route a loaded trailer over a bridge that cannot take
+  /// it. Overstating costs a detour, understating costs a bridge.
+  final double? grossWeightTonnes;
+
+  /// Whether a trailer is attached. On its own this changes no numbers — it
+  /// cannot, because a trailer has no default size — but it is what makes the
+  /// weight field mean the combined weight, and it asks the router to prefer
+  /// straighter roads.
+  final bool towing;
+
+  /// Whether the crew has entered any dimension at all.
+  ///
+  /// The switch that decides whether routing can say anything about physical
+  /// restrictions. False means it cannot, and must not pretend to.
+  bool get hasDimensions =>
+      heightMetres != null ||
+      widthMetres != null ||
+      lengthMetres != null ||
+      grossWeightTonnes != null;
+
+  /// Whether anything at all has been said about the vehicle.
+  bool get isSpecified => hasDimensions || towing;
+
+  /// Whether the route must be planned with Valhalla's `truck` costing rather
+  /// than `auto`.
+  ///
+  /// This is the whole reason the fields exist. Valhalla's `auto` costing
+  /// ignores `maxheight`, `maxweight` and `maxwidth` entirely, so a chase
+  /// vehicle routed as a car is routed under low bridges without a word.
+  /// `truck` costing reads those OpenStreetMap restrictions and applies
+  /// manoeuvre costs that suit something long.
+  ///
+  /// Requires a dimension, not merely [towing]: `truck` costing without
+  /// dimensions falls back to Valhalla's own defaults, which describe an
+  /// articulated lorry — 4.11 m tall and 21.77 t. Applying those to a crew who
+  /// ticked "towing" and typed nothing else would refuse half the roads to the
+  /// county, and refuse them for reasons the crew never stated.
+  bool get requiresTruckCosting => hasDimensions;
+
+  /// The dimensions to send under `costing_options.truck`.
+  ///
+  /// Unentered dimensions are sent as ordinary car figures rather than left out.
+  /// Omitting them would inherit Valhalla's lorry defaults, and a blank field
+  /// means "not told", which must restrict nothing. So the fallbacks are
+  /// deliberately small: understating a dimension the crew never gave applies no
+  /// restriction on that axis, which is the same answer they got before.
+  ///
+  /// This is not a claim that the vehicle is car-sized. It is a refusal to
+  /// invent a restriction from a field nobody filled in.
+  Map<String, Object?> valhallaTruckDimensions() => {
+    'height': heightMetres ?? 2,
+    'width': widthMetres ?? 2,
+    'length': lengthMetres ?? 5,
+    'weight': grossWeightTonnes ?? 2,
+    // Never hazmat. A chase vehicle carries cylinders, and propane is a
+    // dangerous good, but hazmat routing is a legal regime about placarded
+    // loads that a crew has not entered and this app must not assert.
+    'hazmat': false,
+  };
+
+  /// What the crew will read back, so the numbers being routed against can be
+  /// checked. Empty when nothing was entered, which is itself the honest
+  /// summary.
+  List<String> get appliedNotes => [
+    if (towing) 'towing',
+    if (heightMetres case final height?) '${_number(height)} m high',
+    if (widthMetres case final width?) '${_number(width)} m wide',
+    if (lengthMetres case final length?) '${_number(length)} m long',
+    if (grossWeightTonnes case final weight?) '${_number(weight)} t',
+  ];
+
+  ChaseVehicle copyWith({
+    double? heightMetres,
+    double? widthMetres,
+    double? lengthMetres,
+    double? grossWeightTonnes,
+    bool? towing,
+    bool clearHeight = false,
+    bool clearWidth = false,
+    bool clearLength = false,
+    bool clearWeight = false,
+  }) => ChaseVehicle(
+    heightMetres: clearHeight ? null : heightMetres ?? this.heightMetres,
+    widthMetres: clearWidth ? null : widthMetres ?? this.widthMetres,
+    lengthMetres: clearLength ? null : lengthMetres ?? this.lengthMetres,
+    grossWeightTonnes: clearWeight
+        ? null
+        : grossWeightTonnes ?? this.grossWeightTonnes,
+    towing: towing ?? this.towing,
+  );
+
+  Map<String, Object?> toJson() => {
+    'heightMetres': ?heightMetres,
+    'widthMetres': ?widthMetres,
+    'lengthMetres': ?lengthMetres,
+    'grossWeightTonnes': ?grossWeightTonnes,
+    if (towing) 'towing': true,
+  };
+
+  /// Reads a vehicle a route was planned with.
+  ///
+  /// A value that is not a plausible dimension degrades to null — not told —
+  /// rather than throwing or being clamped into range. A stored route from
+  /// another build must still open, and a nonsense height must not quietly
+  /// become a real restriction the crew never entered.
+  factory ChaseVehicle.fromJson(Map<String, Object?> json) => ChaseVehicle(
+    heightMetres: _dimension(json['heightMetres'], maximum: 7),
+    widthMetres: _dimension(json['widthMetres'], maximum: 4),
+    lengthMetres: _dimension(json['lengthMetres'], maximum: 30),
+    grossWeightTonnes: _dimension(json['grossWeightTonnes'], maximum: 44),
+    towing: json['towing'] == true,
+  );
+
+  /// Accepts a number a person could have typed, and nothing else. Zero and
+  /// negatives are not small vehicles, they are empty or broken fields.
+  static double? _dimension(Object? value, {required double maximum}) {
+    final number = value is num
+        ? value.toDouble()
+        : value is String
+        ? double.tryParse(value.trim())
+        : null;
+    if (number == null || !number.isFinite) return null;
+    return number > 0 && number <= maximum ? number : null;
+  }
+
+  static String _number(double value) => value == value.roundToDouble()
+      ? value.round().toString()
+      : value.toStringAsFixed(2).replaceFirst(RegExp(r'0+$'), '');
+
+  @override
+  bool operator ==(Object other) =>
+      other is ChaseVehicle &&
+      other.heightMetres == heightMetres &&
+      other.widthMetres == widthMetres &&
+      other.lengthMetres == lengthMetres &&
+      other.grossWeightTonnes == grossWeightTonnes &&
+      other.towing == towing;
+
+  @override
+  int get hashCode => Object.hash(
+    heightMetres,
+    widthMetres,
+    lengthMetres,
+    grossWeightTonnes,
+    towing,
+  );
+
+  @override
+  String toString() => 'ChaseVehicle(${toJson()})';
+}

--- a/apps/mobile/lib/domain/route_preferences.dart
+++ b/apps/mobile/lib/domain/route_preferences.dart
@@ -1,59 +1,91 @@
-/// Route character preferences, shared with the web planner.
+/// Route preferences: what kind of road, and what size of vehicle.
 ///
-/// These are deliberately *not* a second set of preferences. Every value,
-/// label, threshold and provider option in this file is the Dart half of the
-/// contract the web planner already implements in
-/// `apps/website/planner-core.mjs`, and the contract itself is written down once
-/// in `docs/route-twistiness.md`. A route planned on the desktop and a route
-/// planned in the app must agree about what "avoid motorways" means, so the two
-/// implementations are pinned to identical constants by tests on both sides
-/// rather than left to drift.
+/// This file used to open by declaring itself the Dart half of a contract with
+/// `apps/website/planner-core.mjs`, pinned to it by tests on both sides and
+/// documented in `docs/route-twistiness.md`. None of those files exist, and none
+/// ever have in this repository — they belong to Tail End Charlie, which was
+/// never brought across. The claim cost real time to disprove, so it is written
+/// down here plainly: this is the only implementation, and it is free to change
+/// without renegotiating anything.
 ///
 /// Preferences belong to the route, not to the device: they travel with the
-/// route record and through its GPX, so a route shared into a ride still says
-/// what it was planned for.
+/// route record and through its GPX, so a route shared into a flight still says
+/// what it was planned for, and for what vehicle.
 library;
 
-/// How much extra time a rider will accept in exchange for bends.
+import 'chase_vehicle.dart';
+
+export 'chase_vehicle.dart';
+
+/// What kind of road the route should favour.
 ///
-/// The API values are the web planner's `<select id="route-style">` values, and
-/// the detour limits are `routeDetourLimit` in `planner-core.mjs`.
+/// This replaces a ladder of detour tolerance bought with bends — quickest,
+/// flowing (+25%), twisty (+50%), very twisty (+75%) — inherited from an app
+/// where finding corners was the entire point. A chase crew is trying to be
+/// underneath a balloon when it lands. Spending 75% more time on the road for
+/// entertainment is not a preference they have, and biasing a vehicle that is
+/// towing off main roads and onto lanes does not merely slow it down, it can
+/// stop it getting there at all.
+///
+/// Two options, because there is a real choice underneath: the fastest line, or
+/// main roads even when they are slightly longer. The second is what a driver
+/// towing a trailer usually wants, and it is a preference rather than a
+/// consequence of the trailer, which is why it lives here and not on
+/// [ChaseVehicle].
 enum RouteStyle {
-  quickest('quickest', 'Quickest route', 1),
-  flowing('balanced', 'Flowing (up to 25% longer)', 1.25),
-  twisty('twisty', 'Twisty (up to 50% longer)', 1.5),
-  veryTwisty('very-twisty', 'Very twisty (up to 75% longer)', 1.75);
+  /// The default. Fastest way there, no opinion about road class.
+  direct('direct', 'Direct — fastest way there'),
 
-  const RouteStyle(this.apiValue, this.label, this.detourLimit);
+  /// Favour trunk and primary roads, and accept a modest detour to stay on
+  /// them. Wide lanes, gentle bends, predictable junctions: easier with a
+  /// trailer, and far easier when the driver is watching a balloon rather than
+  /// the map.
+  majorRoads('major-roads', 'Prefer major roads');
 
-  /// The value written to JSON, GPX and provider requests. It is the web
-  /// planner's option value, which is why `flowing` serialises as `balanced`.
+  const RouteStyle(this.apiValue, this.label);
+
+  /// The value written to JSON, GPX and provider requests.
+  ///
+  /// The four inherited values (`quickest`, `balanced`, `twisty`,
+  /// `very-twisty`) are gone from this enum but may still be sitting in stored
+  /// routes, so [fromApiValue] has to keep answering for them. See there.
   final String apiValue;
   final String label;
 
-  /// The most a chosen alternative may exceed the quickest route's duration.
-  final double detourLimit;
-
-  /// A rider asking for bends wants the provider to offer alternatives to
-  /// score; the quickest route needs none.
-  bool get prefersBends => this != RouteStyle.quickest;
-
-  /// Valhalla `use_highways` for this style, or null when the style expresses
-  /// no highway preference of its own.
-  ///
-  /// Inherited from motorcycling, where seeking bends is the point. A chase crew
-  /// wants the quickest way to a landing zone, so biasing them off highways is
-  /// probably wrong — but it is a preference a person chooses, so WP7 gets to
-  /// decide whether the choice survives rather than this changing it quietly.
-  double? get highwayPreference => switch (this) {
-    RouteStyle.quickest => null,
-    RouteStyle.flowing => 0.6,
-    RouteStyle.twisty => 0.35,
-    RouteStyle.veryTwisty => 0.15,
+  /// Valhalla `use_highways` for this style.
+  double get highwayPreference => switch (this) {
+    RouteStyle.direct => 1,
+    RouteStyle.majorRoads => 1,
   };
 
+  /// Valhalla `use_living_streets`. Residential streets and home zones are
+  /// where a long vehicle gets stuck and where children play; a route that
+  /// prefers major roads should not thread through them.
+  double get livingStreetPreference => switch (this) {
+    RouteStyle.direct => 0.5,
+    RouteStyle.majorRoads => 0,
+  };
+
+  /// Reads a stored style, degrading anything unrecognised to [direct].
+  ///
+  /// The four motorcycle styles resolve here, and they all resolve to [direct]
+  /// rather than to the nearest-looking survivor. A route stored as `twisty`
+  /// asked for a 50% detour in exchange for corners; there is no honest
+  /// translation of that into a chase preference, and inventing one would apply
+  /// a bias to somebody's route that they never chose for this vehicle. The
+  /// route itself is unchanged — only what a re-plan would ask for.
   static RouteStyle? fromApiValue(Object? value) =>
-      RouteStyle.values.where((style) => style.apiValue == value).firstOrNull;
+      RouteStyle.values.where((style) => style.apiValue == value).firstOrNull ??
+      (value is String && _retiredStyles.contains(value)
+          ? RouteStyle.direct
+          : null);
+
+  static const _retiredStyles = {
+    'quickest',
+    'balanced',
+    'twisty',
+    'very-twisty',
+  };
 }
 
 /// What to do about byways open to all traffic and other unsurfaced roads.
@@ -90,12 +122,13 @@ enum BywaySurfacePreference {
 /// The route character a rider asked for.
 class RoutePreferences {
   const RoutePreferences({
-    this.style = RouteStyle.quickest,
+    this.style = RouteStyle.direct,
     this.avoidMotorways = false,
     this.avoidMajorRoads = false,
     this.avoidTolls = false,
     this.avoidFerries = false,
     this.bywaySurface = BywaySurfacePreference.avoidUnsurfaced,
+    this.vehicle = ChaseVehicle.unspecified,
   });
 
   static const RoutePreferences defaults = RoutePreferences();
@@ -111,6 +144,10 @@ class RoutePreferences {
   final bool avoidTolls;
   final bool avoidFerries;
   final BywaySurfacePreference bywaySurface;
+
+  /// The vehicle these roads have to fit. Unspecified by default, in which case
+  /// nothing physical is asserted and the route is planned as a car.
+  final ChaseVehicle vehicle;
 
   bool get isDefault => this == defaults;
 
@@ -129,7 +166,55 @@ class RoutePreferences {
       avoidMajorRoads ||
       avoidTolls ||
       avoidFerries ||
-      !bywaySurface.avoidsUnsurfaced;
+      !bywaySurface.avoidsUnsurfaced ||
+      style == RouteStyle.majorRoads ||
+      vehicle.requiresTruckCosting;
+
+  /// Whether tight bends are a problem for this vehicle, so the router should
+  /// be asked for alternatives and given the straightest one it can afford.
+  ///
+  /// Driven by [ChaseVehicle.towing] alone, not by the dimensions. A trailer is
+  /// the thing that makes a sharp bend into a manoeuvre, and it is stated
+  /// explicitly rather than guessed from a length — "5 m long" describes an
+  /// ordinary estate car, and inferring a bend aversion from it would apply one
+  /// to most of the fleet.
+  ///
+  /// The bend score doing the work here is the one the motorcycle build used to
+  /// *seek* corners, read the other way round. That inversion is the whole of
+  /// the change: the measurement was always sound, it was the sign that belonged
+  /// to a different app.
+  bool get prefersStraighterRoads => vehicle.towing;
+
+  /// How much longer a straighter route may take before it stops being worth
+  /// having: 15%, and not a fraction more.
+  ///
+  /// A property of the trailer rather than of the road style, which is what the
+  /// inherited model got wrong. Detour tolerance used to hang off the style, so
+  /// the default style allowed 0% — and a crew who ticked "towing" got a
+  /// preference that could never once change the route they were given. It went
+  /// unnoticed because the field was still there and still being read.
+  ///
+  /// 15% because the deadline is physical. A balloon comes down when it comes
+  /// down, and a crew cannot spend twenty minutes avoiding corners to arrive
+  /// after it has landed in somebody's wheat.
+  static const towingDetourLimit = 1.15;
+
+  /// Which Valhalla costing model plans this route.
+  ///
+  /// `truck` only once the crew has entered a dimension, because that is the
+  /// only thing `truck` can do that `auto` cannot: read `maxheight`,
+  /// `maxweight` and `maxwidth`. Switching on the strength of a ticked "towing"
+  /// box would apply Valhalla's articulated-lorry defaults to a vehicle nobody
+  /// described. See [ChaseVehicle.requiresTruckCosting].
+  String get valhallaCosting => vehicle.requiresTruckCosting ? 'truck' : 'auto';
+
+  /// `costing_options` for [valhallaCosting], keyed as Valhalla expects.
+  Map<String, Object?> valhallaCostingOptions() => {
+    valhallaCosting: {
+      ...valhallaRoadCostingOptions(),
+      if (vehicle.requiresTruckCosting) ...vehicle.valhallaTruckDimensions(),
+    },
+  };
 
   /// Valhalla `costing_options.auto`.
   ///
@@ -148,8 +233,11 @@ class RoutePreferences {
   /// `exclude_unpaved` and `use_tracks` both derive from OpenStreetMap surface
   /// and track tagging, which is what makes the byway preference honour the tags
   /// instead of guessing from road class.
-  Map<String, Object?> valhallaAutoCostingOptions() => {
-    'use_highways': avoidMajorRoads ? 0.08 : style.highwayPreference ?? 1,
+  Map<String, Object?> valhallaRoadCostingOptions() => {
+    // An explicit "avoid major roads" beats the style: it is a hard instruction
+    // the crew typed, where the style is a leaning.
+    'use_highways': avoidMajorRoads ? 0.08 : style.highwayPreference,
+    'use_living_streets': style.livingStreetPreference,
     'use_tolls': avoidTolls ? 0 : 0.5,
     'use_ferry': avoidFerries ? 0 : 0.5,
     'use_tracks': bywaySurface.avoidsUnsurfaced ? 0 : 0.5,
@@ -162,13 +250,7 @@ class RoutePreferences {
   /// One sentence a rider can check the route against, in the same order and
   /// wording as the web planner's status line.
   List<String> get appliedNotes => [
-    if (style.prefersBends)
-      switch (style) {
-        RouteStyle.flowing => 'Flowing-road bias',
-        RouteStyle.twisty => 'Twisty-road bias',
-        RouteStyle.veryTwisty => 'Very-twisty-road bias',
-        RouteStyle.quickest => '',
-      },
+    if (style == RouteStyle.majorRoads) 'Major roads preferred',
     if (avoidMotorways) 'motorways excluded',
     if (avoidMajorRoads) 'major roads avoided',
     if (avoidTolls) 'tolls excluded',
@@ -177,6 +259,11 @@ class RoutePreferences {
       'unsurfaced byways avoided'
     else
       'unsurfaced byways allowed',
+    // Last, and only when entered. A crew reading the summary back needs to see
+    // the numbers being routed against, because a wrong height here is not a
+    // preference that produces a duller route, it is one that produces a route
+    // through a bridge.
+    ...vehicle.appliedNotes,
   ];
 
   /// The rider-facing summary. Never empty: the byway preference always says
@@ -184,7 +271,7 @@ class RoutePreferences {
   /// them" are the difference between a Fireblade and a rutted BOAT.
   String get summary {
     final notes = appliedNotes;
-    if (notes.isEmpty) return 'Quickest route.';
+    if (notes.isEmpty) return 'Direct route.';
     final joined = notes.join(', ');
     return '${joined[0].toUpperCase()}${joined.substring(1)}.';
   }
@@ -196,6 +283,7 @@ class RoutePreferences {
     bool? avoidTolls,
     bool? avoidFerries,
     BywaySurfacePreference? bywaySurface,
+    ChaseVehicle? vehicle,
   }) => RoutePreferences(
     style: style ?? this.style,
     avoidMotorways: avoidMotorways ?? this.avoidMotorways,
@@ -203,6 +291,7 @@ class RoutePreferences {
     avoidTolls: avoidTolls ?? this.avoidTolls,
     avoidFerries: avoidFerries ?? this.avoidFerries,
     bywaySurface: bywaySurface ?? this.bywaySurface,
+    vehicle: vehicle ?? this.vehicle,
   );
 
   Map<String, Object?> toJson() => {
@@ -212,6 +301,7 @@ class RoutePreferences {
     'avoidTolls': avoidTolls,
     'avoidFerries': avoidFerries,
     'bywaySurface': bywaySurface.apiValue,
+    if (vehicle.isSpecified) 'vehicle': vehicle.toJson(),
   };
 
   /// Reads preferences a route was planned with.
@@ -222,7 +312,7 @@ class RoutePreferences {
   /// that never recorded a preference is not silently sent down a green lane.
   factory RoutePreferences.fromJson(Map<String, Object?> json) =>
       RoutePreferences(
-        style: RouteStyle.fromApiValue(json['style']) ?? RouteStyle.quickest,
+        style: RouteStyle.fromApiValue(json['style']) ?? RouteStyle.direct,
         avoidMotorways: json['avoidMotorways'] == true,
         avoidMajorRoads: json['avoidMajorRoads'] == true,
         avoidTolls: json['avoidTolls'] == true,
@@ -230,6 +320,13 @@ class RoutePreferences {
         bywaySurface:
             BywaySurfacePreference.fromApiValue(json['bywaySurface']) ??
             BywaySurfacePreference.avoidUnsurfaced,
+        vehicle: switch (json['vehicle']) {
+          final Map<String, Object?> vehicle => ChaseVehicle.fromJson(vehicle),
+          final Map<Object?, Object?> vehicle => ChaseVehicle.fromJson(
+            vehicle.map((key, value) => MapEntry(key.toString(), value)),
+          ),
+          _ => ChaseVehicle.unspecified,
+        },
       );
 
   @override
@@ -240,7 +337,8 @@ class RoutePreferences {
       other.avoidMajorRoads == avoidMajorRoads &&
       other.avoidTolls == avoidTolls &&
       other.avoidFerries == avoidFerries &&
-      other.bywaySurface == bywaySurface;
+      other.bywaySurface == bywaySurface &&
+      other.vehicle == vehicle;
 
   @override
   int get hashCode => Object.hash(
@@ -250,6 +348,7 @@ class RoutePreferences {
     avoidTolls,
     avoidFerries,
     bywaySurface,
+    vehicle,
   );
 
   @override

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../controllers/chase_vehicle_controller.dart';
 import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/completed_rides_controller.dart';
 import '../../controllers/map_style_mode_controller.dart';
@@ -51,6 +52,7 @@ class HomeScreen extends StatefulWidget {
     required this.riderProfile,
     required this.sharedRoutes,
     required this.speedLimitDisplay,
+    this.chaseVehicle,
     this.routeProgressDisplay,
     required this.recordedRoutes,
     required this.completedRides,
@@ -73,6 +75,7 @@ class HomeScreen extends StatefulWidget {
   final RiderProfileController riderProfile;
   final SharedRouteController sharedRoutes;
   final SpeedLimitDisplayController speedLimitDisplay;
+  final ChaseVehicleController? chaseVehicle;
   final RouteProgressDisplayController? routeProgressDisplay;
   final RecordedRouteStore recordedRoutes;
   final CompletedRidesController completedRides;
@@ -407,6 +410,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           widget.mapStyleMode,
                           widget.riderProfile,
                           speedLimitDisplay: widget.speedLimitDisplay,
+                          chaseVehicle: widget.chaseVehicle,
                           routeProgressDisplay: widget.routeProgressDisplay,
                           testControl: widget.testControl,
                           spokenGuidance: widget.spokenGuidance,

--- a/apps/mobile/lib/features/map/destination_route_sheet.dart
+++ b/apps/mobile/lib/features/map/destination_route_sheet.dart
@@ -22,24 +22,35 @@ class DestinationPlanRequest {
   final List<String> stopQueries;
   final NavigationTarget? handoffTarget;
 
-  /// The route character asked for, using the same preferences as the web
-  /// planner so the two agree about what a route with them means.
+  /// The road preferences and the vehicle they have to suit.
   final RoutePreferences preferences;
 }
 
 class DestinationRouteSheet extends StatefulWidget {
-  const DestinationRouteSheet({super.key, this.initialRequest});
+  const DestinationRouteSheet({
+    super.key,
+    this.initialRequest,
+    this.vehicle = ChaseVehicle.unspecified,
+  });
 
   final DestinationPlanRequest? initialRequest;
+
+  /// The crew's stored vehicle. Shown rather than editable here, and stamped
+  /// onto the route: it is a standing fact about the vehicle, not a decision
+  /// about this journey, so it is edited once in Settings instead of being
+  /// re-confirmed by somebody who is about to start driving.
+  final ChaseVehicle vehicle;
 
   static Future<DestinationPlanRequest?> show(
     BuildContext context, {
     DestinationPlanRequest? initialRequest,
+    ChaseVehicle vehicle = ChaseVehicle.unspecified,
   }) => showModalBottomSheet<DestinationPlanRequest>(
     context: context,
     showDragHandle: true,
     isScrollControlled: true,
-    builder: (_) => DestinationRouteSheet(initialRequest: initialRequest),
+    builder: (_) =>
+        DestinationRouteSheet(initialRequest: initialRequest, vehicle: vehicle),
   );
 
   @override
@@ -65,7 +76,12 @@ class _DestinationRouteSheetState extends State<DestinationRouteSheet> {
           const <TextEditingController>[],
     );
     _handoff = _handoffFromTarget(initial?.handoffTarget);
-    _preferences = initial?.preferences ?? RoutePreferences.defaults;
+    // The stored vehicle wins over anything carried in the request being
+    // re-shown after a failed attempt: Settings is where it is decided, so a
+    // stale copy must not outlive an edit made between attempts.
+    _preferences = (initial?.preferences ?? RoutePreferences.defaults).copyWith(
+      vehicle: widget.vehicle,
+    );
   }
 
   @override
@@ -187,10 +203,15 @@ class _DestinationRouteSheetState extends State<DestinationRouteSheet> {
               style: Theme.of(context).textTheme.labelLarge,
             ),
             const SizedBox(height: 4),
-            const Text(
-              'The same options as the web planner. The route itself can '
-              'differ: this plans for a chase vehicle.',
-              style: TextStyle(color: Color(0xFF98A3B1), fontSize: 12),
+            Text(
+              switch (widget.vehicle.appliedNotes) {
+                [] =>
+                  'Planned for a car. Add your vehicle in Settings to avoid low '
+                      'bridges and weight limits.',
+                final notes => 'Planned for ${notes.join(', ')}.',
+              },
+              key: const Key('route-vehicle-summary'),
+              style: const TextStyle(color: Color(0xFF98A3B1), fontSize: 12),
             ),
             const SizedBox(height: 10),
             DropdownButtonFormField<RouteStyle>(

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -203,6 +203,7 @@ class RideMapFeature extends StatefulWidget {
     this.pendingSharedGpxFile,
     this.pendingInAppRoute,
     this.acquireCurrentPosition,
+    this.chaseVehicle = ChaseVehicle.unspecified,
     this.navigationExportCoordinator,
     this.routeStore,
     this.canEditRoute = true,
@@ -263,6 +264,7 @@ class RideMapFeature extends StatefulWidget {
     PickedGpxFile? pendingSharedGpxFile,
     PendingInAppRoute? pendingInAppRoute,
     Future<GeoPoint?> Function()? acquireCurrentPosition,
+    ChaseVehicle chaseVehicle = ChaseVehicle.unspecified,
     RouteStore? routeStore,
     CompletedRideStore? completedRideStore,
     bool canEditRoute = true,
@@ -317,6 +319,7 @@ class RideMapFeature extends StatefulWidget {
     pendingSharedGpxFile: pendingSharedGpxFile,
     pendingInAppRoute: pendingInAppRoute,
     acquireCurrentPosition: acquireCurrentPosition,
+    chaseVehicle: chaseVehicle,
     routeStore: routeStore,
     completedRideStore: completedRideStore,
     canEditRoute: canEditRoute,
@@ -407,6 +410,10 @@ class RideMapFeature extends StatefulWidget {
   final PickedGpxFile? pendingSharedGpxFile;
   final PendingInAppRoute? pendingInAppRoute;
   final Future<GeoPoint?> Function()? acquireCurrentPosition;
+
+  /// The crew's own vehicle, stamped onto any route planned here so the
+  /// route says what it was planned to fit.
+  final ChaseVehicle chaseVehicle;
   final NavigationExportCoordinator? navigationExportCoordinator;
   final RouteStore? routeStore;
   final bool canEditRoute;
@@ -569,6 +576,7 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         pendingSharedGpxFile: widget.pendingSharedGpxFile,
         pendingInAppRoute: widget.pendingInAppRoute,
         acquireCurrentPosition: widget.acquireCurrentPosition,
+        chaseVehicle: widget.chaseVehicle,
         navigationExportCoordinator: widget.navigationExportCoordinator,
         distanceUnit: widget.distanceUnit,
         speedLimitDisplay: widget.speedLimitDisplay,
@@ -653,6 +661,7 @@ class RideMapScreen extends StatefulWidget {
     this.pendingSharedGpxFile,
     this.pendingInAppRoute,
     this.acquireCurrentPosition,
+    this.chaseVehicle = ChaseVehicle.unspecified,
     this.navigationExportCoordinator,
     this.destinationRoutePlanner,
     this.roadRoutingService,
@@ -753,6 +762,10 @@ class RideMapScreen extends StatefulWidget {
   final PickedGpxFile? pendingSharedGpxFile;
   final PendingInAppRoute? pendingInAppRoute;
   final Future<GeoPoint?> Function()? acquireCurrentPosition;
+
+  /// The crew's own vehicle, stamped onto any route planned here so the
+  /// route says what it was planned to fit.
+  final ChaseVehicle chaseVehicle;
   final NavigationExportCoordinator? navigationExportCoordinator;
   final DestinationRoutePlanner? destinationRoutePlanner;
   final RoadRoutingService? roadRoutingService;
@@ -4373,6 +4386,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       request = await DestinationRouteSheet.show(
         context,
         initialRequest: request,
+        vehicle: widget.chaseVehicle,
       );
       if (request == null || !mounted) return;
       setState(() => _routing = true);

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -6,6 +6,8 @@ import 'package:http/http.dart' as http;
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../controllers/chase_vehicle_controller.dart';
+import '../../domain/chase_vehicle.dart';
 import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/foreground_location_controller.dart';
 import '../../controllers/internet_relay_controller.dart';
@@ -258,6 +260,7 @@ class ActiveRideShell extends StatefulWidget {
     required this.riderProfile,
     required this.sharedRoutes,
     required this.speedLimitDisplay,
+    this.chaseVehicle,
     this.routeProgressDisplay,
     this.completedRideStore,
     this.screenWakeLock = const WakelockPlusScreenWakeLock(),
@@ -300,6 +303,7 @@ class ActiveRideShell extends StatefulWidget {
   final RiderProfileController riderProfile;
   final SharedRouteController sharedRoutes;
   final SpeedLimitDisplayController speedLimitDisplay;
+  final ChaseVehicleController? chaseVehicle;
   final RouteProgressDisplayController? routeProgressDisplay;
   final CompletedRideStore? completedRideStore;
   final ScreenWakeLock screenWakeLock;
@@ -3319,6 +3323,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       canEditRoute: _isSimulation || widget.rideController.isLocalRideLeader,
       distanceUnit: widget.distanceUnits.value,
       speedLimitDisplay: widget.speedLimitDisplay,
+      chaseVehicle: widget.chaseVehicle?.vehicle ?? ChaseVehicle.unspecified,
       showRouteProgress: widget.routeProgressDisplay?.enabled ?? true,
       darkMapStyle: widget.mapStyleMode.resolveDark(
         MediaQuery.platformBrightnessOf(context),
@@ -4574,6 +4579,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       mapStyleMode: widget.mapStyleMode,
       riderProfile: widget.riderProfile,
       speedLimitDisplay: widget.speedLimitDisplay,
+      chaseVehicle: widget.chaseVehicle,
       routeProgressDisplay: widget.routeProgressDisplay,
       currentRideActive: true,
       lastRelaySync: _internetRelayController?.status.lastSuccessfulSync,

--- a/apps/mobile/lib/features/settings/chase_vehicle_sheet.dart
+++ b/apps/mobile/lib/features/settings/chase_vehicle_sheet.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../controllers/chase_vehicle_controller.dart';
+import '../../domain/chase_vehicle.dart';
+
+/// Where the crew describes their own vehicle, once.
+///
+/// Four numbers and a switch, all optional. The wording is doing real work
+/// here: an empty field has to read as "not told" and never as "no restriction",
+/// because the failure mode is not a duller route, it is a trailer under a
+/// bridge that fitted the number nobody entered.
+class ChaseVehicleSheet extends StatefulWidget {
+  const ChaseVehicleSheet({super.key, required this.controller});
+
+  final ChaseVehicleController controller;
+
+  static Future<void> show(
+    BuildContext context, {
+    required ChaseVehicleController controller,
+  }) => showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (sheetContext) => ChaseVehicleSheet(controller: controller),
+  );
+
+  @override
+  State<ChaseVehicleSheet> createState() => _ChaseVehicleSheetState();
+}
+
+class _ChaseVehicleSheetState extends State<ChaseVehicleSheet> {
+  late final TextEditingController _height;
+  late final TextEditingController _width;
+  late final TextEditingController _length;
+  late final TextEditingController _weight;
+  late bool _towing;
+
+  @override
+  void initState() {
+    super.initState();
+    final vehicle = widget.controller.vehicle;
+    _height = TextEditingController(text: _text(vehicle.heightMetres));
+    _width = TextEditingController(text: _text(vehicle.widthMetres));
+    _length = TextEditingController(text: _text(vehicle.lengthMetres));
+    _weight = TextEditingController(text: _text(vehicle.grossWeightTonnes));
+    _towing = vehicle.towing;
+  }
+
+  @override
+  void dispose() {
+    _height.dispose();
+    _width.dispose();
+    _length.dispose();
+    _weight.dispose();
+    super.dispose();
+  }
+
+  static String _text(double? value) => value == null
+      ? ''
+      : value == value.roundToDouble()
+      ? value.round().toString()
+      : value.toString();
+
+  ChaseVehicle get _edited => ChaseVehicle.fromJson({
+    'heightMetres': _height.text,
+    'widthMetres': _width.text,
+    'lengthMetres': _length.text,
+    'grossWeightTonnes': _weight.text,
+    'towing': _towing,
+  });
+
+  Future<void> _save() async {
+    await widget.controller.set(_edited);
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) => SafeArea(
+    child: Padding(
+      padding: EdgeInsets.fromLTRB(
+        20,
+        8,
+        20,
+        18 + MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Chase vehicle',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'All optional, and remembered between flights. Fill in what you '
+              'know and routes will avoid low bridges, weight limits and width '
+              'restrictions that OpenStreetMap records.',
+              style: TextStyle(color: Color(0xFF9CA7B5), fontSize: 13),
+            ),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              key: const Key('chase-vehicle-towing-switch'),
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Towing a trailer'),
+              subtitle: const Text(
+                'Prefers straighter roads, and makes the weight below the '
+                'combined weight.',
+              ),
+              value: _towing,
+              onChanged: (value) => setState(() => _towing = value),
+            ),
+            const SizedBox(height: 8),
+            _Dimension(
+              fieldKey: const Key('chase-vehicle-height-field'),
+              controller: _height,
+              label: 'Height (m)',
+              helper:
+                  'Including anything on the roof. This is the one low '
+                  'bridges care about.',
+            ),
+            const SizedBox(height: 12),
+            _Dimension(
+              fieldKey: const Key('chase-vehicle-width-field'),
+              controller: _width,
+              label: 'Width (m)',
+              helper: 'Excluding mirrors.',
+            ),
+            const SizedBox(height: 12),
+            _Dimension(
+              fieldKey: const Key('chase-vehicle-length-field'),
+              controller: _length,
+              label: 'Length (m)',
+              helper: _towing
+                  ? 'Vehicle and trailer together.'
+                  : 'Overall length.',
+            ),
+            const SizedBox(height: 12),
+            _Dimension(
+              fieldKey: const Key('chase-vehicle-weight-field'),
+              controller: _weight,
+              label: 'Maximum weight (tonnes)',
+              // Never abbreviated in the label. Reading this as a towing
+              // capacity instead of a laden weight puts the wrong number
+              // against a weight-limited bridge, and it is the crew who finds
+              // out.
+              helper: _towing
+                  ? 'The heaviest the vehicle and loaded trailer can legally be '
+                        'together — not what the towbar is rated for.'
+                  : 'The heaviest the vehicle can legally be when loaded.',
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Routes can only avoid restrictions that are mapped. A clear '
+              'route means nothing was recorded on it, not that it is '
+              'definitely passable — keep reading the signs.',
+              key: Key('chase-vehicle-coverage-caveat'),
+              style: TextStyle(color: Color(0xFFFFC857), fontSize: 12),
+            ),
+            const SizedBox(height: 18),
+            FilledButton(
+              key: const Key('chase-vehicle-save'),
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+class _Dimension extends StatelessWidget {
+  const _Dimension({
+    required this.fieldKey,
+    required this.controller,
+    required this.label,
+    required this.helper,
+  });
+
+  final Key fieldKey;
+  final TextEditingController controller;
+  final String label;
+  final String helper;
+
+  @override
+  Widget build(BuildContext context) => TextField(
+    key: fieldKey,
+    controller: controller,
+    keyboardType: const TextInputType.numberWithOptions(decimal: true),
+    inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))],
+    decoration: InputDecoration(
+      labelText: label,
+      helperText: helper,
+      helperMaxLines: 3,
+      // Not "0" and not "none": an empty field means nobody has said, and the
+      // hint must not read as a value.
+      hintText: 'Not set',
+    ),
+  );
+}

--- a/apps/mobile/lib/features/settings/unit_settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/unit_settings_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../controllers/chase_vehicle_controller.dart';
 import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/map_style_mode_controller.dart';
 import '../../controllers/rider_profile_controller.dart';
@@ -19,6 +20,7 @@ import '../../services/build_identity.dart';
 import '../../services/natural_voice_pack.dart';
 import '../../services/spoken_guidance.dart';
 import 'about_build_sheet.dart';
+import 'chase_vehicle_sheet.dart';
 import 'rider_profile_sheet.dart';
 import 'ride_diagnostics_section.dart';
 import 'test_control_section.dart';
@@ -30,6 +32,7 @@ class UnitSettingsSheet extends StatelessWidget {
     required this.mapStyleMode,
     required this.riderProfile,
     required this.speedLimitDisplay,
+    this.chaseVehicle,
     this.routeProgressDisplay,
     this.currentRideActive = false,
     this.lastRelaySync,
@@ -44,6 +47,10 @@ class UnitSettingsSheet extends StatelessWidget {
   final MapStyleModeController mapStyleMode;
   final RiderProfileController riderProfile;
   final SpeedLimitDisplayController speedLimitDisplay;
+
+  /// Absent only where a caller has no vehicle store, which is tests: the
+  /// section is then hidden rather than shown broken.
+  final ChaseVehicleController? chaseVehicle;
   final RouteProgressDisplayController? routeProgressDisplay;
   final bool currentRideActive;
 
@@ -79,6 +86,7 @@ class UnitSettingsSheet extends StatelessWidget {
     MapStyleModeController mapStyleMode,
     RiderProfileController riderProfile, {
     required SpeedLimitDisplayController speedLimitDisplay,
+    ChaseVehicleController? chaseVehicle,
     RouteProgressDisplayController? routeProgressDisplay,
     bool currentRideActive = false,
     DateTime? lastRelaySync,
@@ -95,6 +103,7 @@ class UnitSettingsSheet extends StatelessWidget {
       mapStyleMode: mapStyleMode,
       riderProfile: riderProfile,
       speedLimitDisplay: speedLimitDisplay,
+      chaseVehicle: chaseVehicle,
       routeProgressDisplay: routeProgressDisplay,
       currentRideActive: currentRideActive,
       lastRelaySync: lastRelaySync,
@@ -111,6 +120,7 @@ class UnitSettingsSheet extends StatelessWidget {
       controller,
       mapStyleMode,
       speedLimitDisplay,
+      ?chaseVehicle,
       ?routeProgressDisplay,
     ]),
     builder: (context, _) => SingleChildScrollView(
@@ -157,6 +167,40 @@ class UnitSettingsSheet extends StatelessWidget {
               );
             },
           ),
+          if (chaseVehicle case final chaseVehicle?) ...[
+            const SizedBox(height: 16),
+            Text(
+              'CHASE VEHICLE',
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: const Color(0xFF8D98A7),
+                letterSpacing: 1.1,
+              ),
+            ),
+            const SizedBox(height: 6),
+            ListTile(
+              key: const Key('open-chase-vehicle'),
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.local_shipping_outlined),
+              title: Text(switch (chaseVehicle.vehicle.appliedNotes) {
+                [] => 'Add vehicle size',
+                final notes => notes.join(' · '),
+              }),
+              subtitle: const Text(
+                'Avoid low bridges, weight limits and narrow roads.',
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () {
+                final appContext = Navigator.of(
+                  context,
+                  rootNavigator: true,
+                ).context;
+                if (!embedded) Navigator.of(context).pop();
+                unawaited(
+                  ChaseVehicleSheet.show(appContext, controller: chaseVehicle),
+                );
+              },
+            ),
+          ],
           const SizedBox(height: 16),
           Text(
             'DISTANCE UNITS',

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -14,6 +14,7 @@ import 'controllers/ride_invitation_link_controller.dart';
 import 'controllers/route_progress_display_controller.dart';
 import 'controllers/rider_profile_controller.dart';
 import 'controllers/shared_route_controller.dart';
+import 'controllers/chase_vehicle_controller.dart';
 import 'controllers/speed_limit_display_controller.dart';
 import 'controllers/spoken_guidance_controller.dart';
 import 'controllers/test_control_controller.dart';
@@ -60,6 +61,7 @@ Future<void> main() async {
     spokenGuidance,
     rideInvitationLinks,
     routeProgressDisplay,
+    chaseVehicle,
   ) = await (
     (
       RiderProfileController.load(),
@@ -77,6 +79,10 @@ Future<void> main() async {
     SpokenGuidanceController.load(),
     RideInvitationLinkController.load(),
     RouteProgressDisplayController.load(),
+    // In the nested group rather than the first: that one is at the nine-future
+    // limit the #209 note describes, and this must not become a tenth serial
+    // await on the path to first paint.
+    ChaseVehicleController.load(),
   ).wait;
 
   final completedRides = await CompletedRidesController.load(
@@ -119,6 +125,7 @@ Future<void> main() async {
       riderProfile: riderProfile,
       sharedRoutes: sharedRoutes,
       speedLimitDisplay: speedLimitDisplay,
+      chaseVehicle: chaseVehicle,
       routeProgressDisplay: routeProgressDisplay,
       recordedRoutes: recordedRoutes,
       completedRides: completedRides,

--- a/apps/mobile/lib/services/road_routing.dart
+++ b/apps/mobile/lib/services/road_routing.dart
@@ -32,8 +32,8 @@ class RoutingConfiguration {
       ),
     ),
     // The Valhalla service used for the exclusions OSRM's driving profile
-    // cannot express. Same host the web planner uses; the costing differs, see
-    // [RoutePreferences.valhallaAutoCostingOptions].
+    // cannot express, and for the vehicle dimensions it cannot express at all.
+    // See [RoutePreferences.valhallaCostingOptions].
     valhallaRoutingUrl: Uri.parse(
       const String.fromEnvironment(
         'BALLOON_CRUMBS_VALHALLA_ROUTING_URL',
@@ -383,8 +383,8 @@ class OsrmRoadRoutingService implements RoadRoutingService {
     this.readMiniRoundabouts = bundledMiniRoundabouts,
   });
 
-  /// Alternatives asked of OSRM when a bendier style has to choose between
-  /// them. The web planner asks for the same three.
+  /// Alternatives asked of OSRM when there is a choice worth making between
+  /// them, which is when the vehicle is towing and wants the straightest one.
   static const alternativeCount = 3;
 
   final http.Client client;
@@ -413,7 +413,7 @@ class OsrmRoadRoutingService implements RoadRoutingService {
       );
     }
     _requireHttps(baseUrl, 'Routing');
-    final style = preferences?.style ?? RouteStyle.quickest;
+    final resolvedPreferences = preferences ?? RoutePreferences.defaults;
     final coordinates = waypoints
         .map((point) => '${point.longitude},${point.latitude}')
         .join(';');
@@ -424,10 +424,11 @@ class OsrmRoadRoutingService implements RoadRoutingService {
         'overview': 'full',
         'geometries': 'geojson',
         'steps': 'true',
-        // Only asked for when a style has to choose. The quickest route needs
-        // no alternatives, and not asking keeps the default request identical
-        // to the one this client has always sent.
-        if (style.prefersBends) 'alternatives': '$alternativeCount',
+        // Only asked for when something will choose between them. Not asking
+        // keeps the default request identical to the one this client has always
+        // sent.
+        if (resolvedPreferences.prefersStraighterRoads)
+          'alternatives': '$alternativeCount',
         // Constrains only the origin, so the rejoin point and the target may be
         // approached however the engine likes (#444).
         'bearings': ?osrmBearings(
@@ -465,10 +466,10 @@ class OsrmRoadRoutingService implements RoadRoutingService {
     final chosen =
         RouteTwistiness.chooseWithinDetour(
           parsed,
-          style: style,
+          preferences: resolvedPreferences,
           duration: (candidate) =>
               candidate.duration.inMilliseconds.toDouble() / 1000,
-          twistiness: (candidate) => candidate.twistinessScore ?? 0,
+          bendScore: (candidate) => candidate.twistinessScore ?? 0,
         ) ??
         parsed.first;
     final miniRoundabouts = await readMiniRoundabouts();
@@ -610,9 +611,22 @@ class OsrmRoadRoutingService implements RoadRoutingService {
 
 /// Valhalla road routing, for the exclusions OSRM cannot express.
 ///
-/// Sends `costing: auto` with `costing_options.auto` from
-/// [RoutePreferences.valhallaAutoCostingOptions], and kilometre units. It asked
-/// for `motorcycle` costing until the motorcycle domain was deleted: a chase
+/// Sends `costing: auto` or `costing: truck` with matching `costing_options`
+/// from [RoutePreferences.valhallaCostingOptions], and kilometre units.
+///
+/// `truck` is what makes low bridges avoidable: `auto` costing ignores
+/// `maxheight`, `maxweight` and `maxwidth` outright, so a crew who entered a
+/// height gets nothing back from `auto` at all. It is used only once a dimension
+/// has been entered — see [ChaseVehicle.requiresTruckCosting] for why a ticked
+/// "towing" box is not enough on its own.
+///
+/// The honest limit, which the surface must not overstate: this can only avoid
+/// restrictions OpenStreetMap actually records. UK `maxheight` coverage is
+/// patchy and plenty of signed bridges are unmapped, so a clear route means "no
+/// mapped restriction on this line", never "this line is passable". The same
+/// discipline the speed-camera layer already keeps.
+///
+/// It asked for `motorcycle` costing until the motorcycle domain was deleted: a chase
 /// vehicle is a Land Rover or a van, often towing, and routing one as a motorbike
 /// picks roads it should not and reads speed limits off roads it cannot use.
 ///
@@ -669,8 +683,8 @@ class ValhallaRoadRoutingService implements RoadRoutingService {
             },
           )
           .toList(growable: false),
-      'costing': 'auto',
-      'costing_options': {'auto': resolved.valhallaAutoCostingOptions()},
+      'costing': resolved.valhallaCosting,
+      'costing_options': resolved.valhallaCostingOptions(),
       'units': 'kilometers',
       'directions_options': {'units': 'kilometers'},
     };

--- a/apps/mobile/lib/services/route_twistiness.dart
+++ b/apps/mobile/lib/services/route_twistiness.dart
@@ -2,15 +2,21 @@ import 'dart:math' as math;
 
 import '../domain/imported_route.dart';
 
-/// The web planner's twistiness score, in Dart.
+/// How bendy a route is: 150 m sampling, heading changes below 8 degrees
+/// discarded as geometry noise, changes above 70 degrees discarded as route
+/// manoeuvres, and the remainder divided by route distance in kilometres.
 ///
-/// This is the score #46 established and `docs/route-twistiness.md` records:
-/// 150 m sampling, heading changes below 8 degrees discarded as geometry noise,
-/// changes above 70 degrees discarded as route manoeuvres, and the remainder
-/// divided by route distance in kilometres. It is a port of `routeBendScore`
-/// and `formatRouteBendScore` in `apps/website/planner-core.mjs`, not a second
-/// notion of twisty, and the fixtures in `route_twistiness_test.dart` pin it to
-/// the same numbers the web planner produces.
+/// Built to *seek* corners for motorcyclists (#46). It survives the deletion of
+/// that app because the measurement was never the motorcycling part — a road
+/// with 40 degrees of bend per kilometre is a road with 40 degrees of bend per
+/// kilometre, and whether that is the point of the ride or the reason the
+/// trailer will not make the corner is a question of who is driving. See
+/// [chooseWithinDetour], which now reads it the other way up.
+///
+/// The doc comment here used to claim this was pinned to `routeBendScore` in
+/// `apps/website/planner-core.mjs` by the fixtures in its test. That file does
+/// not exist in this repository and never has; the fixtures pin the score
+/// against itself, which is still worth having but is not a cross-check.
 class RouteTwistiness {
   const RouteTwistiness._();
 
@@ -88,16 +94,18 @@ class RouteTwistiness {
   /// the quickest is kept. It never asks for a road the provider did not offer.
   static T? chooseWithinDetour<T>(
     List<T> alternatives, {
-    required RouteStyle style,
+    required RoutePreferences preferences,
     required double Function(T) duration,
-    required double Function(T) twistiness,
+    required double Function(T) bendScore,
   }) {
     if (alternatives.isEmpty) return null;
     final quickest = alternatives.first;
-    if (!style.prefersBends || alternatives.length == 1) return quickest;
+    if (!preferences.prefersStraighterRoads || alternatives.length == 1) {
+      return quickest;
+    }
 
     final quickestDuration = duration(quickest);
-    final allowance = quickestDuration * style.detourLimit;
+    final allowance = quickestDuration * RoutePreferences.towingDetourLimit;
     final eligible = alternatives
         .where((candidate) {
           final candidateDuration = duration(candidate);
@@ -107,9 +115,12 @@ class RouteTwistiness {
         .toList(growable: false);
     if (eligible.isEmpty) return quickest;
 
+    // The straightest, not the twistiest. Same score, opposite sign: a vehicle
+    // with a trailer behind it wants the fewest tight bends it can get away
+    // with, where a motorcycle wanted the most.
     return eligible.reduce(
       (best, candidate) =>
-          twistiness(candidate) > twistiness(best) ? candidate : best,
+          bendScore(candidate) < bendScore(best) ? candidate : best,
     );
   }
 }

--- a/apps/mobile/test/controllers/chase_vehicle_controller_test.dart
+++ b/apps/mobile/test/controllers/chase_vehicle_controller_test.dart
@@ -1,0 +1,93 @@
+import 'package:balloon_crumbs/controllers/chase_vehicle_controller.dart';
+import 'package:balloon_crumbs/domain/chase_vehicle.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('a fresh install has no vehicle and claims none', () async {
+    final controller = await ChaseVehicleController.load();
+    expect(controller.vehicle, ChaseVehicle.unspecified);
+  });
+
+  test('a saved vehicle survives a restart', () async {
+    // The whole reason this is stored rather than asked each flight: the crew
+    // tows the same trailer next weekend, and the person who would answer is
+    // about to start driving.
+    final controller = await ChaseVehicleController.load();
+    await controller.set(
+      const ChaseVehicle(
+        heightMetres: 3.2,
+        grossWeightTonnes: 3.5,
+        towing: true,
+      ),
+    );
+
+    final restarted = await ChaseVehicleController.load();
+    expect(restarted.vehicle.heightMetres, 3.2);
+    expect(restarted.vehicle.grossWeightTonnes, 3.5);
+    expect(restarted.vehicle.towing, isTrue);
+  });
+
+  test(
+    'clearing a vehicle removes the key, rather than storing an empty one',
+    () async {
+      // "Never told us" and "told us and then cleared it" mean the same thing, so
+      // they must read back the same.
+      final controller = await ChaseVehicleController.load();
+      await controller.set(const ChaseVehicle(heightMetres: 3.2));
+      await controller.set(ChaseVehicle.unspecified);
+
+      final preferences = await SharedPreferences.getInstance();
+      expect(
+        preferences.containsKey(ChaseVehicleController.preferenceKey),
+        isFalse,
+      );
+      expect(
+        (await ChaseVehicleController.load()).vehicle,
+        ChaseVehicle.unspecified,
+      );
+    },
+  );
+
+  test('listeners hear a change, and are not woken for a no-op', () async {
+    final controller = await ChaseVehicleController.load();
+    var notifications = 0;
+    controller.addListener(() => notifications += 1);
+
+    await controller.set(const ChaseVehicle(heightMetres: 3.2));
+    expect(notifications, 1);
+    await controller.set(const ChaseVehicle(heightMetres: 3.2));
+    expect(notifications, 1, reason: 'the same vehicle is not a change');
+  });
+
+  test(
+    'unreadable stored data degrades to unspecified, and does not throw',
+    () async {
+      // The cost of degrading is a crew re-entering four numbers. The cost of
+      // throwing is an app that will not open at a launch site.
+      for (final corrupt in ['not json at all', '[]', '{', '3']) {
+        SharedPreferences.setMockInitialValues({
+          ChaseVehicleController.preferenceKey: corrupt,
+        });
+        expect(
+          (await ChaseVehicleController.load()).vehicle,
+          ChaseVehicle.unspecified,
+          reason: corrupt,
+        );
+      }
+    },
+  );
+
+  test('a stored vehicle with a nonsense dimension keeps the rest', () async {
+    SharedPreferences.setMockInitialValues({
+      ChaseVehicleController.preferenceKey:
+          '{"heightMetres":99,"grossWeightTonnes":3.5,"towing":true}',
+    });
+    final controller = await ChaseVehicleController.load();
+    expect(controller.vehicle.heightMetres, isNull);
+    expect(controller.vehicle.grossWeightTonnes, 3.5);
+    expect(controller.vehicle.towing, isTrue);
+  });
+}

--- a/apps/mobile/test/domain/chase_vehicle_test.dart
+++ b/apps/mobile/test/domain/chase_vehicle_test.dart
@@ -1,0 +1,168 @@
+import 'package:balloon_crumbs/domain/chase_vehicle.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('an empty field means "not told", never "no restriction"', () {
+    test('nothing entered claims nothing and routes as before', () {
+      const vehicle = ChaseVehicle.unspecified;
+      expect(vehicle.hasDimensions, isFalse);
+      expect(vehicle.isSpecified, isFalse);
+      expect(vehicle.requiresTruckCosting, isFalse);
+      expect(vehicle.appliedNotes, isEmpty);
+      expect(vehicle.toJson(), isEmpty);
+    });
+
+    test('a single dimension is enough to route on', () {
+      // A crew who knows only their height should get bridges avoided for it.
+      const vehicle = ChaseVehicle(heightMetres: 3.2);
+      expect(vehicle.hasDimensions, isTrue);
+      expect(vehicle.requiresTruckCosting, isTrue);
+    });
+
+    test('towing alone is specified, but is not a dimension', () {
+      const vehicle = ChaseVehicle(towing: true);
+      expect(vehicle.isSpecified, isTrue);
+      expect(vehicle.hasDimensions, isFalse);
+      // The distinction that keeps Valhalla's lorry defaults out: 4.11 m and
+      // 21.77 t applied to a vehicle nobody measured would refuse most of the
+      // roads to a launch site.
+      expect(vehicle.requiresTruckCosting, isFalse);
+    });
+  });
+
+  group('reading a stored vehicle', () {
+    test('a plausible number is kept, whether typed or stored', () {
+      expect(
+        ChaseVehicle.fromJson(const {'heightMetres': 3.2}).heightMetres,
+        3.2,
+      );
+      // The editor hands over what the crew typed, so strings must parse.
+      expect(
+        ChaseVehicle.fromJson(const {'heightMetres': '3.2'}).heightMetres,
+        3.2,
+      );
+      expect(
+        ChaseVehicle.fromJson(const {'heightMetres': ' 3.2 '}).heightMetres,
+        3.2,
+      );
+    });
+
+    test('an implausible number degrades to not-told, not to a clamp', () {
+      // Clamping would invent a restriction the crew never entered, and a
+      // restriction is the thing that reroutes them. Zero and negatives are not
+      // small vehicles: they are empty or broken fields.
+      for (final value in [0, -3, 'abc', '', null, double.nan, true]) {
+        expect(
+          ChaseVehicle.fromJson({'heightMetres': value}).heightMetres,
+          isNull,
+          reason: '$value',
+        );
+      }
+    });
+
+    test('each dimension has its own plausible ceiling', () {
+      // 8 m is not a chase vehicle, it is a typo for 1.8.
+      expect(
+        ChaseVehicle.fromJson(const {'heightMetres': 8}).heightMetres,
+        isNull,
+      );
+      expect(ChaseVehicle.fromJson(const {'heightMetres': 4}).heightMetres, 4);
+      expect(
+        ChaseVehicle.fromJson(const {'widthMetres': 6}).widthMetres,
+        isNull,
+      );
+      expect(
+        ChaseVehicle.fromJson(const {'lengthMetres': 40}).lengthMetres,
+        isNull,
+      );
+      expect(
+        ChaseVehicle.fromJson(const {'lengthMetres': 12}).lengthMetres,
+        12,
+      );
+      expect(
+        ChaseVehicle.fromJson(const {
+          'grossWeightTonnes': 60,
+        }).grossWeightTonnes,
+        isNull,
+      );
+      expect(
+        ChaseVehicle.fromJson(const {
+          'grossWeightTonnes': 3.5,
+        }).grossWeightTonnes,
+        3.5,
+      );
+    });
+
+    test('a vehicle round-trips through JSON', () {
+      const vehicle = ChaseVehicle(
+        heightMetres: 3.2,
+        widthMetres: 2.1,
+        lengthMetres: 11,
+        grossWeightTonnes: 3.5,
+        towing: true,
+      );
+      expect(ChaseVehicle.fromJson(vehicle.toJson()), vehicle);
+    });
+
+    test('unset dimensions are absent from the JSON, not null entries', () {
+      expect(const ChaseVehicle(heightMetres: 3).toJson(), {
+        'heightMetres': 3.0,
+      });
+    });
+  });
+
+  group('what gets sent to the router', () {
+    test('an unentered dimension restricts nothing', () {
+      // Understating is the safe direction: it applies no restriction on that
+      // axis, which is the answer the crew got before they told us anything.
+      // Omitting the key instead would inherit Valhalla's lorry defaults.
+      final dimensions = const ChaseVehicle(
+        grossWeightTonnes: 3.5,
+      ).valhallaTruckDimensions();
+      expect(dimensions['weight'], 3.5);
+      expect(dimensions['height'], 2);
+      expect(dimensions['width'], 2);
+      expect(dimensions['length'], 5);
+    });
+
+    test('hazmat is never asserted', () {
+      // A chase vehicle carries propane cylinders, and propane is a dangerous
+      // good — but hazmat routing is a legal regime about placarded loads that
+      // the crew has not declared, and the app must not declare it for them.
+      expect(
+        const ChaseVehicle(
+          heightMetres: 3,
+          towing: true,
+        ).valhallaTruckDimensions()['hazmat'],
+        isFalse,
+      );
+    });
+  });
+
+  group('what the crew reads back', () {
+    test('the notes name every number entered, and nothing else', () {
+      expect(
+        const ChaseVehicle(
+          heightMetres: 3.2,
+          grossWeightTonnes: 3.5,
+          towing: true,
+        ).appliedNotes,
+        ['towing', '3.2 m high', '3.5 t'],
+      );
+    });
+
+    test('whole numbers read as whole numbers', () {
+      expect(
+        const ChaseVehicle(heightMetres: 3, lengthMetres: 11).appliedNotes,
+        ['3 m high', '11 m long'],
+      );
+    });
+  });
+
+  test('clearing a dimension is distinguishable from not changing it', () {
+    const vehicle = ChaseVehicle(heightMetres: 3.2, towing: true);
+    expect(vehicle.copyWith(towing: false).heightMetres, 3.2);
+    expect(vehicle.copyWith(clearHeight: true).heightMetres, isNull);
+    expect(vehicle.copyWith(clearHeight: true).towing, isTrue);
+  });
+}

--- a/apps/mobile/test/domain/route_preferences_test.dart
+++ b/apps/mobile/test/domain/route_preferences_test.dart
@@ -1,43 +1,64 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:balloon_crumbs/domain/route_preferences.dart';
+import 'package:flutter_test/flutter_test.dart';
 
-/// These fixtures are the web planner's own numbers, copied from
-/// `apps/website/planner-core.mjs`. If either side changes, one of the two test
-/// suites fails, which is what stops the app and the planner disagreeing about
-/// what a preference means (#182).
 void main() {
-  group('route styles match the web planner contract', () {
-    test('api values and detour limits are the planner values', () {
+  group('route styles', () {
+    test('the twisty ladder is gone, and two chase options remain', () {
+      // The inherited ladder bought bends with time: +25%, +50%, +75%. A crew
+      // trying to be under a balloon when it lands has no use for any of it.
       expect(RouteStyle.values.map((style) => style.apiValue), [
-        'quickest',
-        'balanced',
-        'twisty',
-        'very-twisty',
+        'direct',
+        'major-roads',
       ]);
-      expect(RouteStyle.quickest.detourLimit, 1);
-      expect(RouteStyle.flowing.detourLimit, 1.25);
-      expect(RouteStyle.twisty.detourLimit, 1.5);
-      expect(RouteStyle.veryTwisty.detourLimit, 1.75);
     });
 
-    test('only the quickest style declines alternatives', () {
-      expect(RouteStyle.quickest.prefersBends, isFalse);
-      expect(RouteStyle.flowing.prefersBends, isTrue);
-      expect(RouteStyle.twisty.prefersBends, isTrue);
-      expect(RouteStyle.veryTwisty.prefersBends, isTrue);
+    test('detour tolerance belongs to the trailer, not to the style', () {
+      // The bug this replaced: tolerance hung off the style, the default style
+      // allowed 0%, so a crew who ticked "towing" got a preference that could
+      // never once change their route. Nothing failed — the field was still
+      // there and still being read.
+      expect(RoutePreferences.towingDetourLimit, 1.15);
     });
 
-    test('an unknown stored style falls back to quickest', () {
-      expect(RouteStyle.fromApiValue('flowing'), isNull);
+    test('every retired motorcycle style degrades to direct', () {
+      // The trap in this change. These four are sitting in stored routes, and a
+      // route stored as `twisty` asked for a 50% detour in exchange for
+      // corners. There is no honest translation of that into a chase
+      // preference, so none is invented — but it must not throw or read as
+      // null either, because then the route will not open.
+      for (final retired in ['quickest', 'balanced', 'twisty', 'very-twisty']) {
+        expect(
+          RouteStyle.fromApiValue(retired),
+          RouteStyle.direct,
+          reason: retired,
+        );
+        expect(
+          RoutePreferences.fromJson({'style': retired}).style,
+          RouteStyle.direct,
+          reason: retired,
+        );
+      }
+    });
+
+    test('a style this build has never heard of also degrades to direct', () {
+      expect(RouteStyle.fromApiValue('scenic'), isNull);
+      expect(RouteStyle.fromApiValue(null), isNull);
       expect(
-        RoutePreferences.fromJson(const {'style': 'flowing'}).style,
-        RouteStyle.quickest,
+        RoutePreferences.fromJson(const {'style': 'scenic'}).style,
+        RouteStyle.direct,
       );
+      expect(RoutePreferences.fromJson(const {}).style, RouteStyle.direct);
+    });
+
+    test('preferring major roads shuts living streets out', () {
+      // Where a long vehicle gets stuck and where children play.
+      expect(RouteStyle.majorRoads.livingStreetPreference, 0);
+      expect(RouteStyle.direct.livingStreetPreference, 0.5);
     });
   });
 
   group('byway default', () {
-    test('unsurfaced byways are avoided unless a rider says otherwise', () {
+    test('unsurfaced byways are avoided unless the crew says otherwise', () {
       expect(
         RoutePreferences.defaults.bywaySurface,
         BywaySurfacePreference.avoidUnsurfaced,
@@ -60,94 +81,83 @@ void main() {
         );
       },
     );
+  });
 
-    test('the summary always states which way round the byways are', () {
-      expect(RoutePreferences.defaults.summary, 'Unsurfaced byways avoided.');
+  group('which Valhalla costing plans the route', () {
+    test('nothing entered routes as a car, exactly as before', () {
+      expect(RoutePreferences.defaults.valhallaCosting, 'auto');
+      expect(RoutePreferences.defaults.vehicle.requiresTruckCosting, isFalse);
       expect(
-        const RoutePreferences(
-          bywaySurface: BywaySurfacePreference.allowUnsurfaced,
-        ).summary,
-        'Unsurfaced byways allowed.',
+        RoutePreferences.defaults.valhallaCostingOptions().keys,
+        contains('auto'),
       );
+    });
+
+    test('a single entered dimension switches to truck costing', () {
+      // The whole point of the feature. Valhalla's `auto` costing ignores
+      // `maxheight` outright, so a crew who entered a height gets nothing back
+      // from `auto` — the switch is what makes a low bridge avoidable at all.
+      const tall = RoutePreferences(vehicle: ChaseVehicle(heightMetres: 3.2));
+      expect(tall.valhallaCosting, 'truck');
+      expect(tall.requiresValhallaCosting, isTrue);
+      final options = tall.valhallaCostingOptions();
+      expect(options.keys, ['truck']);
+      expect((options['truck']! as Map)['height'], 3.2);
+    });
+
+    test('towing alone does not switch to truck costing', () {
+      // The dangerous case, asserted rather than assumed. `truck` costing with
+      // no dimensions inherits Valhalla's articulated-lorry defaults — 4.11 m
+      // and 21.77 t — which would refuse most of the roads to a launch site,
+      // for reasons the crew never stated.
+      const towingOnly = RoutePreferences(vehicle: ChaseVehicle(towing: true));
+      expect(towingOnly.vehicle.towing, isTrue);
+      expect(towingOnly.valhallaCosting, 'auto');
+      expect(towingOnly.valhallaCostingOptions().keys, ['auto']);
+    });
+
+    test('unentered dimensions are sent small, never omitted', () {
+      // Omitting them would inherit the lorry defaults. A blank field means
+      // "not told", which must restrict nothing, so the fallbacks understate.
+      final dimensions = const ChaseVehicle(
+        heightMetres: 3,
+      ).valhallaTruckDimensions();
+      expect(dimensions['height'], 3);
+      expect(dimensions['width'], 2);
+      expect(dimensions['length'], 5);
+      expect(dimensions['weight'], 2);
+      expect(dimensions['hazmat'], isFalse);
     });
   });
 
-  group('engine choice matches requestRoadRoute in the web planner', () {
-    test('defaults stay on OSRM', () {
-      expect(RoutePreferences.defaults.requiresValhallaCosting, isFalse);
-    });
-
-    test('a bendier style alone stays on OSRM', () {
-      for (final style in RouteStyle.values) {
-        expect(
-          RoutePreferences(style: style).requiresValhallaCosting,
-          isFalse,
-          reason: '${style.apiValue} needs only OSRM alternatives',
-        );
-      }
-    });
-
-    test('each avoidance moves to the motorcycle service', () {
-      expect(
-        const RoutePreferences(avoidMotorways: true).requiresValhallaCosting,
-        isTrue,
-      );
-      expect(
-        const RoutePreferences(avoidMajorRoads: true).requiresValhallaCosting,
-        isTrue,
-      );
-      expect(
-        const RoutePreferences(avoidTolls: true).requiresValhallaCosting,
-        isTrue,
-      );
-      expect(
-        const RoutePreferences(avoidFerries: true).requiresValhallaCosting,
-        isTrue,
-      );
-    });
-
-    test('seeking byways moves to the motorcycle service', () {
-      // OSRM's car profile does not route highway=track at all, so this is the
-      // byway case OSRM cannot serve.
-      expect(
-        const RoutePreferences(
-          bywaySurface: BywaySurfacePreference.allowUnsurfaced,
-        ).requiresValhallaCosting,
-        isTrue,
-      );
-    });
-  });
-
-  group('Valhalla auto costing options', () {
+  group('Valhalla road costing options', () {
     test('the profile is auto, and never motorcycle again', () {
-      // A chase vehicle is a Land Rover or a van, often towing. Routing it as a
-      // motorbike sends it down roads it should not take and reads speed limits
-      // off roads it cannot use, so the option names themselves are pinned:
-      // `use_tracks` is auto's lever, `use_trails` is the motorcycle one and
-      // Valhalla ignores it under auto.
-      final options = RoutePreferences.defaults.valhallaAutoCostingOptions();
+      // `use_tracks` is auto's lever; `use_trails` is the motorcycle one, and
+      // Valhalla ignores it under auto. A naive rename would have silently
+      // stopped the byway preference working at all.
+      final options = RoutePreferences.defaults.valhallaRoadCostingOptions();
       expect(options.containsKey('use_tracks'), isTrue);
       expect(options.containsKey('use_trails'), isFalse);
     });
 
     test('a crew that has not asked to avoid unsurfaced ways gets tracks', () {
-      // The one that matters for a retrieve: a landing field is usually reached
-      // down a farm track, and Valhalla's auto costing avoids tracks by default,
-      // so they have to be opened back up explicitly.
+      // A landing field is usually reached down a farm track, and auto costing
+      // avoids tracks by default, so they must be opened back up explicitly.
       const allowed = RoutePreferences(
         bywaySurface: BywaySurfacePreference.allowUnsurfaced,
       );
-      expect(allowed.valhallaAutoCostingOptions()['use_tracks'], 0.5);
-      expect(allowed.valhallaAutoCostingOptions()['exclude_unpaved'], isFalse);
+      expect(allowed.valhallaRoadCostingOptions()['use_tracks'], 0.5);
+      expect(allowed.valhallaRoadCostingOptions()['exclude_unpaved'], isFalse);
       expect(
-        RoutePreferences.defaults.valhallaAutoCostingOptions()['use_tracks'],
+        RoutePreferences.defaults.valhallaRoadCostingOptions()['use_tracks'],
         0,
       );
     });
 
     test('defaults', () {
-      expect(RoutePreferences.defaults.valhallaAutoCostingOptions(), {
+      expect(RoutePreferences.defaults.valhallaRoadCostingOptions(), {
         'use_highways': 1,
+        'use_living_streets': 0.5,
         'use_tolls': 0.5,
         'use_ferry': 0.5,
         'use_tracks': 0,
@@ -158,23 +168,13 @@ void main() {
       });
     });
 
-    test('each style sets its own highway preference', () {
-      expect(
-        RouteStyle.values.map(
-          (style) => RoutePreferences(
-            style: style,
-          ).valhallaAutoCostingOptions()['use_highways'],
-        ),
-        [1, 0.6, 0.35, 0.15],
-      );
-    });
-
-    test('avoiding major roads overrides the style highway preference', () {
+    test('avoiding major roads beats a style that prefers them', () {
+      // One is a leaning, the other is an instruction the crew typed.
       expect(
         const RoutePreferences(
-          style: RouteStyle.veryTwisty,
+          style: RouteStyle.majorRoads,
           avoidMajorRoads: true,
-        ).valhallaAutoCostingOptions()['use_highways'],
+        ).valhallaRoadCostingOptions()['use_highways'],
         0.08,
       );
     });
@@ -182,72 +182,105 @@ void main() {
     test('avoiding motorways excludes rather than penalises them', () {
       final options = const RoutePreferences(
         avoidMotorways: true,
-      ).valhallaAutoCostingOptions();
+      ).valhallaRoadCostingOptions();
       expect(options['exclude_highways'], isTrue);
-      // The motorway exclusion is independent of the twistiness setting.
       expect(options['use_highways'], 1);
     });
 
-    test('allowing byways relaxes both surface levers together', () {
-      final options = const RoutePreferences(
-        bywaySurface: BywaySurfacePreference.allowUnsurfaced,
-      ).valhallaAutoCostingOptions();
-      expect(options['use_tracks'], 0.5);
-      expect(options['exclude_unpaved'], isFalse);
+    test('the dimensions ride alongside the road levers, not instead', () {
+      final options =
+          const RoutePreferences(
+                avoidMotorways: true,
+                vehicle: ChaseVehicle(heightMetres: 3.1, towing: true),
+              ).valhallaCostingOptions()['truck']!
+              as Map;
+      expect(options['exclude_highways'], isTrue);
+      expect(options['use_tracks'], 0);
+      expect(options['height'], 3.1);
     });
+  });
 
-    test('the whole combination the issue asks for', () {
+  group('choosing between alternatives', () {
+    test('only a towing vehicle asks for straighter roads', () {
+      expect(RoutePreferences.defaults.prefersStraighterRoads, isFalse);
       expect(
         const RoutePreferences(
-          style: RouteStyle.twisty,
-          avoidMotorways: true,
-        ).valhallaAutoCostingOptions(),
-        {
-          'use_highways': 0.35,
-          'use_tolls': 0.5,
-          'use_ferry': 0.5,
-          'use_tracks': 0,
-          'exclude_highways': true,
-          'exclude_tolls': false,
-          'exclude_ferries': false,
-          'exclude_unpaved': true,
-        },
+          vehicle: ChaseVehicle(towing: true),
+        ).prefersStraighterRoads,
+        isTrue,
+      );
+    });
+
+    test('a length alone is not read as a bend aversion', () {
+      // "5 m long" describes an ordinary estate car. Inferring that it wants
+      // straighter roads would apply the preference to most of the fleet.
+      expect(
+        const RoutePreferences(
+          vehicle: ChaseVehicle(lengthMetres: 5),
+        ).prefersStraighterRoads,
+        isFalse,
       );
     });
   });
 
-  test('preferences round-trip through JSON', () {
+  test('preferences round-trip through JSON, vehicle and all', () {
     const preferences = RoutePreferences(
-      style: RouteStyle.veryTwisty,
+      style: RouteStyle.majorRoads,
       avoidMotorways: true,
       avoidMajorRoads: true,
       avoidTolls: true,
       avoidFerries: true,
       bywaySurface: BywaySurfacePreference.allowUnsurfaced,
+      vehicle: ChaseVehicle(
+        heightMetres: 3.2,
+        widthMetres: 2.1,
+        lengthMetres: 11,
+        grossWeightTonnes: 3.5,
+        towing: true,
+      ),
     );
 
     expect(RoutePreferences.fromJson(preferences.toJson()), preferences);
-    expect(preferences.toJson()['style'], 'very-twisty');
+    expect(preferences.toJson()['style'], 'major-roads');
     expect(preferences.toJson()['bywaySurface'], 'allow-unsurfaced');
   });
 
-  test('the applied notes read in the planner order', () {
+  test('an unspecified vehicle is absent from the JSON, not an empty map', () {
+    // "Never told us" and "told us and then cleared it" mean the same thing and
+    // must read back the same.
+    expect(RoutePreferences.defaults.toJson().containsKey('vehicle'), isFalse);
+    expect(
+      RoutePreferences.fromJson(RoutePreferences.defaults.toJson()).vehicle,
+      ChaseVehicle.unspecified,
+    );
+  });
+
+  test('the applied notes end with the numbers being routed against', () {
     expect(
       const RoutePreferences(
-        style: RouteStyle.flowing,
+        style: RouteStyle.majorRoads,
         avoidMotorways: true,
-        avoidMajorRoads: true,
         avoidTolls: true,
-        avoidFerries: true,
+        vehicle: ChaseVehicle(heightMetres: 3.2, towing: true),
       ).appliedNotes,
       [
-        'Flowing-road bias',
+        'Major roads preferred',
         'motorways excluded',
-        'major roads avoided',
         'tolls excluded',
-        'ferries excluded',
         'unsurfaced byways avoided',
+        'towing',
+        '3.2 m high',
       ],
+    );
+  });
+
+  test('with nothing chosen the summary says direct, not quickest', () {
+    expect(RoutePreferences.defaults.summary, 'Unsurfaced byways avoided.');
+    expect(
+      const RoutePreferences(
+        bywaySurface: BywaySurfacePreference.allowUnsurfaced,
+      ).summary,
+      'Unsurfaced byways allowed.',
     );
   });
 }

--- a/apps/mobile/test/features/map/destination_route_sheet_test.dart
+++ b/apps/mobile/test/features/map/destination_route_sheet_test.dart
@@ -168,12 +168,10 @@ void main() {
       BywaySurfacePreference.avoidUnsurfaced,
     );
     // Avoiding motorways alone is not a byway decision, and vice versa.
-    expect(request?.preferences.style, RouteStyle.quickest);
+    expect(request?.preferences.style, RouteStyle.direct);
   });
 
-  testWidgets('a rider can ask for twisty roads and for byways', (
-    tester,
-  ) async {
+  testWidgets('a crew can ask for major roads and for byways', (tester) async {
     DestinationPlanRequest? request;
     await tester.pumpWidget(
       MaterialApp(
@@ -185,7 +183,7 @@ void main() {
                   context,
                   initialRequest: const DestinationPlanRequest(
                     query: 'Matlock Bath',
-                    preferences: RoutePreferences(style: RouteStyle.twisty),
+                    preferences: RoutePreferences(style: RouteStyle.majorRoads),
                   ),
                 );
               },
@@ -214,11 +212,86 @@ void main() {
     await tester.tap(find.byKey(const Key('plan-destination-button')));
     await tester.pumpAndSettle();
 
-    expect(request?.preferences.style, RouteStyle.twisty);
+    expect(request?.preferences.style, RouteStyle.majorRoads);
     expect(
       request?.preferences.bywaySurface,
       BywaySurfacePreference.allowUnsurfaced,
     );
     expect(request?.preferences.requiresValhallaCosting, isTrue);
+  });
+
+  testWidgets('the stored vehicle is stamped onto the planned route', (
+    tester,
+  ) async {
+    DestinationPlanRequest? request;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: FilledButton(
+              onPressed: () async {
+                request = await DestinationRouteSheet.show(
+                  context,
+                  initialRequest: const DestinationPlanRequest(
+                    query: 'Long Marston',
+                  ),
+                  vehicle: const ChaseVehicle(heightMetres: 3.2, towing: true),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    // Read back on screen, so the driver can see the numbers being routed
+    // against before committing to the route.
+    expect(
+      tester.widget<Text>(find.byKey(const Key('route-vehicle-summary'))).data,
+      'Planned for towing, 3.2 m high.',
+    );
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('plan-destination-button')),
+      250,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(find.byKey(const Key('plan-destination-button')));
+    await tester.pumpAndSettle();
+
+    expect(request?.preferences.vehicle.heightMetres, 3.2);
+    expect(request?.preferences.vehicle.towing, isTrue);
+    // The reason the whole feature exists: a height entered in Settings has to
+    // reach the router as truck costing, or low bridges are never considered.
+    expect(request?.preferences.valhallaCosting, 'truck');
+  });
+
+  testWidgets('with no vehicle stored the crew is told it plans for a car', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: FilledButton(
+              onPressed: () => DestinationRouteSheet.show(context),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<Text>(find.byKey(const Key('route-vehicle-summary'))).data,
+      contains('Planned for a car'),
+    );
   });
 }

--- a/apps/mobile/test/features/settings/chase_vehicle_sheet_test.dart
+++ b/apps/mobile/test/features/settings/chase_vehicle_sheet_test.dart
@@ -1,0 +1,174 @@
+import 'package:balloon_crumbs/controllers/chase_vehicle_controller.dart';
+import 'package:balloon_crumbs/domain/chase_vehicle.dart';
+import 'package:balloon_crumbs/features/settings/chase_vehicle_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _open(
+  WidgetTester tester,
+  ChaseVehicleController controller,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () =>
+                ChaseVehicleSheet.show(context, controller: controller),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('Open'));
+  await tester.pumpAndSettle();
+}
+
+/// Scrolls to Save before tapping it.
+///
+/// Toggling towing rewrites two helper lines, which is enough to push the button
+/// off an 800x600 test viewport. Tapping blind then misses and the test fails
+/// for a reason that has nothing to do with what it is checking.
+Future<void> _save(WidgetTester tester) async {
+  final save = find.byKey(const Key('chase-vehicle-save'));
+  await tester.scrollUntilVisible(
+    save,
+    200,
+    scrollable: find.byType(Scrollable).last,
+  );
+  await tester.tap(save);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a crew enters what they know and it is saved', (tester) async {
+    final controller = ChaseVehicleController.memory();
+    await _open(tester, controller);
+
+    await tester.enterText(
+      find.byKey(const Key('chase-vehicle-height-field')),
+      '3.2',
+    );
+    await tester.enterText(
+      find.byKey(const Key('chase-vehicle-weight-field')),
+      '3.5',
+    );
+    final towing = find.byKey(const Key('chase-vehicle-towing-switch'));
+    await tester.scrollUntilVisible(
+      towing,
+      -200,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(towing);
+    await tester.pumpAndSettle();
+    await _save(tester);
+
+    expect(controller.vehicle.heightMetres, 3.2);
+    expect(controller.vehicle.grossWeightTonnes, 3.5);
+    expect(controller.vehicle.towing, isTrue);
+    // Untouched fields stay untold rather than becoming a number.
+    expect(controller.vehicle.widthMetres, isNull);
+    expect(controller.vehicle.lengthMetres, isNull);
+  });
+
+  testWidgets('saving nothing saves nothing', (tester) async {
+    final controller = ChaseVehicleController.memory();
+    await _open(tester, controller);
+    await _save(tester);
+
+    expect(controller.vehicle, ChaseVehicle.unspecified);
+  });
+
+  testWidgets('an existing vehicle opens with its numbers in the fields', (
+    tester,
+  ) async {
+    final controller = ChaseVehicleController.memory(
+      vehicle: const ChaseVehicle(heightMetres: 3.2, lengthMetres: 11),
+    );
+    await _open(tester, controller);
+
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const Key('chase-vehicle-height-field')),
+          )
+          .controller
+          ?.text,
+      '3.2',
+    );
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const Key('chase-vehicle-length-field')),
+          )
+          .controller
+          ?.text,
+      '11',
+    );
+  });
+
+  testWidgets('an empty field is hinted as not set, never as zero', (
+    tester,
+  ) async {
+    // "0" would read as a value, and a height of zero fits under everything.
+    await _open(tester, ChaseVehicleController.memory());
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const Key('chase-vehicle-height-field')),
+          )
+          .decoration
+          ?.hintText,
+      'Not set',
+    );
+  });
+
+  testWidgets('the weight label says which weight, never just "MTW"', (
+    tester,
+  ) async {
+    // Reading this as a towing capacity instead of a laden weight puts the
+    // wrong number against a weight-limited bridge, and it is the crew who
+    // finds out.
+    final controller = ChaseVehicleController.memory(
+      vehicle: const ChaseVehicle(towing: true),
+    );
+    await _open(tester, controller);
+
+    final weight = tester.widget<TextField>(
+      find.byKey(const Key('chase-vehicle-weight-field')),
+    );
+    expect(weight.decoration?.labelText, 'Maximum weight (tonnes)');
+    expect(weight.decoration?.helperText, contains('together'));
+    expect(weight.decoration?.helperText, contains('not what the towbar'));
+  });
+
+  testWidgets('the mapping caveat is on screen, not buried', (tester) async {
+    // The feature can only avoid restrictions OpenStreetMap records, and UK
+    // maxheight coverage is patchy. A clear route must not read as a promise.
+    await _open(tester, ChaseVehicleController.memory());
+    expect(
+      tester
+          .widget<Text>(find.byKey(const Key('chase-vehicle-coverage-caveat')))
+          .data,
+      allOf(
+        contains('only avoid restrictions that are mapped'),
+        contains('keep reading the signs'),
+      ),
+    );
+  });
+
+  testWidgets('a nonsense number is discarded rather than stored', (
+    tester,
+  ) async {
+    final controller = ChaseVehicleController.memory();
+    await _open(tester, controller);
+    await tester.enterText(
+      find.byKey(const Key('chase-vehicle-height-field')),
+      '0',
+    );
+    await _save(tester);
+
+    expect(controller.vehicle.heightMetres, isNull);
+  });
+}

--- a/apps/mobile/test/services/road_routing_test.dart
+++ b/apps/mobile/test/services/road_routing_test.dart
@@ -516,8 +516,8 @@ void main() {
       expect(result.twistinessScore, isNotNull);
     });
 
-    test('a bendier style asks OSRM for three alternatives and picks the '
-        'bendiest inside the allowance', () async {
+    test('a towing vehicle asks OSRM for three alternatives and picks the '
+        'straightest inside the allowance', () async {
       Uri? requested;
       final service = OsrmRoadRoutingService(
         client: MockClient((request) async {
@@ -527,22 +527,32 @@ void main() {
         baseUrl: Uri.parse('https://routing.example.test'),
       );
 
-      final flowing = await service.routeThrough(
+      final towing = await service.routeThrough(
         _twoPoints,
-        preferences: const RoutePreferences(style: RouteStyle.flowing),
+        preferences: const RoutePreferences(
+          vehicle: ChaseVehicle(towing: true),
+        ),
       );
-      final veryTwisty = await service.routeThrough(
+      final notTowing = await service.routeThrough(
         _twoPoints,
-        preferences: const RoutePreferences(style: RouteStyle.veryTwisty),
+        preferences: RoutePreferences.defaults,
       );
 
-      expect(requested!.queryParameters['alternatives'], '3');
-      // Quickest is 1000 s. Flowing allows 1250 s, so only the 1200 s
-      // alternative qualifies; very twisty allows 1750 s and reaches the
-      // bendiest 1700 s one.
-      expect(flowing.duration, const Duration(seconds: 1200));
-      expect(veryTwisty.duration, const Duration(seconds: 1700));
-      expect(veryTwisty.twistinessScore, greaterThan(flowing.twistinessScore!));
+      expect(
+        requested!.queryParameters.containsKey('alternatives'),
+        isFalse,
+        reason: 'the last request was the one without a trailer',
+      );
+      // Without a trailer the fastest route is taken as offered, corners and
+      // all. Towing allows 1000 * 1.15 = 1150 s, which reaches the straight
+      // 1100 s road but not the straighter 1700 s one.
+      expect(notTowing.duration, const Duration(seconds: 1000));
+      expect(towing.duration, const Duration(seconds: 1100));
+      expect(
+        towing.twistinessScore,
+        lessThan(notTowing.twistinessScore!),
+        reason: 'the trailer got the straighter road',
+      );
     });
 
     test('avoiding motorways sends the documented auto costing to '
@@ -566,14 +576,12 @@ void main() {
 
       final result = await service.routeThrough(
         _twoPoints,
-        preferences: const RoutePreferences(
-          style: RouteStyle.twisty,
-          avoidMotorways: true,
-        ),
+        preferences: const RoutePreferences(avoidMotorways: true),
       );
 
       expect(costing, {
-        'use_highways': 0.35,
+        'use_highways': 1,
+        'use_living_streets': 0.5,
         'use_tolls': 0.5,
         'use_ferry': 0.5,
         'use_tracks': 0,
@@ -824,7 +832,7 @@ void main() {
       );
       await dispatcher.routeThrough(
         _twoPoints,
-        preferences: const RoutePreferences(style: RouteStyle.veryTwisty),
+        preferences: const RoutePreferences(style: RouteStyle.majorRoads),
       );
       await dispatcher.routeThrough(
         _twoPoints,
@@ -836,16 +844,30 @@ void main() {
           bywaySurface: BywaySurfacePreference.allowUnsurfaced,
         ),
       );
+      await dispatcher.routeThrough(
+        _twoPoints,
+        preferences: const RoutePreferences(
+          vehicle: ChaseVehicle(heightMetres: 3.2),
+        ),
+      );
+      await dispatcher.routeThrough(
+        _twoPoints,
+        preferences: const RoutePreferences(
+          vehicle: ChaseVehicle(towing: true),
+        ),
+      );
 
       expect(
         osrm.requests,
         hasLength(3),
-        reason: 'no preference, the defaults, and a style-only change',
+        reason: 'no preference, the defaults, and towing with no dimensions',
       );
       expect(
         valhalla.requests,
-        hasLength(2),
-        reason: 'a hard exclusion, and seeking byways',
+        hasLength(4),
+        reason:
+            'preferring major roads, a hard exclusion, seeking byways, and '
+            'a height to route around',
       );
     });
 
@@ -875,14 +897,17 @@ void main() {
             originQuery: 'Start',
             query: 'Finish',
             preferences: const RoutePreferences(
-              style: RouteStyle.twisty,
+              style: RouteStyle.majorRoads,
               avoidMotorways: true,
             ),
           );
 
       expect(
         plan.route.preferences,
-        const RoutePreferences(style: RouteStyle.twisty, avoidMotorways: true),
+        const RoutePreferences(
+          style: RouteStyle.majorRoads,
+          avoidMotorways: true,
+        ),
       );
       expect(plan.route.description, contains('motorways excluded'));
       expect(plan.route.description, contains('unsurfaced byways avoided'));
@@ -954,7 +979,7 @@ void main() {
         ],
         waypoints: const [],
         preferences: const RoutePreferences(
-          style: RouteStyle.twisty,
+          style: RouteStyle.majorRoads,
           avoidMotorways: true,
         ),
       );
@@ -993,6 +1018,13 @@ String _osrmResponse() => jsonEncode({
 
 /// Three alternatives: straight and quickest first, then a bendier one inside
 /// the flowing allowance, then the bendiest and slowest.
+/// Three alternatives where the fastest is also the bendiest.
+///
+/// Deliberately that way round, and it is what makes this fixture able to fail.
+/// Ordered straightest-first, both a towing and a non-towing vehicle would pick
+/// the same route and the test would pass without exercising anything. It is
+/// also the realistic case: a lane through the hills is often quicker than the
+/// A-road, right up until there is a trailer on the back.
 String _osrmAlternativesResponse() {
   List<List<double>> sinusoid(double amplitude) => [
     for (var index = 0; index < 40; index += 1)
@@ -1001,20 +1033,23 @@ String _osrmAlternativesResponse() {
   return jsonEncode({
     'code': 'Ok',
     'routes': [
+      // OSRM's first route is its fastest, and this one is all corners.
       {
         'distance': 20000,
         'duration': 1000,
-        'geometry': {'coordinates': sinusoid(0)},
+        'geometry': {'coordinates': sinusoid(0.012)},
       },
+      // Straight, and inside the 1150 s a towing vehicle will accept.
       {
         'distance': 22000,
-        'duration': 1200,
-        'geometry': {'coordinates': sinusoid(0.006)},
+        'duration': 1100,
+        'geometry': {'coordinates': sinusoid(0)},
       },
+      // Straighter still, but far too slow to be worth it.
       {
         'distance': 26000,
         'duration': 1700,
-        'geometry': {'coordinates': sinusoid(0.012)},
+        'geometry': {'coordinates': sinusoid(0)},
       },
     ],
   });

--- a/apps/mobile/test/services/route_twistiness_test.dart
+++ b/apps/mobile/test/services/route_twistiness_test.dart
@@ -2,12 +2,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/services/route_twistiness.dart';
 
-/// The same geometry and the same expected numbers as
-/// `apps/website/planner-core.test.mjs`. These fixtures exist so the app cannot
-/// grow a second notion of twisty: if either implementation drifts, one of the
-/// two suites fails (#46, #182).
+/// Geometry fixtures for the bend score (#46, #182).
+///
+/// These were described as pinning the score against
+/// `apps/website/planner-core.test.mjs`, so that a drift in either
+/// implementation failed one of two suites. That file does not exist in this
+/// repository and never has, so what these actually do is pin the score against
+/// itself — a regression test, not a cross-check. Still worth having, and worth
+/// not being wrong about.
 void main() {
-  test('the shared calibration fixture scores what the web planner scores', () {
+  test('the calibration fixture scores what it has always scored', () {
     final score = RouteTwistiness.score(
       _sinusoidalLane,
       distanceMeters: _sinusoidalLaneMeters,
@@ -69,77 +73,85 @@ void main() {
   });
 
   group('alternative selection within the detour allowance', () {
-    const quickest = (duration: 3600.0, twistiness: 5.0);
-    const bendier = (duration: 4300.0, twistiness: 40.0);
-    const bendiest = (duration: 6000.0, twistiness: 90.0);
-    const candidates = [quickest, bendier, bendiest];
+    // Named for the road, not the rider: the straight one is the one a trailer
+    // can follow, the bendy ones are the ones it cannot.
+    const straightest = (duration: 3600.0, bends: 5.0);
+    const bendy = (duration: 4000.0, bends: 40.0);
+    const hairpins = (duration: 4100.0, bends: 90.0);
 
-    ({double duration, double twistiness})? choose(RouteStyle style) =>
-        RouteTwistiness.chooseWithinDetour(
-          candidates,
-          style: style,
-          duration: (candidate) => candidate.duration,
-          twistiness: (candidate) => candidate.twistiness,
+    ({double duration, double bends})? choose(
+      List<({double duration, double bends})> candidates, {
+      RoutePreferences preferences = RoutePreferences.defaults,
+    }) => RouteTwistiness.chooseWithinDetour(
+      candidates,
+      preferences: preferences,
+      duration: (candidate) => candidate.duration,
+      bendScore: (candidate) => candidate.bends,
+    );
+
+    const towing = RoutePreferences(vehicle: ChaseVehicle(towing: true));
+
+    test('not towing keeps the provider order and ignores bends', () {
+      // The engine's first route is its quickest. With no trailer there is
+      // nothing to trade time for, so it is taken as offered.
+      expect(choose(const [hairpins, straightest]), hairpins);
+    });
+
+    test('towing takes the straightest route it can afford', () {
+      // The inversion this change is built on: the same score the motorcycle
+      // build used to seek corners now avoids them.
+      expect(
+        choose(const [bendy, hairpins, straightest], preferences: towing),
+        straightest,
+      );
+    });
+
+    test('towing will not exceed the allowance to straighten a route', () {
+      // 3600 * 1.15 = 4140 s. A straighter road half an hour away is not worth
+      // it to a crew whose balloon is coming down now.
+      expect(
+        choose(const [
+          bendy,
+          (duration: 9000.0, bends: 1.0),
+        ], preferences: towing),
+        bendy,
+        reason: '9000 s exceeds the 4600 s allowance',
+      );
+    });
+
+    test('the allowance does not depend on the road style', () {
+      // It is the trailer that makes a straighter road worth 15% more time, so
+      // both styles reach the same alternative. Hanging tolerance off the style
+      // is what previously made the default style allow nothing at all.
+      for (final style in RouteStyle.values) {
+        expect(
+          choose(
+            const [bendy, (duration: 4500.0, bends: 2.0)],
+            preferences: RoutePreferences(
+              style: style,
+              vehicle: const ChaseVehicle(towing: true),
+            ),
+          ),
+          (duration: 4500.0, bends: 2.0),
+          reason: '4000 * 1.15 = 4600 s, so it fits — ${style.name}',
         );
-
-    test('quickest keeps the provider order and ignores bends', () {
-      expect(choose(RouteStyle.quickest), quickest);
+      }
     });
 
-    test('flowing accepts 25% and no more', () {
-      // 4300 s is over the 4500 s allowance? No: 3600 * 1.25 = 4500, so it fits.
-      expect(choose(RouteStyle.flowing), bendier);
-    });
-
-    test('very twisty reaches the 75% alternative', () {
-      // 3600 * 1.75 = 6300 s, so the bendiest becomes eligible.
-      expect(choose(RouteStyle.veryTwisty), bendiest);
-    });
-
-    test('nothing eligible keeps the quickest', () {
-      expect(
-        RouteTwistiness.chooseWithinDetour(
-          const [quickest, bendiest],
-          style: RouteStyle.flowing,
-          duration: (candidate) => candidate.duration,
-          twistiness: (candidate) => candidate.twistiness,
-        ),
-        quickest,
-        reason: '6000 s exceeds the 4500 s allowance',
-      );
-    });
-
-    test('a single alternative is the answer whatever the style', () {
-      expect(
-        RouteTwistiness.chooseWithinDetour(
-          const [bendiest],
-          style: RouteStyle.twisty,
-          duration: (candidate) => candidate.duration,
-          twistiness: (candidate) => candidate.twistiness,
-        ),
-        bendiest,
-      );
+    test('a single alternative is the answer whatever is towed', () {
+      expect(choose(const [hairpins], preferences: towing), hairpins);
     });
 
     test('no alternatives at all is null, never an invented route', () {
-      expect(
-        RouteTwistiness.chooseWithinDetour(
-          const <({double duration, double twistiness})>[],
-          style: RouteStyle.twisty,
-          duration: (candidate) => candidate.duration,
-          twistiness: (candidate) => candidate.twistiness,
-        ),
-        isNull,
-      );
+      expect(choose(const [], preferences: towing), isNull);
     });
   });
 }
 
-/// Distance of [_sinusoidalLane], as the web planner measures it.
+/// Distance of [_sinusoidalLane].
 const _sinusoidalLaneMeters = 12963.688380;
 
-/// A deterministic sinusoidal lane. Byte-for-byte the coordinates used by the
-/// matching web planner test.
+/// A deterministic sinusoidal lane.
 const _sinusoidalLane = [
   GeoPoint(latitude: 51.4, longitude: -2.5),
   GeoPoint(latitude: 51.402337, longitude: -2.496),


### PR DESCRIPTION
Closes #22.

Retargets the inherited route styles at the crew who actually drive them, and gives them somewhere to say how big their vehicle is.

## The styles

The ladder traded time for bends — quickest / flowing (+25%) / twisty (+50%) / very twisty (+75%), with `use_highways` falling to 0.15 as it got twistier. Coherent for someone whose journey is the point; wrong for a crew trying to be under a balloon when it lands, and actively harmful when towing, since biasing a trailer off main roads onto lanes can stop it arriving at all.

Two options now: **Direct — fastest way there**, and **Prefer major roads**.

The four retired names degrade to `direct`, not to the nearest-looking survivor. A route stored as `twisty` asked for half again the journey time in exchange for corners; there is no honest translation of that into a chase preference, and inventing one would apply a bias to a stored route that nobody chose for this vehicle.

## Low bridges need a different costing, not different numbers

Valhalla's `auto` costing **ignores `maxheight`, `maxweight` and `maxwidth` outright**, so no combination of options under `auto` can avoid a low bridge. The router now switches to `truck` costing once a dimension has been entered.

Only once a dimension is entered — `truck` costing without dimensions inherits Valhalla's articulated-lorry defaults (4.11 m, 21.77 t), which applied to a crew who ticked "towing" and typed nothing else would refuse most of the roads to a launch site, for reasons they never stated. Unentered dimensions are sent as car figures rather than omitted, for the same reason inverted: a blank field means "not told", which must restrict nothing.

The mapping limit is on screen, not in a comment: OSM `maxheight` coverage is patchy, so a clear route means "nothing mapped on this line", never "passable".

## The twisty score survives, upside down

`route_twistiness.dart` stays. The measurement was never the motorcycling part — a road with 40 degrees of bend per kilometre is that road whoever is driving it. What changes is the sign: with a trailer the router asks for alternatives and takes the **straightest** it can afford. Roads suitable for towing, from the code that used to find roads unsuitable for it.

## A bug the test found

Detour tolerance hung off the route style, and the new default style allows 0%. A crew who ticked "towing" would have got a preference that **could never once change their route** — silently, because the field was still there and still being read. Tolerance belongs to the trailer, so it moved: one `towingDetourLimit` of 1.15, one consumer. `RouteStyle.detourLimit` is gone rather than left as a field nothing implements.

## Six files were lying about a contract

`route_preferences.dart` declared itself the Dart half of a contract with `apps/website/planner-core.mjs`, pinned by tests both sides, documented in `docs/route-twistiness.md`. **Neither file exists, and `git log --all` shows neither ever has** — they belong to Tail End Charlie. That claim cost real time to disprove before this could even be scoped, so all six now say what is true, including fixtures that "pin" the bend score against nothing but themselves.

## Threading

Four forwarding sites (two in `ride_map_feature.dart`, two in `active_ride_shell.dart`) that `flutter analyze` was happy to leave unforwarded, since the parameter has a default. Each checked by hand. The home backdrop is deliberately not threaded — `canEditRoute: false`, it plans nothing.

## Simulator proof

Ride 545103 on an iPad Pro 11-inch, walked end to end:

| step | result |
| --- | --- |
| Settings | new **CHASE VEHICLE** section, "Add vehicle size · Avoid low bridges, weight limits and narrow roads" |
| toggle towing | length helper rewrites to "Vehicle and trailer together"; weight helper to "…can legally be together — **not what the towbar is rated for**" |
| enter 3.2, Save | Settings row reads **"towing · 3.2 m high"** |
| Plan a destination | **"Planned for towing, 3.2 m high."** under Route preferences |
| style dropdown | exactly two entries — Direct, Prefer major roads |

The MTW disambiguation is the one worth looking at: read as a towbar rating instead of a laden weight it puts the wrong number against a weight-limited bridge, so the label never abbreviates it and the helper text changes with the towing switch.

## Verification

- `flutter analyze` clean, `dart format` clean
- **1665 tests** pass (from 1634): new coverage for the vehicle model, the persisted store, the editor, truck dispatch, and the straightest-route selection
- the alternatives fixture was **reordered so it can fail** — straightest-first, both towing and not-towing pick the same route and the test proves nothing

## Still open for you

Is length worth keeping? You named height, width, weight and towing; I added length because Valhalla's truck costing uses it for turn costs and towing changes it most. Easy to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)