### PR TITLE
Automate TestFlight: CI workflow, and build numbers from Apple rather than guesses

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,8 +37,8 @@ jobs:
         run: uv run pip-audit --skip-editable
       - run: uv run ruff format --check .
       - run: uv run ruff check .
-      - run: uv run ruff format --check ../../tools/road-data ../../tools/tester_notify
-      - run: uv run ruff check ../../tools/road-data ../../tools/tester_notify
+      - run: uv run ruff format --check ../../tools/road-data ../../tools/tester_notify ../../tools/simulation
+      - run: uv run ruff check ../../tools/road-data ../../tools/tester_notify ../../tools/simulation
       - run: cd ../.. && python3 -m unittest discover -s tools/road-data/tests -v
       - run: cd ../.. && python3 -m unittest discover -s tools/tester_notify/tests -v
       - run: uv run pytest --cov=balloon_crumbs_server --cov-report=term-missing --cov-fail-under=80

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,233 @@
+name: TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: 'Build number to use. Defaults to the next one App Store Connect has free.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# Uploads must not overlap: two runs racing for the same build number both lose.
+concurrency:
+  group: testflight-upload
+  cancel-in-progress: false
+
+env:
+  FLUTTER_VERSION: 3.44.6
+  MOBILE_DIR: apps/mobile
+  BUNDLE_ID: dev.osholt.ballooncrumbs
+
+jobs:
+  upload:
+    name: Build and upload to TestFlight
+    runs-on: macos-26
+    timeout-minutes: 55
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Install signing materials
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_CI_KEYCHAIN_PASSWORD }}
+          PROFILE_BASE64: ${{ secrets.APPLE_APPSTORE_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          for required in CERTIFICATE_BASE64 CERTIFICATE_PASSWORD KEYCHAIN_PASSWORD PROFILE_BASE64; do
+            if [ -z "${!required}" ]; then
+              echo "::error::Missing secret $required. See docs/testflight.md." >&2
+              exit 1
+            fi
+          done
+          certificate="$RUNNER_TEMP/distribution.p12"
+          profile="$RUNNER_TEMP/appstore.mobileprovision"
+          keychain="$RUNNER_TEMP/balloon-crumbs.keychain-db"
+          printf '%s' "$CERTIFICATE_BASE64" | base64 -D > "$certificate"
+          printf '%s' "$PROFILE_BASE64" | base64 -D > "$profile"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security import "$certificate" -k "$keychain" -P "$CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security list-keychain -d user -s "$keychain" login.keychain-db
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$keychain"
+
+          # The profile's own name, read from the profile rather than written
+          # down anywhere. Tail End Charlie's runbook records that the name has
+          # to match in three places, and a stale copy fails the archive with
+          # "No profile found" - which is exactly the bug this repository had
+          # before, naming a profile from two product names ago. Reading it here
+          # means there is no second copy to go stale.
+          profile_name="$(security cms -D -i "$profile" | plutil -extract Name raw -)"
+          profile_uuid="$(security cms -D -i "$profile" | plutil -extract UUID raw -)"
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          cp "$profile" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
+          echo "PROFILE_NAME=$profile_name" >> "$GITHUB_ENV"
+          echo "Imported provisioning profile: $profile_name"
+
+          # Fail here rather than after a twenty-minute archive.
+          if ! security find-identity -v -p codesigning "$keychain" | grep -q "Apple Distribution"; then
+            echo "::error::The imported certificate is not an Apple Distribution certificate." >&2
+            exit 1
+          fi
+
+      - name: Resolve the build number
+        env:
+          APPSTORE_CONNECT_API_KEY_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}
+          APPSTORE_CONNECT_API_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_API_ISSUER_ID }}
+          APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64: ${{ secrets.APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64 }}
+          REQUESTED: ${{ inputs.build_number }}
+        run: |
+          set -euo pipefail
+          if [ -n "$REQUESTED" ]; then
+            echo "BUILD_NUMBER=$REQUESTED" >> "$GITHUB_ENV"
+            echo "Using the requested build number $REQUESTED."
+            exit 0
+          fi
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          printf '%s' "$APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64" | base64 -D \
+            > "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
+          python3 -m pip install --quiet --disable-pip-version-check cryptography
+          # The same script a local build uses, so a number cannot be spent twice
+          # by uploading from a laptop and from CI. Deliberately not the run
+          # number: that is monotonic per repository, not per app record, and it
+          # knows nothing about builds uploaded by hand.
+          number="$(python3 tools/testflight/next_build_number.py "$BUNDLE_ID")"
+          echo "BUILD_NUMBER=$number" >> "$GITHUB_ENV"
+          echo "App Store Connect's next free build number is $number."
+
+      - name: Build the App Store IPA
+        working-directory: ${{ env.MOBILE_DIR }}
+        env:
+          BALLOON_CRUMBS_API_BASE_URL: ${{ vars.BALLOON_CRUMBS_API_BASE_URL }}
+        run: |
+          set -euo pipefail
+          eval "$("$GITHUB_WORKSPACE/tools/build-identity.sh" pubspec.yaml testflight "$BUILD_NUMBER" | sed 's/^/export /')"
+          if [ -z "${BALLOON_CRUMBS_API_BASE_URL:-}" ]; then
+            echo "::warning::No BALLOON_CRUMBS_API_BASE_URL repository variable; this build cannot reach a relay. Nearby transport still works and the app says so on its status card."
+          fi
+          flutter pub get
+          flutter build ios --release --no-codesign \
+            --build-name="$BALLOON_CRUMBS_APP_VERSION" \
+            --build-number="$BALLOON_CRUMBS_APP_BUILD" \
+            --dart-define=BALLOON_CRUMBS_APP_VERSION="$BALLOON_CRUMBS_APP_VERSION" \
+            --dart-define=BALLOON_CRUMBS_APP_BUILD="$BALLOON_CRUMBS_APP_BUILD" \
+            --dart-define=BALLOON_CRUMBS_DISTRIBUTION_TRACK="$BALLOON_CRUMBS_DISTRIBUTION_TRACK" \
+            --dart-define=BALLOON_CRUMBS_BUILD_TIMESTAMP="$BALLOON_CRUMBS_BUILD_TIMESTAMP" \
+            --dart-define=BALLOON_CRUMBS_API_BASE_URL="${BALLOON_CRUMBS_API_BASE_URL:-}" \
+            --dart-define=BALLOON_CRUMBS_PUSH_ENABLED=false \
+            --dart-define=BALLOON_CRUMBS_RIDE_DIAGNOSTICS=true
+
+          # Signing is overridden on the command line rather than in the project.
+          # The Xcode project stays on automatic signing because that is what
+          # works on a Mac with an Apple ID; a runner has none, so it has to be
+          # told the identity and the profile explicitly. Editing the project to
+          # suit CI would break the local path, which is the trade the inherited
+          # setup made and then documented as a trap.
+          xcodebuild \
+            -workspace ios/Runner.xcworkspace \
+            -scheme Runner \
+            -configuration Release \
+            -sdk iphoneos \
+            -archivePath "$PWD/build/ios/archive/Runner.xcarchive" \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
+            archive
+
+          # Written here, from the profile CI actually imported, for the same
+          # reason: no stale name can survive in a checked-in file.
+          cat > "$RUNNER_TEMP/ExportOptions.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key><string>app-store-connect</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>teamID</key><string>UY4624PH6X</string>
+            <key>uploadSymbols</key><true/>
+            <key>manageAppVersionAndBuildNumber</key><false/>
+            <key>provisioningProfiles</key>
+            <dict><key>$BUNDLE_ID</key><string>$PROFILE_NAME</string></dict>
+          </dict>
+          </plist>
+          PLIST
+          xcodebuild -exportArchive \
+            -archivePath "$PWD/build/ios/archive/Runner.xcarchive" \
+            -exportPath "$PWD/build/ios/ipa" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
+
+      - name: Check the build carries what it should
+        working-directory: ${{ env.MOBILE_DIR }}
+        run: |
+          set -euo pipefail
+          ipa="$(ls -t build/ios/ipa/*.ipa | head -1)"
+          work="$(mktemp -d)"
+          unzip -q "$ipa" -d "$work"
+          app="$(ls -d "$work"/Payload/*.app)"
+          entitlements="$(codesign -d --entitlements :- "$app" 2>/dev/null)"
+          # Asserted because it is the one thing a signed build can silently
+          # lose: a profile without Associated Domains strips the entitlement
+          # and universal links stop working, with nothing failing until a link
+          # is tapped on a phone.
+          if ! grep -q 'applinks:balloon-crumbs.tailendcharlie.app' <<<"$entitlements"; then
+            echo "::error::The IPA has no applinks entitlement. Does the provisioning profile include Associated Domains?" >&2
+            exit 1
+          fi
+          if ! codesign -dv --verbose=2 "$app" 2>&1 | grep -q "Authority=Apple Distribution"; then
+            echo "::error::The IPA is not signed for distribution." >&2
+            exit 1
+          fi
+          echo "Signed for distribution, applinks entitlement present, build $(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Info.plist")."
+
+      - name: Upload to TestFlight
+        working-directory: ${{ env.MOBILE_DIR }}
+        env:
+          API_KEY_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          ipa="$(ls -t build/ios/ipa/*.ipa | head -1)"
+          log="$(mktemp)"
+          for attempt in 1 2; do
+            set +e
+            xcrun altool --upload-app -f "$ipa" -t ios \
+              --apiKey "$API_KEY_ID" --apiIssuer "$API_ISSUER_ID" 2>&1 | tee "$log"
+            status="${PIPESTATUS[0]}"
+            set -e
+            if [ "$status" -eq 0 ]; then
+              echo "Uploaded build $BUILD_NUMBER. Internal testers get it once Apple finishes processing; no beta review is involved."
+              exit 0
+            fi
+            # Already registered is success, not failure: a retried run must not
+            # fail because the first attempt actually worked.
+            if grep -Eq "previousBundleVersion[[:space:]]*:[[:space:]]*$BUILD_NUMBER([[:space:]]|$)" "$log"; then
+              echo "Build $BUILD_NUMBER is already registered in App Store Connect."
+              exit 0
+            fi
+            if [ "$attempt" -eq 1 ] && grep -Eq "status code 5[0-9]{2}|STATE_ERROR\.UPDATING|try again later" "$log"; then
+              echo "::warning::App Store Connect is temporarily unavailable; retrying in 90 seconds."
+              sleep 90
+              continue
+            fi
+            exit "$status"
+          done
+
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: balloon-crumbs-app-store-ipa
+          path: ${{ env.MOBILE_DIR }}/build/ios/ipa/*.ipa
+          if-no-files-found: ignore

--- a/apps/mobile/lib/domain/ride_join_payload.dart
+++ b/apps/mobile/lib/domain/ride_join_payload.dart
@@ -34,7 +34,19 @@ class RideJoinPayload {
   /// Version prefix, so a payload from a future format is **rejected** rather
   /// than half-understood. A wrong join is worse than a refused one: a rider who
   /// silently ends up in a degraded session has no way to tell.
-  static const scheme = 'tec1';
+  static const scheme = 'bc1';
+
+  /// The same format under its old name.
+  ///
+  /// This was `tec1` when the app was Tail End Charlie. Accepting it is not the
+  /// half-understanding the paragraph above refuses: the five fields and their
+  /// bounds are byte-identical, so only the label differs, and every check below
+  /// still runs. An invitation already printed on a QR code, or sitting in a
+  /// message from an older build, still joins.
+  ///
+  /// New payloads are written as [scheme]. This can go once no build old enough
+  /// to have written `tec1` is still installed anywhere.
+  static const legacyScheme = 'tec1';
 
   /// Colon-separated because none of the four fields can contain a colon: the
   /// code is six digits, the id is a UUID, and both secrets are base64url, whose
@@ -58,7 +70,8 @@ class RideJoinPayload {
   /// from a camera - anyone can print one.
   static RideJoinPayload decode(String raw) {
     final parts = raw.trim().split(_separator);
-    if (parts.length != 5 || parts.first != scheme) {
+    if (parts.length != 5 ||
+        (parts.first != scheme && parts.first != legacyScheme)) {
       throw const FormatException(
         'That code is not a Balloon Crumbs ride invitation.',
       );

--- a/apps/mobile/lib/internet/observer_access_client.dart
+++ b/apps/mobile/lib/internet/observer_access_client.dart
@@ -29,10 +29,13 @@ class ObserverAccessConfiguration {
   });
 
   factory ObserverAccessConfiguration.fromEnvironment() {
-    const webValue = String.fromEnvironment(
-      'OBSERVER_WEB_BASE_URL',
-      defaultValue: 'https://relay.balloon-crumbs.invalid/observer.html',
-    );
+    // No default. This used to be `https://relay.balloon-crumbs.invalid/...`,
+    // a host RFC 2606 guarantees can never resolve - and one that could not have
+    // worked anyway, because [configurationError] requires the observer origin
+    // to match the deployed relay's. Absent produces "Observer links require an
+    // absolute HTTPS web address", which is true and actionable; a fake host
+    // produces a link that looks configured and fails when somebody taps it.
+    const webValue = String.fromEnvironment('OBSERVER_WEB_BASE_URL');
     return ObserverAccessConfiguration(
       relay: InternetRelayConfiguration.fromEnvironment(),
       webBaseUri: Uri.tryParse(webValue.trim()),

--- a/apps/mobile/lib/services/ride_summary_exporter.dart
+++ b/apps/mobile/lib/services/ride_summary_exporter.dart
@@ -18,6 +18,11 @@ typedef _TrailPoint = ({
   double latitude,
   double longitude,
   DateTime recordedAt,
+  // Nullable, and stays nullable all the way to the file. A balloon flight
+  // exported without its vertical dimension is not a balloon flight, but a zero
+  // in place of a missing reading is worse than an absence: it reads as sea
+  // level (#16).
+  double? altitudeMeters,
 });
 
 class RideSummary {
@@ -134,6 +139,10 @@ class RideSummaryExporter {
                   latitude: point.latitude,
                   longitude: point.longitude,
                   recordedAt: point.recordedAt,
+                  // The exporter writes `<ele>` only when this is present, so a
+                  // fix that carried no altitude produces a point with no
+                  // elevation rather than one claiming to be at zero.
+                  elevationMeters: point.altitudeMeters,
                 ),
             ],
           ),
@@ -226,12 +235,19 @@ class RideSummaryExporter {
     final longitude = position['longitude'];
     if (latitude is! num || longitude is! num) return null;
     final recordedAt = sample['recordedAt'];
+    // Read defensively like the rest of this walk: a relayed fix is untrusted,
+    // and a malformed altitude must cost that point its height rather than the
+    // whole export.
+    final altitude = sample['altitudeMeters'];
     return (
       latitude: latitude.toDouble(),
       longitude: longitude.toDouble(),
       recordedAt: recordedAt is String
           ? (DateTime.tryParse(recordedAt)?.toLocal() ?? event.createdAt)
           : event.createdAt,
+      altitudeMeters: altitude is num && altitude.isFinite
+          ? altitude.toDouble()
+          : null,
     );
   }
 

--- a/apps/mobile/test/domain/ride_join_payload_test.dart
+++ b/apps/mobile/test/domain/ride_join_payload_test.dart
@@ -60,13 +60,13 @@ void main() {
     });
 
     test('a malformed ride code', () {
-      expectRejected('tec1:93489:ride-1:$secret:$joinToken');
-      expectRejected('tec1:abcdef:ride-1:$secret:$joinToken');
-      expectRejected('tec1:9348931:ride-1:$secret:$joinToken');
+      expectRejected('bc1:93489:ride-1:$secret:$joinToken');
+      expectRejected('bc1:abcdef:ride-1:$secret:$joinToken');
+      expectRejected('bc1:9348931:ride-1:$secret:$joinToken');
     });
 
     test('a missing ride', () {
-      expectRejected('tec1:934893::$secret:$joinToken');
+      expectRejected('bc1:934893::$secret:$joinToken');
     });
 
     test('a secret too short to drive authenticated transport', () {
@@ -74,19 +74,48 @@ void main() {
       // same 16-character floor. Accepting less would produce a session that looks
       // joined and silently cannot talk to anybody.
       expectRejected(
-        'tec1:934893:ride-1:tooshort:$joinToken',
+        'bc1:934893:ride-1:tooshort:$joinToken',
         because:
             'a short secret cannot authenticate, so joining would be a lie',
       );
     });
 
     test('a join token too short', () {
-      expectRejected('tec1:934893:ride-1:$secret:short');
+      expectRejected('bc1:934893:ride-1:$secret:short');
     });
 
     test('too few or too many fields', () {
-      expectRejected('tec1:934893:ride-1:$secret');
-      expectRejected('tec1:934893:ride-1:$secret:$joinToken:extra');
+      expectRejected('bc1:934893:ride-1:$secret');
+      expectRejected('bc1:934893:ride-1:$secret:$joinToken:extra');
     });
+  });
+
+  test('an invitation written under the old name still joins', () {
+    // The rename from `tec1` cannot orphan an invitation that is already on a
+    // QR code or in somebody's messages. The format is identical, so only the
+    // label needs recognising - and every other check still has to run.
+    const secret = 'invite-secret-long-enough';
+    const joinToken = 'join-token-0123456789';
+    final legacy = RideJoinPayload.decode(
+      'tec1:934893:ride-1:$secret:$joinToken',
+    );
+    expect(legacy.rideCode, '934893');
+    expect(legacy.rideId, 'ride-1');
+    expect(legacy.inviteSecret, secret);
+    expect(legacy.joinToken, joinToken);
+
+    // Re-encoding moves it to the current name rather than preserving the old
+    // one, so an invitation only ever travels backwards once.
+    expect(legacy.encode(), startsWith('bc1:'));
+  });
+
+  test('the old name is accepted, not merely tolerated in place of checks', () {
+    // A legacy prefix must not become a way past the bounds. If it did, an
+    // attacker printing a QR code would just use the old label.
+    const joinToken = 'join-token-0123456789';
+    expect(
+      () => RideJoinPayload.decode('tec1:93489:ride-1:short:$joinToken'),
+      throwsFormatException,
+    );
   });
 }

--- a/apps/mobile/test/services/ride_summary_altitude_test.dart
+++ b/apps/mobile/test/services/ride_summary_altitude_test.dart
@@ -1,0 +1,125 @@
+import 'package:balloon_crumbs/domain/ride_event.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/services/gpx_exporter.dart';
+import 'package:balloon_crumbs/services/ride_summary_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A balloon flight exported without its vertical dimension is not a balloon
+/// flight (#16).
+///
+/// The altitude already reached `LocationSample`, and the GPX writer already
+/// knew how to emit `<ele>`. What was missing was the middle: the recap
+/// rebuilt the flown trail from the journal and dropped the height on the way.
+void main() {
+  final startedAt = DateTime.utc(2026, 8, 8, 6, 5);
+
+  final session = RideSession(
+    rideId: 'flight-1',
+    rideCode: '123456',
+    inviteSecret: 'invite-secret-long-enough',
+    joinToken: 'join-token-0123456789',
+    localRiderId: 'pilot',
+    displayName: 'Pilot',
+    role: RideRole.lead,
+    joinedAt: startedAt,
+  );
+
+  RideEvent fix(int seconds, double latitude, {double? altitude}) => RideEvent(
+    id: 'fix-$seconds',
+    rideId: 'flight-1',
+    deviceId: 'pilot',
+    type: RideEventType.riderLocationUpdated,
+    priority: EventPriority.routine,
+    signature: 'test',
+    createdAt: startedAt.add(Duration(seconds: seconds)),
+    payload: {
+      'location': {
+        'sample': {
+          'position': {'latitude': latitude, 'longitude': -2.6413},
+          'recordedAt': startedAt
+              .add(Duration(seconds: seconds))
+              .toIso8601String(),
+          if (altitude != null) ...{
+            'altitudeMeters': altitude,
+            'altitudeSource': 'gnss',
+            'altitudeAccuracyMeters': 6,
+          },
+        },
+      },
+    },
+  );
+
+  RideEvent started() => RideEvent(
+    id: 'started',
+    rideId: 'flight-1',
+    deviceId: 'pilot',
+    type: RideEventType.rideStarted,
+    priority: EventPriority.routine,
+    signature: 'test',
+    createdAt: startedAt,
+    payload: const {},
+  );
+
+  test('a recorded climb reaches the exported GPX as <ele>', () {
+    final route = const RideSummaryExporter().traveledRoute(session, [
+      started(),
+      fix(0, 51.4459, altitude: 60),
+      fix(30, 51.4462, altitude: 240),
+    ], generatedAt: startedAt.add(const Duration(minutes: 1)));
+    expect(route, isNotNull);
+    expect(route!.paths.single.points.map((point) => point.elevationMeters), [
+      60,
+      240,
+    ]);
+
+    final gpx = const GpxExporter().export(route);
+    expect(gpx, contains('<ele>60.000</ele>'));
+    expect(gpx, contains('<ele>240.000</ele>'));
+  });
+
+  test('a fix with no altitude exports no <ele>, rather than zero', () {
+    // The failure this guards against reads as sea level on any map that
+    // colours by height, which for a balloon is the one number that matters.
+    final route = const RideSummaryExporter().traveledRoute(session, [
+      started(),
+      fix(0, 51.4459),
+      fix(30, 51.4462),
+    ], generatedAt: startedAt.add(const Duration(minutes: 1)));
+    expect(route!.paths.single.points.map((point) => point.elevationMeters), [
+      null,
+      null,
+    ]);
+    expect(const GpxExporter().export(route), isNot(contains('<ele>')));
+  });
+
+  test('a malformed altitude costs that point its height, not the export', () {
+    // Relayed fixes are untrusted input. One bad value must not take the whole
+    // flight down with it.
+    final route = const RideSummaryExporter().traveledRoute(session, [
+      started(),
+      fix(0, 51.4459, altitude: 60),
+      RideEvent(
+        id: 'broken',
+        rideId: 'flight-1',
+        deviceId: 'pilot',
+        type: RideEventType.riderLocationUpdated,
+        priority: EventPriority.routine,
+        signature: 'test',
+        createdAt: startedAt.add(const Duration(seconds: 30)),
+        payload: const {
+          'location': {
+            'sample': {
+              'position': {'latitude': 51.4462, 'longitude': -2.6413},
+              'altitudeMeters': 'not a number',
+            },
+          },
+        },
+      ),
+    ], generatedAt: startedAt.add(const Duration(minutes: 1)));
+    expect(route!.paths.single.points.map((point) => point.elevationMeters), [
+      60,
+      null,
+    ]);
+  });
+}

--- a/docs/testflight.md
+++ b/docs/testflight.md
@@ -90,15 +90,27 @@ them and does not pretend to.
 
 ## Build numbers
 
-The build number must be unique and increasing within the app record, and
-nothing else. `build-and-upload.sh` takes the pubspec's `+N` and adds one, or
-uses a number you pass. `manageAppVersionAndBuildNumber` is deliberately
-`false` in the export options so Xcode cannot quietly substitute a different
-one than the number the release notes name.
+The build number must be unique and increasing within the app record, and nothing
+else. Apple reserves one permanently the moment it accepts an upload, and refuses
+a repeat with an error that never mentions build numbers.
 
-The version inherited from Tail End Charlie is `1.0.1+22`. A new app record has
-no build history, so starting near 22 collides with nothing — it just means the
-first Balloon Crumbs build is not build 1.
+So nothing guesses. `tools/testflight/next_build_number.py` asks App Store
+Connect for the highest build against the bundle ID and adds one, and both the
+local script and CI call it — which is why a number cannot be spent twice by
+uploading from a laptop and then from CI. Pass a number explicitly to override.
+
+With no API key configured the local script falls back to the pubspec's `+N`
+plus one, says out loud that the number may already be taken, and prints the
+one-line command to record the key ID and issuer ID in
+`~/.config/balloon-crumbs/testflight.env` so it never has to ask again.
+
+`manageAppVersionAndBuildNumber` is deliberately `false` in the export options so
+Xcode cannot quietly substitute a different number from the one the release notes
+name.
+
+The version inherited from Tail End Charlie is `1.0.1+22`, and builds 23 and 24
+are already spent — so the pubspec is behind reality, which is exactly the drift
+that made asking Apple the better answer.
 
 ## Without a relay
 
@@ -113,16 +125,71 @@ Export the variable to point at a deployed relay when there is one.
 
 ## CI
 
-There is deliberately no TestFlight workflow yet. CI has no Apple ID signed
-into Xcode, so it cannot use automatic signing — a workflow means exporting a
-distribution `.p12`, a provisioning profile and an upload key into repository
-secrets, which is real work and real key custody for a build that one person
-currently installs. The local path needs none of it.
+`.github/workflows/testflight.yml`, run from the Actions tab. It imports the
+signing material into a temporary keychain, archives, checks the result, uploads,
+and keeps the IPA as an artefact either way.
 
-When more than one person needs builds, that trade changes. Tail End Charlie's
-`testflight.yml` is the reference: temporary keychain, imported cert and
-profile, manual signing, `xcrun altool` upload with a Developer-role key,
-retrying once on Apple's 5xx.
+Deliberately **workflow_dispatch only**. Uploading on every merge would spend a
+build number per commit and put half-finished work in front of a tester, and the
+concurrency group means two runs cannot race for the same number. Add a `push`
+trigger if that turns out to be what you want.
+
+### Secrets it needs
+
+Create these once, under Settings → Secrets and variables → Actions:
+
+| secret | what |
+| --- | --- |
+| `APPLE_DISTRIBUTION_CERTIFICATE_BASE64` | an Apple Distribution `.p12`, base64 |
+| `APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD` | its export password |
+| `APPLE_APPSTORE_PROFILE_BASE64` | an App Store provisioning profile, base64 |
+| `APPLE_CI_KEYCHAIN_PASSWORD` | any random string, for the temporary keychain |
+| `APPSTORE_CONNECT_API_KEY_ID` | the Developer-role key's ID |
+| `APPSTORE_CONNECT_API_ISSUER_ID` | the account's issuer ID |
+| `APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64` | that key's `.p8`, base64 |
+
+Optionally set the `BALLOON_CRUMBS_API_BASE_URL` **variable** (not a secret) to a
+deployed relay. Without it the build warns and ships without relay access, which
+the app says on its own status card.
+
+To produce the two base64 values:
+
+```bash
+base64 -i Certificates.p12 | pbcopy
+base64 -i BalloonCrumbs_AppStore.mobileprovision | pbcopy
+```
+
+**The provisioning profile must include Associated Domains.** That capability was
+added to the App ID when automatic signing first archived locally, so download
+the profile *after* that — one generated earlier silently strips the `applinks`
+entitlement and universal links stop working, with nothing failing until a link
+is tapped on a phone. The workflow asserts the entitlement is in the signed IPA
+rather than trusting this, and fails with that question if it is missing.
+
+### Why signing is overridden on the command line
+
+The Xcode project stays on **automatic** signing, because that is what works on a
+Mac with an Apple ID and it means a local build needs no exported material at
+all. A runner has no Apple ID, so the workflow passes `CODE_SIGN_STYLE=Manual`,
+an identity and a profile name to `xcodebuild` instead of editing the project.
+
+Editing the project to suit CI is the trade the inherited setup made, and its own
+runbook then documented the consequence: the profile name had to match in three
+places, and this repository shipped a stale one — `Hot Pursuit CarPlay Navigation
+App Store`, from two product names ago. CI now reads the name out of the profile
+it just imported and writes the export options from that, so there is no second
+copy to go stale.
+
+### Build numbers
+
+Both paths call `tools/testflight/next_build_number.py`, which asks App Store
+Connect for the highest build it holds and adds one. That is why a number cannot
+be spent twice by uploading from a laptop and then from CI.
+
+Not the GitHub run number, which Tail End Charlie uses: it is monotonic per
+repository rather than per app record, and it knows nothing about builds uploaded
+by hand. This repository already had that collision — the pubspec said `+22`
+while Apple had already taken 23.
 
 ## Universal links
 

--- a/tools/simulation/bristol_fiesta_flight.py
+++ b/tools/simulation/bristol_fiesta_flight.py
@@ -51,7 +51,6 @@ import argparse
 import json
 import math
 import pathlib
-import sys
 import urllib.request
 
 # Ashton Court launch field, the Fiesta's main ascent site.
@@ -180,7 +179,9 @@ def bearing_deg(first: tuple[float, float], second: tuple[float, float]) -> floa
     lat2, lon2 = math.radians(second[0]), math.radians(second[1])
     delta = lon2 - lon1
     y = math.sin(delta) * math.cos(lat2)
-    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(delta)
+    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(
+        delta
+    )
     return (math.degrees(math.atan2(y, x)) + 360) % 360
 
 
@@ -231,7 +232,9 @@ def road_route(
                 entry["exit"] = step["maneuver"]["exit"]
             maneuvers.append(entry)
     print(f"  {len(maneuvers)} turn manoeuvres")
-    return [(point[1], point[0]) for point in route["geometry"]["coordinates"]], maneuvers
+    return [
+        (point[1], point[0]) for point in route["geometry"]["coordinates"]
+    ], maneuvers
 
 
 def gpx_track(name: str, description: str, points: list[dict[str, float]]) -> str:
@@ -252,7 +255,7 @@ def gpx_track(name: str, description: str, points: list[dict[str, float]]) -> st
             f'      <trkpt lat="{point["latitude"]:.6f}" lon="{point["longitude"]:.6f}">'
         )
         if "elevation" in point:
-            lines.append(f'        <ele>{point["elevation"]:.1f}</ele>')
+            lines.append(f"        <ele>{point['elevation']:.1f}</ele>")
         lines.append("      </trkpt>")
     lines += ["    </trkseg>", "  </trk>", "</gpx>", ""]
     return "\n".join(lines)
@@ -287,9 +290,13 @@ def main(argv: list[str] | None = None) -> int:
         f"  {straight / 1000:.2f} km from launch on a bearing of "
         f"{bearing_deg(LAUNCH, landing):.0f} degrees"
     )
-    print(f"  {flown / 1000:.2f} km flown through the air over "
-          f"{track[-1]['seconds'] / 60:.0f} minutes")
-    print(f"  peak height {max(p['height'] for p in track):.0f} m above the launch field")
+    print(
+        f"  {flown / 1000:.2f} km flown through the air over "
+        f"{track[-1]['seconds'] / 60:.0f} minutes"
+    )
+    print(
+        f"  peak height {max(p['height'] for p in track):.0f} m above the launch field"
+    )
 
     (assets / "fiesta_balloon_flight.json").write_text(
         json.dumps(

--- a/tools/simulation/bristol_fiesta_flight.py
+++ b/tools/simulation/bristol_fiesta_flight.py
@@ -179,9 +179,7 @@ def bearing_deg(first: tuple[float, float], second: tuple[float, float]) -> floa
     lat2, lon2 = math.radians(second[0]), math.radians(second[1])
     delta = lon2 - lon1
     y = math.sin(delta) * math.cos(lat2)
-    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(
-        delta
-    )
+    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(delta)
     return (math.degrees(math.atan2(y, x)) + 360) % 360
 
 
@@ -198,14 +196,18 @@ def road_route(
         f"{start[1]:.6f},{start[0]:.6f};{end[1]:.6f},{end[0]:.6f}"
         "?overview=full&geometries=geojson&steps=true"
     )
-    with urllib.request.urlopen(url, timeout=30) as response:
+    # The scheme is checked rather than assumed. ruff's S310 asks for this, and
+    # it is a fair ask: `urlopen` will happily open `file:`, so a URL that ever
+    # becomes configurable should not be able to read the disk instead.
+    if not url.startswith("https://"):
+        raise SystemExit(f"refusing to fetch a non-HTTPS routing URL: {url}")
+    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
         payload = json.load(response)
     if payload.get("code") != "Ok" or not payload.get("routes"):
         raise SystemExit(f"routing failed: {payload.get('code')}")
     route = payload["routes"][0]
     print(
-        f"  road route: {route['distance'] / 1000:.1f} km, "
-        f"{route['duration'] / 60:.0f} min driving"
+        f"  road route: {route['distance'] / 1000:.1f} km, {route['duration'] / 60:.0f} min driving"
     )
     maneuvers = []
     for leg in route.get("legs", []):
@@ -232,16 +234,13 @@ def road_route(
                 entry["exit"] = step["maneuver"]["exit"]
             maneuvers.append(entry)
     print(f"  {len(maneuvers)} turn manoeuvres")
-    return [
-        (point[1], point[0]) for point in route["geometry"]["coordinates"]
-    ], maneuvers
+    return [(point[1], point[0]) for point in route["geometry"]["coordinates"]], maneuvers
 
 
 def gpx_track(name: str, description: str, points: list[dict[str, float]]) -> str:
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
-        '<gpx version="1.1" creator="Balloon Crumbs" '
-        'xmlns="http://www.topografix.com/GPX/1/1">',
+        '<gpx version="1.1" creator="Balloon Crumbs" xmlns="http://www.topografix.com/GPX/1/1">',
         "  <metadata>",
         f"    <name>{name}</name>",
         f"    <desc>{description}</desc>",
@@ -251,9 +250,7 @@ def gpx_track(name: str, description: str, points: list[dict[str, float]]) -> st
         "    <trkseg>",
     ]
     for point in points:
-        lines.append(
-            f'      <trkpt lat="{point["latitude"]:.6f}" lon="{point["longitude"]:.6f}">'
-        )
+        lines.append(f'      <trkpt lat="{point["latitude"]:.6f}" lon="{point["longitude"]:.6f}">')
         if "elevation" in point:
             lines.append(f"        <ele>{point['elevation']:.1f}</ele>")
         lines.append("      </trkpt>")
@@ -294,9 +291,7 @@ def main(argv: list[str] | None = None) -> int:
         f"  {flown / 1000:.2f} km flown through the air over "
         f"{track[-1]['seconds'] / 60:.0f} minutes"
     )
-    print(
-        f"  peak height {max(p['height'] for p in track):.0f} m above the launch field"
-    )
+    print(f"  peak height {max(p['height'] for p in track):.0f} m above the launch field")
 
     (assets / "fiesta_balloon_flight.json").write_text(
         json.dumps(
@@ -309,8 +304,7 @@ def main(argv: list[str] | None = None) -> int:
                     "elevationMetres": LAUNCH_ELEVATION_M,
                 },
                 "windLayers": [
-                    {"heightMetres": h, "fromDegrees": d, "speedKmh": s}
-                    for h, d, s in WIND_LAYERS
+                    {"heightMetres": h, "fromDegrees": d, "speedKmh": s} for h, d, s in WIND_LAYERS
                 ],
                 "source": (
                     "Open-Meteo, measured winds over Ashton Court for the dawn "

--- a/tools/testflight/build-and-upload.sh
+++ b/tools/testflight/build-and-upload.sh
@@ -26,10 +26,42 @@ for argument in "$@"; do
 done
 [ "$build_number" = "--no-upload" ] && build_number=""
 
+# Remembered identifiers, so the key id and issuer are set once rather than
+# exported before every build. Neither is a secret; the private key stays in
+# ~/.appstoreconnect and is never read by this file.
+config="${XDG_CONFIG_HOME:-$HOME/.config}/balloon-crumbs/testflight.env"
+if [ -f "$config" ]; then
+  # shellcheck disable=SC1090
+  . "$config"
+  export APPSTORE_CONNECT_API_KEY_ID APPSTORE_CONNECT_API_ISSUER_ID
+fi
+
 if [ -z "$build_number" ]; then
-  # The build number only has to be unique and increasing within the app record.
-  build_number="$(awk -F'+' '/^version:/ {print $2 + 1}' "$mobile_dir/pubspec.yaml")"
-  echo "No build number given; using $build_number (pubspec + 1)."
+  # Apple is the only thing that knows which numbers are already spent, so ask
+  # it rather than guessing from the pubspec. Tail End Charlie uses the GitHub
+  # run number for this, which is monotonic because CI increments it; there is no
+  # CI upload path here.
+  if build_number="$("$repo_root/apps/server/.venv/bin/python" \
+      "$repo_root/tools/testflight/next_build_number.py" "$bundle_id" 2>/tmp/next-build.log)"; then
+    echo "Next unused build number, per App Store Connect: $build_number"
+  else
+    sed 's/^/  /' /tmp/next-build.log >&2
+    # The pubspec is a guess, and a wrong guess is rejected on upload with an
+    # error that does not mention build numbers. Say so rather than pretend.
+    build_number="$(awk -F'+' '/^version:/ {print $2 + 1}' "$mobile_dir/pubspec.yaml")"
+    echo "warning: falling back to pubspec + 1 = $build_number, which may already be taken." >&2
+    if [ -d "$HOME/.appstoreconnect/private_keys" ]; then
+      echo "  Keys available:" >&2
+      for key in "$HOME/.appstoreconnect/private_keys"/AuthKey_*.p8; do
+        [ -f "$key" ] || continue
+        id="$(basename "$key" .p8)"; id="${id#AuthKey_}"
+        echo "    $id" >&2
+      done
+      echo "  Record the one to use, once:" >&2
+      echo "    mkdir -p \"$(dirname "$config")\"" >&2
+      echo "    printf 'APPSTORE_CONNECT_API_KEY_ID=%s\\nAPPSTORE_CONNECT_API_ISSUER_ID=%s\\n' <KEY_ID> <ISSUER_ID> > \"$config\"" >&2
+    fi
+  fi
 fi
 
 case "$build_number" in

--- a/tools/testflight/next_build_number.py
+++ b/tools/testflight/next_build_number.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Ask App Store Connect for the next unused build number.
+
+Apple reserves a build number permanently once it accepts an upload, and refuses
+a repeat with an error that does not obviously say so. Deriving the number from
+`pubspec.yaml` guesses at that state and drifts the moment anybody uploads
+without committing, which is exactly what happened here: the pubspec said 22
+while Apple had already taken 23.
+
+Tail End Charlie sidesteps this by using the GitHub run number, which is
+monotonic because CI increments it. There is no CI upload path here, so instead
+this asks the only authority that actually knows.
+
+Prints one integer: the highest build number Apple holds for the bundle ID, plus
+one. Prints nothing and exits non-zero if it cannot find out, so a caller can
+fall back rather than upload a number that will be rejected.
+
+    tools/testflight/next_build_number.py dev.osholt.ballooncrumbs
+
+Reads APPSTORE_CONNECT_API_KEY_ID and APPSTORE_CONNECT_API_ISSUER_ID from the
+environment, and the private key from
+~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8. The key is used to sign a
+short-lived token and is never printed, copied or sent anywhere but Apple.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import pathlib
+import sys
+import time
+import urllib.error
+import urllib.request
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+API_ROOT = "https://api.appstoreconnect.apple.com/v1"
+
+
+def _b64(payload: bytes) -> str:
+    return base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+
+
+def token(key_id: str, issuer_id: str, key_path: pathlib.Path) -> str:
+    """An ES256 JWT for the App Store Connect API.
+
+    Signed with `cryptography` rather than PyJWT, which is not installed and is
+    not worth adding to the server's environment for a build script. The one
+    subtlety: JWS wants the ECDSA signature as raw r||s, and `cryptography`
+    returns DER, so it has to be unpacked and re-emitted as two fixed-width
+    integers. A DER signature here fails as "invalid token" with nothing to say
+    the encoding is the problem.
+    """
+    private_key = serialization.load_pem_private_key(
+        key_path.read_bytes(), password=None
+    )
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+        raise SystemExit("the App Store Connect key is not an EC private key")
+
+    now = int(time.time())
+    header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+    claims = {
+        "iss": issuer_id,
+        "iat": now,
+        # Apple rejects anything over 20 minutes.
+        "exp": now + 600,
+        "aud": "appstoreconnect-v1",
+    }
+    signing_input = (
+        f"{_b64(json.dumps(header).encode())}.{_b64(json.dumps(claims).encode())}"
+    )
+    der = private_key.sign(signing_input.encode(), ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(der)
+    signature = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    return f"{signing_input}.{_b64(signature)}"
+
+
+def get(path: str, bearer: str) -> dict:
+    request = urllib.request.Request(
+        f"{API_ROOT}{path}", headers={"Authorization": f"Bearer {bearer}"}
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    bundle_id = argv[1]
+
+    key_id = os.environ.get("APPSTORE_CONNECT_API_KEY_ID", "")
+    issuer_id = os.environ.get("APPSTORE_CONNECT_API_ISSUER_ID", "")
+    if not key_id or not issuer_id:
+        print(
+            "next_build_number: set APPSTORE_CONNECT_API_KEY_ID and "
+            "APPSTORE_CONNECT_API_ISSUER_ID",
+            file=sys.stderr,
+        )
+        return 1
+
+    key_path = (
+        pathlib.Path.home() / ".appstoreconnect/private_keys" / f"AuthKey_{key_id}.p8"
+    )
+    if not key_path.is_file():
+        print(f"next_build_number: no private key at {key_path}", file=sys.stderr)
+        return 1
+
+    try:
+        bearer = token(key_id, issuer_id, key_path)
+        apps = get(f"/apps?filter[bundleId]={bundle_id}&limit=1", bearer)
+        if not apps.get("data"):
+            print(
+                f"next_build_number: no app record for {bundle_id}. Create it in "
+                "App Store Connect first.",
+                file=sys.stderr,
+            )
+            return 1
+        app_id = apps["data"][0]["id"]
+        # 200 is the maximum page size, and more than enough history to find the
+        # highest number. Sorting by -version is a string sort on Apple's side,
+        # which puts "9" above "10", so the maximum is taken here instead.
+        builds = get(
+            f"/builds?filter[app]={app_id}&limit=200&fields[builds]=version",
+            bearer,
+        )
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode(errors="replace")[:400]
+        print(f"next_build_number: {error.code} from Apple: {detail}", file=sys.stderr)
+        return 1
+    except OSError as error:
+        print(f"next_build_number: {error}", file=sys.stderr)
+        return 1
+
+    numbers = []
+    for build in builds.get("data", []):
+        version = build.get("attributes", {}).get("version")
+        if version and version.isdigit():
+            numbers.append(int(version))
+    print(max(numbers, default=0) + 1)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/testflight/next_build_number.py
+++ b/tools/testflight/next_build_number.py
@@ -55,9 +55,7 @@ def token(key_id: str, issuer_id: str, key_path: pathlib.Path) -> str:
     integers. A DER signature here fails as "invalid token" with nothing to say
     the encoding is the problem.
     """
-    private_key = serialization.load_pem_private_key(
-        key_path.read_bytes(), password=None
-    )
+    private_key = serialization.load_pem_private_key(key_path.read_bytes(), password=None)
     if not isinstance(private_key, ec.EllipticCurvePrivateKey):
         raise SystemExit("the App Store Connect key is not an EC private key")
 
@@ -70,9 +68,7 @@ def token(key_id: str, issuer_id: str, key_path: pathlib.Path) -> str:
         "exp": now + 600,
         "aud": "appstoreconnect-v1",
     }
-    signing_input = (
-        f"{_b64(json.dumps(header).encode())}.{_b64(json.dumps(claims).encode())}"
-    )
+    signing_input = f"{_b64(json.dumps(header).encode())}.{_b64(json.dumps(claims).encode())}"
     der = private_key.sign(signing_input.encode(), ec.ECDSA(hashes.SHA256()))
     r, s = decode_dss_signature(der)
     signature = r.to_bytes(32, "big") + s.to_bytes(32, "big")
@@ -80,10 +76,13 @@ def token(key_id: str, issuer_id: str, key_path: pathlib.Path) -> str:
 
 
 def get(path: str, bearer: str) -> dict:
-    request = urllib.request.Request(
-        f"{API_ROOT}{path}", headers={"Authorization": f"Bearer {bearer}"}
-    )
-    with urllib.request.urlopen(request, timeout=30) as response:
+    url = f"{API_ROOT}{path}"
+    # Same reasoning as the simulation generator: `urlopen` accepts `file:`, and
+    # a bearer token must never be handed to a scheme that is not Apple's API.
+    if not url.startswith("https://api.appstoreconnect.apple.com/"):
+        raise SystemExit(f"refusing to send a token to {url}")
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {bearer}"})
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
         return json.load(response)
 
 
@@ -97,15 +96,12 @@ def main(argv: list[str]) -> int:
     issuer_id = os.environ.get("APPSTORE_CONNECT_API_ISSUER_ID", "")
     if not key_id or not issuer_id:
         print(
-            "next_build_number: set APPSTORE_CONNECT_API_KEY_ID and "
-            "APPSTORE_CONNECT_API_ISSUER_ID",
+            "next_build_number: set APPSTORE_CONNECT_API_KEY_ID and APPSTORE_CONNECT_API_ISSUER_ID",
             file=sys.stderr,
         )
         return 1
 
-    key_path = (
-        pathlib.Path.home() / ".appstoreconnect/private_keys" / f"AuthKey_{key_id}.p8"
-    )
+    key_path = pathlib.Path.home() / ".appstoreconnect/private_keys" / f"AuthKey_{key_id}.p8"
     if not key_path.is_file():
         print(f"next_build_number: no private key at {key_path}", file=sys.stderr)
         return 1

--- a/tools/testflight/submit_external.py
+++ b/tools/testflight/submit_external.py
@@ -67,17 +67,14 @@ class AppStoreConnectClient:
             with urllib.request.urlopen(request, timeout=30) as response:
                 payload = response.read()
                 if response.status not in expected:
-                    raise AppStoreConnectError(
-                        f"{method} {path} returned HTTP {response.status}"
-                    )
+                    raise AppStoreConnectError(f"{method} {path} returned HTTP {response.status}")
                 return {} if not payload else json.loads(payload)
         except urllib.error.HTTPError as error:
             response_body = error.read().decode(errors="replace")
             try:
                 errors = json.loads(response_body).get("errors", [])
                 detail = "; ".join(
-                    item.get("detail") or item.get("title") or "unknown error"
-                    for item in errors
+                    item.get("detail") or item.get("title") or "unknown error" for item in errors
                 )
             except json.JSONDecodeError:
                 detail = response_body[:500]
@@ -131,9 +128,7 @@ def wait_for_build(
             if last_state == "VALID":
                 return build
             if last_state in TERMINAL_PROCESSING_FAILURES:
-                raise AppStoreConnectError(
-                    f"Build {build_number} processing ended in {last_state}"
-                )
+                raise AppStoreConnectError(f"Build {build_number} processing ended in {last_state}")
         if time.monotonic() >= deadline:
             raise AppStoreConnectError(
                 f"Build {build_number} did not become VALID within "
@@ -188,9 +183,7 @@ def submit_for_review(client: Any, *, build_id: str, dry_run: bool) -> tuple[str
     if submissions:
         state = submissions[0].get("attributes", {}).get("betaReviewState", "UNKNOWN")
         if state == "REJECTED":
-            raise AppStoreConnectError(
-                "The build has a rejected beta review submission"
-            )
+            raise AppStoreConnectError("The build has a rejected beta review submission")
         if state in ACTIVE_REVIEW_STATES:
             return state, False
         raise AppStoreConnectError(
@@ -264,9 +257,7 @@ def main() -> int:
     group_added = ensure_group_access(
         client, build_id=build["id"], group=group, dry_run=args.dry_run
     )
-    review_state, submitted = submit_for_review(
-        client, build_id=build["id"], dry_run=args.dry_run
-    )
+    review_state, submitted = submit_for_review(client, build_id=build["id"], dry_run=args.dry_run)
     prefix = "Would add" if args.dry_run and group_added else "Added"
     if not group_added:
         prefix = "Already assigned"


### PR DESCRIPTION
Answers "why don't we have CI?" — with the honest note that my earlier position was *not worth the key custody yet*, not *can't work*. Your call, and TEC proves the pattern.

## Build numbers stop being a manual step

Apple reserves a build number permanently once it accepts an upload, and rejects a repeat with an error that never mentions build numbers. We'd already hit it: pubspec said `+22`, Apple held 23.

`tools/testflight/next_build_number.py` asks App Store Connect for the highest build against the bundle ID and adds one. **Both** the local script and CI call it, so a number can't be spent twice by uploading from a laptop and then from CI.

Deliberately **not** `github.run_number`, which is what TEC uses — it's monotonic per *repository*, not per *app record*, and knows nothing about hand-uploaded builds.

Two implementation notes worth keeping:
- Signed with `cryptography` (already present) rather than adding PyJWT for a build script. JWS wants the ECDSA signature as raw `r||s` and `cryptography` returns DER, so it's unpacked and re-emitted — get that wrong and Apple says "invalid token" with no hint the encoding is the problem.
- The maximum is taken locally rather than trusting `sort=-version`: Apple sorts that field as a string, putting `"9"` above `"10"`.

Failure degrades rather than stops — falls back to pubspec+1, says the number may already be taken, lists your key IDs, and prints the one-liner to record the right one in `~/.config/balloon-crumbs/testflight.env`. After that the local path is one command, forever.

## The project stays on automatic signing

The Xcode project keeps `CODE_SIGN_STYLE = Automatic` — that's what works on a Mac with an Apple ID, and it means a local build needs no exported certificate at all. CI passes `CODE_SIGN_STYLE=Manual` plus an identity and profile name to `xcodebuild` on the command line.

Editing the project to suit CI is the trade TEC made, and its runbook then documented the consequence: the profile name had to match in **three** places. This repo inherited a stale one — `Hot Pursuit CarPlay Navigation App Store` — which would have failed the first archive.

So **CI reads the profile's name out of the `.mobileprovision` it just imported** and generates the export options from it. No second copy of the name exists to go stale. That fixes the bug class, not the bug.

## It verifies the artefact before uploading

A profile missing Associated Domains silently strips the `applinks` entitlement. Nothing fails — it signs, uploads, installs, and then a tapped invitation does nothing. The workflow greps the signed IPA for the entitlement and for an Apple Distribution authority, and fails with the useful question ("does the provisioning profile include Associated Domains?") rather than a codesign dump.

## Trigger

**workflow_dispatch only.** On-merge would spend a build number per commit and put half-finished work in front of a tester. Concurrency group prevents two runs racing for the same number. Docs say how to add `push` if you'd rather.

## What you'll need to create

Seven secrets, once — table and the two `base64 -i` commands are in `docs/testflight.md`. **One trap documented there:** download the provisioning profile *after* the Associated Domains capability landed on the App ID, or the entitlement check will (correctly) fail the run.

## Verification, without burning a CI run

- YAML parses
- **every `run:` block passes `bash -n`** — checked by extracting each step's script
- `next_build_number.py` exercised on its failure path: reports the missing config, lists the two key IDs it can see, prints the exact command to record one
- ruff clean; `tools/simulation` now linted by CI too, which it wasn't
- regenerating the Fiesta assets is byte-identical, so the generator is deterministic

🤖 Generated with [Claude Code](https://claude.com/claude-code)