### PR TITLE
Preserve altitude evidence through GPX

### DIFF
--- a/apps/mobile/lib/controllers/ride_simulation_controller.dart
+++ b/apps/mobile/lib/controllers/ride_simulation_controller.dart
@@ -434,6 +434,9 @@ class RideSimulationController extends ChangeNotifier {
           altitudeSource: flight == null
               ? AltitudeSource.unknown
               : AltitudeSource.gnss,
+          altitudeDatum: flight == null
+              ? AltitudeDatum.unknown
+              : AltitudeDatum.relativeToLaunch,
           altitudeAccuracyMeters: flight == null ? null : 6,
           verticalSpeedMetersPerSecond: flight?.verticalSpeedMetersPerSecond,
         );

--- a/apps/mobile/lib/domain/altitude.dart
+++ b/apps/mobile/lib/domain/altitude.dart
@@ -1,0 +1,39 @@
+/// Where an altitude reading came from.
+///
+/// Recorded rather than inferred because the two sources fail differently: a
+/// GNSS altitude is noisy but absolute, a barometric one is smooth but drifts
+/// with the weather and needs a reference setting. A balloon crew judging a
+/// climb rate needs to know which they are looking at.
+enum AltitudeSource {
+  /// Height from the positioning fix itself.
+  gnss,
+
+  /// Height from a pressure sensor.
+  barometric,
+
+  /// An altitude arrived with no statement of where it came from — typically an
+  /// imported file. Never used to mean "no altitude": that is a null reading.
+  unknown,
+}
+
+/// The vertical reference used by an altitude reading.
+///
+/// This cannot be inferred from [AltitudeSource]. Core Location reports height
+/// above mean sea level, while Android's ordinary `Location.altitude` reports
+/// height above the WGS84 ellipsoid. The difference is tens of metres in parts
+/// of the UK, so losing this field can make a technically precise reading
+/// materially misleading.
+enum AltitudeDatum {
+  /// Orthometric height above the WGS84-associated mean-sea-level geoid.
+  wgs84Geoid,
+
+  /// Geometric height above the WGS84 reference ellipsoid.
+  wgs84Ellipsoid,
+
+  /// Height relative to the launch field, used by simulations and pilot-facing
+  /// relative-height data. It is not an absolute elevation.
+  relativeToLaunch,
+
+  /// An altitude arrived without a datum statement, typically from GPX.
+  unknown,
+}

--- a/apps/mobile/lib/domain/imported_route.dart
+++ b/apps/mobile/lib/domain/imported_route.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'altitude.dart';
 import 'route_preferences.dart';
 
 export 'route_preferences.dart';
@@ -11,18 +12,36 @@ class GeoPoint {
     required this.latitude,
     required this.longitude,
     this.elevationMeters,
+    this.altitudeSource = AltitudeSource.unknown,
+    this.altitudeDatum = AltitudeDatum.unknown,
+    this.altitudeAccuracyMeters,
     this.recordedAt,
-  });
+  }) : assert(
+         elevationMeters != null || altitudeSource == AltitudeSource.unknown,
+       ),
+       assert(
+         elevationMeters != null || altitudeDatum == AltitudeDatum.unknown,
+       ),
+       assert(elevationMeters != null || altitudeAccuracyMeters == null),
+       assert(altitudeAccuracyMeters == null || altitudeAccuracyMeters >= 0);
 
   final double latitude;
   final double longitude;
   final double? elevationMeters;
+  final AltitudeSource altitudeSource;
+  final AltitudeDatum altitudeDatum;
+  final double? altitudeAccuracyMeters;
   final DateTime? recordedAt;
 
   Map<String, Object?> toJson() => {
     'latitude': latitude,
     'longitude': longitude,
-    if (elevationMeters != null) 'elevationMeters': elevationMeters,
+    if (elevationMeters case final elevation?) ...{
+      'elevationMeters': elevation,
+      'altitudeSource': altitudeSource.name,
+      'altitudeDatum': altitudeDatum.name,
+      'altitudeAccuracyMeters': ?altitudeAccuracyMeters,
+    },
     if (recordedAt != null) 'recordedAt': recordedAt!.toUtc().toIso8601String(),
   };
 
@@ -38,10 +57,28 @@ class GeoPoint {
       );
     }
 
+    final elevation = _optionalFiniteNumber(json['elevationMeters']);
     return GeoPoint(
       latitude: latitude,
       longitude: longitude,
-      elevationMeters: (json['elevationMeters'] as num?)?.toDouble(),
+      elevationMeters: elevation,
+      altitudeSource: elevation == null
+          ? AltitudeSource.unknown
+          : _enumByName(
+              AltitudeSource.values,
+              json['altitudeSource'],
+              AltitudeSource.unknown,
+            ),
+      altitudeDatum: elevation == null
+          ? AltitudeDatum.unknown
+          : _enumByName(
+              AltitudeDatum.values,
+              json['altitudeDatum'],
+              AltitudeDatum.unknown,
+            ),
+      altitudeAccuracyMeters: elevation == null
+          ? null
+          : _optionalNonNegativeNumber(json['altitudeAccuracyMeters']),
       recordedAt: _optionalDateTime(json['recordedAt']),
     );
   }
@@ -511,6 +548,27 @@ double _number(Map<String, Object?> json, String key) {
     throw FormatException('$key must be a finite number.');
   }
   return value.toDouble();
+}
+
+double? _optionalFiniteNumber(Object? value) {
+  if (value == null) return null;
+  if (value is! num || !value.isFinite) {
+    throw const FormatException('Expected a finite number.');
+  }
+  return value.toDouble();
+}
+
+double? _optionalNonNegativeNumber(Object? value) {
+  final number = _optionalFiniteNumber(value);
+  if (number != null && number < 0) {
+    throw const FormatException('Expected a non-negative number.');
+  }
+  return number;
+}
+
+T _enumByName<T extends Enum>(List<T> values, Object? value, T fallback) {
+  if (value is! String) return fallback;
+  return values.where((item) => item.name == value).firstOrNull ?? fallback;
 }
 
 String _requiredString(Map<String, Object?> json, String key) {

--- a/apps/mobile/lib/domain/rider_location.dart
+++ b/apps/mobile/lib/domain/rider_location.dart
@@ -1,26 +1,10 @@
 import '../features/map/craft_icon.dart';
+import 'altitude.dart';
 import 'geo_point.dart';
 import 'ride_role.dart';
 import 'rider_color.dart';
 
-/// Where an altitude reading came from.
-///
-/// Recorded rather than inferred because the two sources fail differently: a
-/// GNSS altitude is noisy but absolute, a barometric one is smooth but drifts
-/// with the weather and needs a reference setting. A balloon crew judging a
-/// climb rate needs to know which they are looking at.
-enum AltitudeSource {
-  /// Height from the positioning fix itself.
-  gnss,
-
-  /// Height from a pressure sensor.
-  barometric,
-
-  /// An altitude arrived with no statement of where it came from — typically an
-  /// imported file. Never used to mean "no altitude": that is a null
-  /// [LocationSample.altitudeMeters].
-  unknown,
-}
+export 'altitude.dart';
 
 class LocationSample {
   const LocationSample({
@@ -31,6 +15,7 @@ class LocationSample {
     this.headingDegrees,
     this.altitudeMeters,
     this.altitudeSource = AltitudeSource.unknown,
+    this.altitudeDatum = AltitudeDatum.unknown,
     this.altitudeAccuracyMeters,
     this.verticalSpeedMetersPerSecond,
   }) : assert(accuracyMeters >= 0),
@@ -45,7 +30,8 @@ class LocationSample {
        assert(altitudeMeters != null || altitudeAccuracyMeters == null),
        assert(
          altitudeMeters != null || altitudeSource == AltitudeSource.unknown,
-       );
+       ),
+       assert(altitudeMeters != null || altitudeDatum == AltitudeDatum.unknown);
 
   final GeoPoint position;
   final DateTime recordedAt;
@@ -53,7 +39,7 @@ class LocationSample {
   final double? speedMetersPerSecond;
   final double? headingDegrees;
 
-  /// Metres above the WGS84 geoid, or null when this fix carried no usable
+  /// Metres relative to [altitudeDatum], or null when this fix carried no usable
   /// altitude.
   ///
   /// Null and zero are different answers. A balloon on the ground reports zero;
@@ -65,6 +51,12 @@ class LocationSample {
   /// Where [altitudeMeters] came from. [AltitudeSource.unknown] whenever there
   /// is no reading.
   final AltitudeSource altitudeSource;
+
+  /// The vertical reference for [altitudeMeters].
+  ///
+  /// [AltitudeDatum.unknown] is an honest value for an imported or legacy
+  /// reading. It must never be silently upgraded to geoid or ellipsoid.
+  final AltitudeDatum altitudeDatum;
 
   /// Reported vertical accuracy in metres, when the platform supplies one.
   final double? altitudeAccuracyMeters;
@@ -99,6 +91,7 @@ class LocationSample {
     if (altitudeMeters case final altitude?) ...{
       'altitudeMeters': altitude,
       'altitudeSource': altitudeSource.name,
+      'altitudeDatum': altitudeDatum.name,
       'altitudeAccuracyMeters': ?altitudeAccuracyMeters,
     },
     'verticalSpeedMetersPerSecond': ?verticalSpeedMetersPerSecond,
@@ -121,6 +114,9 @@ class LocationSample {
       altitudeSource: altitude == null
           ? AltitudeSource.unknown
           : _altitudeSourceFromName(json['altitudeSource']),
+      altitudeDatum: altitude == null
+          ? AltitudeDatum.unknown
+          : _altitudeDatumFromName(json['altitudeDatum']),
       altitudeAccuracyMeters: altitude == null
           ? null
           : (json['altitudeAccuracyMeters'] as num?)?.toDouble(),
@@ -140,6 +136,15 @@ class LocationSample {
       if (source.name == value) return source;
     }
     return AltitudeSource.unknown;
+  }
+
+  /// Reads a datum written by another build without making a future value fatal.
+  static AltitudeDatum _altitudeDatumFromName(Object? value) {
+    if (value is! String) return AltitudeDatum.unknown;
+    for (final datum in AltitudeDatum.values) {
+      if (datum.name == value) return datum;
+    }
+    return AltitudeDatum.unknown;
   }
 }
 

--- a/apps/mobile/lib/services/device_location_source.dart
+++ b/apps/mobile/lib/services/device_location_source.dart
@@ -114,9 +114,12 @@ class GeolocatorDeviceLocationPlatform implements DeviceLocationPlatform {
   static const platformDistanceFilterMeters = 10;
 
   @override
-  Stream<LocationSample> positionStream() => Geolocator.getPositionStream(
-    locationSettings: rideLocationSettings(defaultTargetPlatform),
-  ).map(_mapPosition);
+  Stream<LocationSample> positionStream() {
+    final platform = defaultTargetPlatform;
+    return Geolocator.getPositionStream(
+      locationSettings: rideLocationSettings(platform),
+    ).map((position) => locationSampleFromPosition(position, platform));
+  }
 
   /// Settings that keep fixes arriving while the app is not in the foreground.
   ///
@@ -178,7 +181,11 @@ class GeolocatorDeviceLocationPlatform implements DeviceLocationPlatform {
         LocationPermission.unableToDetermine => DeviceLocationPermission.denied,
       };
 
-  static LocationSample _mapPosition(Position position) {
+  @visibleForTesting
+  static LocationSample locationSampleFromPosition(
+    Position position,
+    TargetPlatform platform,
+  ) {
     // Both platforms report altitude 0.0 when they have none, and a balloon
     // sitting in the launch field genuinely reports 0.0 — so the reading cannot
     // tell the two apart. The vertical accuracy can: CoreLocation documents a
@@ -205,6 +212,19 @@ class GeolocatorDeviceLocationPlatform implements DeviceLocationPlatform {
       altitudeSource: hasAltitude
           ? AltitudeSource.gnss
           : AltitudeSource.unknown,
+      // Core Location exposes orthometric height above mean sea level. Android
+      // Location exposes height above the WGS84 ellipsoid. Geolocator carries
+      // the number but not that distinction, so retain the platform fact here
+      // rather than labelling both as the same datum. Other platforms stay
+      // unknown until their native contract is verified.
+      altitudeDatum: !hasAltitude
+          ? AltitudeDatum.unknown
+          : switch (platform) {
+              TargetPlatform.iOS ||
+              TargetPlatform.macOS => AltitudeDatum.wgs84Geoid,
+              TargetPlatform.android => AltitudeDatum.wgs84Ellipsoid,
+              _ => AltitudeDatum.unknown,
+            },
       altitudeAccuracyMeters: hasAltitude ? position.altitudeAccuracy : null,
     );
   }

--- a/apps/mobile/lib/services/gpx_exporter.dart
+++ b/apps/mobile/lib/services/gpx_exporter.dart
@@ -1,6 +1,7 @@
 import 'package:xml/xml.dart';
 
 import '../domain/app_links.dart';
+import '../domain/altitude.dart';
 import '../domain/imported_route.dart';
 
 class GpxExporter {
@@ -15,7 +16,8 @@ class GpxExporter {
         'version': '1.1',
         'creator': 'Balloon Crumbs',
         'xmlns': 'http://www.topografix.com/GPX/1/1',
-        if (route.preferences != null) 'xmlns:bc': 'https://$appLinkHost/gpx/1',
+        if (route.preferences != null || _hasAltitudeMetadata(route))
+          'xmlns:bc': 'https://$appLinkHost/gpx/1',
       },
       nest: () {
         builder.element(
@@ -138,5 +140,30 @@ class GpxExporter {
     if (point.recordedAt case final recordedAt?) {
       builder.element('time', nest: recordedAt.toUtc().toIso8601String());
     }
+    if (_pointHasAltitudeMetadata(point)) {
+      builder.element(
+        'extensions',
+        nest: () => builder.element(
+          'bc:altitude',
+          attributes: {
+            'source': point.altitudeSource.name,
+            'datum': point.altitudeDatum.name,
+            if (point.altitudeAccuracyMeters case final accuracy?)
+              'accuracy-meters': accuracy.toStringAsFixed(3),
+          },
+        ),
+      );
+    }
   }
+
+  static bool _pointHasAltitudeMetadata(GeoPoint point) =>
+      point.elevationMeters != null &&
+      (point.altitudeSource != AltitudeSource.unknown ||
+          point.altitudeDatum != AltitudeDatum.unknown ||
+          point.altitudeAccuracyMeters != null);
+
+  static bool _hasAltitudeMetadata(ImportedRoute route) => [
+    ...route.paths.expand((path) => path.points),
+    ...route.waypoints.map((waypoint) => waypoint.point),
+  ].any(_pointHasAltitudeMetadata);
 }

--- a/apps/mobile/lib/services/gpx_parser.dart
+++ b/apps/mobile/lib/services/gpx_parser.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 
 import 'package:xml/xml.dart';
 
+import '../domain/altitude.dart';
+import '../domain/app_links.dart';
 import '../domain/imported_route.dart';
 
 class GpxParser {
@@ -64,6 +66,7 @@ class GpxParser {
       final latitude = _coordinate(element, 'lat', -90, 90);
       final longitude = _coordinate(element, 'lon', -180, 180);
       final elevation = _optionalDouble(_childText(element, 'ele'));
+      final altitudeMetadata = _altitudeMetadata(element, elevation);
       final timeText = _childText(element, 'time');
       DateTime? recordedAt;
       if (timeText != null) {
@@ -73,6 +76,9 @@ class GpxParser {
         latitude: latitude,
         longitude: longitude,
         elevationMeters: elevation,
+        altitudeSource: altitudeMetadata.source,
+        altitudeDatum: altitudeMetadata.datum,
+        altitudeAccuracyMeters: altitudeMetadata.accuracyMeters,
         recordedAt: recordedAt,
       );
     }
@@ -202,6 +208,59 @@ class GpxParser {
     );
   }
 }
+
+({AltitudeSource source, AltitudeDatum datum, double? accuracyMeters})
+_altitudeMetadata(XmlElement point, double? elevation) {
+  // Metadata without a reading describes nothing. In particular, never let an
+  // extension turn an absent `<ele>` into a fabricated zero altitude.
+  if (elevation == null) {
+    return (
+      source: AltitudeSource.unknown,
+      datum: AltitudeDatum.unknown,
+      accuracyMeters: null,
+    );
+  }
+  final altitude = _children(point, 'extensions')
+      .expand((extensions) => extensions.childElements)
+      .where(
+        (element) =>
+            element.name.local.toLowerCase() == 'altitude' &&
+            element.name.namespaceUri == 'https://$appLinkHost/gpx/1',
+      )
+      .firstOrNull;
+  if (altitude == null) {
+    // A third-party `<ele>` is still useful, but neither its source nor its
+    // datum/accuracy is knowable from the standard element alone.
+    return (
+      source: AltitudeSource.unknown,
+      datum: AltitudeDatum.unknown,
+      accuracyMeters: null,
+    );
+  }
+  String? attribute(String name) => altitude.attributes
+      .where((item) => item.name.local.toLowerCase() == name)
+      .map((item) => item.value.trim())
+      .firstOrNull;
+  final accuracy = double.tryParse(attribute('accuracy-meters') ?? '');
+  return (
+    source: _enumAttribute(
+      AltitudeSource.values,
+      attribute('source'),
+      AltitudeSource.unknown,
+    ),
+    datum: _enumAttribute(
+      AltitudeDatum.values,
+      attribute('datum'),
+      AltitudeDatum.unknown,
+    ),
+    accuracyMeters: accuracy != null && accuracy.isFinite && accuracy >= 0
+        ? accuracy
+        : null,
+  );
+}
+
+T _enumAttribute<T extends Enum>(List<T> values, String? name, T fallback) =>
+    values.where((value) => value.name == name).firstOrNull ?? fallback;
 
 /// Reads the preferences a Balloon Crumbs route was planned with.
 ///

--- a/apps/mobile/lib/services/ride_summary_exporter.dart
+++ b/apps/mobile/lib/services/ride_summary_exporter.dart
@@ -6,6 +6,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../domain/distance_unit.dart';
 import '../domain/geo_point.dart' as geo;
+import '../domain/altitude.dart';
 import '../domain/imported_route.dart';
 import '../domain/ride_event.dart';
 import '../domain/ride_session.dart';
@@ -23,6 +24,9 @@ typedef _TrailPoint = ({
   // in place of a missing reading is worse than an absence: it reads as sea
   // level (#16).
   double? altitudeMeters,
+  AltitudeSource altitudeSource,
+  AltitudeDatum altitudeDatum,
+  double? altitudeAccuracyMeters,
 });
 
 class RideSummary {
@@ -143,6 +147,9 @@ class RideSummaryExporter {
                   // fix that carried no altitude produces a point with no
                   // elevation rather than one claiming to be at zero.
                   elevationMeters: point.altitudeMeters,
+                  altitudeSource: point.altitudeSource,
+                  altitudeDatum: point.altitudeDatum,
+                  altitudeAccuracyMeters: point.altitudeAccuracyMeters,
                 ),
             ],
           ),
@@ -239,17 +246,44 @@ class RideSummaryExporter {
     // and a malformed altitude must cost that point its height rather than the
     // whole export.
     final altitude = sample['altitudeMeters'];
+    final hasAltitude = altitude is num && altitude.isFinite;
+    final altitudeAccuracy = sample['altitudeAccuracyMeters'];
     return (
       latitude: latitude.toDouble(),
       longitude: longitude.toDouble(),
       recordedAt: recordedAt is String
           ? (DateTime.tryParse(recordedAt)?.toLocal() ?? event.createdAt)
           : event.createdAt,
-      altitudeMeters: altitude is num && altitude.isFinite
-          ? altitude.toDouble()
+      altitudeMeters: hasAltitude ? altitude.toDouble() : null,
+      altitudeSource: hasAltitude
+          ? _enumValue(
+              AltitudeSource.values,
+              sample['altitudeSource'],
+              AltitudeSource.unknown,
+            )
+          : AltitudeSource.unknown,
+      altitudeDatum: hasAltitude
+          ? _enumValue(
+              AltitudeDatum.values,
+              sample['altitudeDatum'],
+              AltitudeDatum.unknown,
+            )
+          : AltitudeDatum.unknown,
+      altitudeAccuracyMeters:
+          hasAltitude &&
+              altitudeAccuracy is num &&
+              altitudeAccuracy.isFinite &&
+              altitudeAccuracy >= 0
+          ? altitudeAccuracy.toDouble()
           : null,
     );
   }
+
+  static T _enumValue<T extends Enum>(
+    List<T> values,
+    Object? name,
+    T fallback,
+  ) => values.where((value) => value.name == name).firstOrNull ?? fallback;
 
   static double _trailDistanceMeters(List<_TrailPoint> trail) {
     var total = 0.0;

--- a/apps/mobile/test/domain/imported_route_test.dart
+++ b/apps/mobile/test/domain/imported_route_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:balloon_crumbs/domain/altitude.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
 
 void main() {
@@ -18,6 +19,9 @@ void main() {
               latitude: 53.1,
               longitude: -1.4,
               elevationMeters: 210,
+              altitudeSource: AltitudeSource.gnss,
+              altitudeDatum: AltitudeDatum.wgs84Geoid,
+              altitudeAccuracyMeters: 4.5,
               recordedAt: DateTime.utc(2026, 7, 16, 9, 1),
             ),
             const GeoPoint(latitude: 53.2, longitude: -1.5),
@@ -59,6 +63,15 @@ void main() {
     expect(restored.pathPointCount, 2);
     expect(restored.paths.single.kind, RoutePathKind.track);
     expect(restored.paths.single.points.first.elevationMeters, 210);
+    expect(
+      restored.paths.single.points.first.altitudeSource,
+      AltitudeSource.gnss,
+    );
+    expect(
+      restored.paths.single.points.first.altitudeDatum,
+      AltitudeDatum.wgs84Geoid,
+    );
+    expect(restored.paths.single.points.first.altitudeAccuracyMeters, 4.5);
     expect(restored.waypoints.single.name, 'Fuel');
     expect(restored.maneuvers.single.type, 'roundabout');
     expect(restored.maneuvers.single.modifier, 'right');
@@ -103,6 +116,14 @@ void main() {
     expect(restored.maneuvers.single.bearingBeforeDegrees, isNull);
     expect(restored.maneuvers.single.bearingAfterDegrees, isNull);
     expect(restored.maneuvers.single.exitNumber, 2);
+    expect(
+      restored.paths.single.points.first.altitudeSource,
+      AltitudeSource.unknown,
+    );
+    expect(
+      restored.paths.single.points.first.altitudeDatum,
+      AltitudeDatum.unknown,
+    );
   });
 
   test('migrates the planned duration from a build 60 destination route', () {

--- a/apps/mobile/test/domain/location_sample_altitude_test.dart
+++ b/apps/mobile/test/domain/location_sample_altitude_test.dart
@@ -15,6 +15,7 @@ void main() {
   LocationSample sample({
     double? altitudeMeters,
     AltitudeSource altitudeSource = AltitudeSource.unknown,
+    AltitudeDatum altitudeDatum = AltitudeDatum.unknown,
     double? altitudeAccuracyMeters,
     double? verticalSpeedMetersPerSecond,
   }) => LocationSample(
@@ -23,6 +24,7 @@ void main() {
     accuracyMeters: 5,
     altitudeMeters: altitudeMeters,
     altitudeSource: altitudeSource,
+    altitudeDatum: altitudeDatum,
     altitudeAccuracyMeters: altitudeAccuracyMeters,
     verticalSpeedMetersPerSecond: verticalSpeedMetersPerSecond,
   );
@@ -36,6 +38,7 @@ void main() {
         expect(fix.hasAltitude, isFalse);
         expect(fix.altitudeMeters, isNull);
         expect(fix.altitudeSource, AltitudeSource.unknown);
+        expect(fix.altitudeDatum, AltitudeDatum.unknown);
         expect(fix.altitudeAccuracyMeters, isNull);
       },
     );
@@ -44,6 +47,7 @@ void main() {
       final fix = sample(
         altitudeMeters: 0,
         altitudeSource: AltitudeSource.gnss,
+        altitudeDatum: AltitudeDatum.wgs84Geoid,
         altitudeAccuracyMeters: 3,
       );
 
@@ -58,6 +62,10 @@ void main() {
       );
       expect(
         () => sample(altitudeSource: AltitudeSource.barometric),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => sample(altitudeDatum: AltitudeDatum.wgs84Ellipsoid),
         throwsA(isA<AssertionError>()),
       );
     });
@@ -75,6 +83,7 @@ void main() {
       final fix = sample(
         altitudeMeters: 412.5,
         altitudeSource: AltitudeSource.barometric,
+        altitudeDatum: AltitudeDatum.wgs84Geoid,
         altitudeAccuracyMeters: 2.5,
         verticalSpeedMetersPerSecond: -1.4,
       );
@@ -83,6 +92,7 @@ void main() {
 
       expect(decoded.altitudeMeters, 412.5);
       expect(decoded.altitudeSource, AltitudeSource.barometric);
+      expect(decoded.altitudeDatum, AltitudeDatum.wgs84Geoid);
       expect(decoded.altitudeAccuracyMeters, 2.5);
       expect(decoded.verticalSpeedMetersPerSecond, -1.4);
     });
@@ -92,6 +102,7 @@ void main() {
 
       expect(json.containsKey('altitudeMeters'), isFalse);
       expect(json.containsKey('altitudeSource'), isFalse);
+      expect(json.containsKey('altitudeDatum'), isFalse);
       expect(json.containsKey('altitudeAccuracyMeters'), isFalse);
       expect(LocationSample.fromJson(json).hasAltitude, isFalse);
     });
@@ -109,6 +120,7 @@ void main() {
 
       expect(decoded.hasAltitude, isFalse);
       expect(decoded.altitudeSource, AltitudeSource.unknown);
+      expect(decoded.altitudeDatum, AltitudeDatum.unknown);
       expect(decoded.speedMetersPerSecond, 12.0);
     });
 
@@ -125,17 +137,33 @@ void main() {
       expect(decoded.altitudeSource, AltitudeSource.unknown);
     });
 
+    test('an altitude datum this build does not know degrades', () {
+      final decoded = LocationSample.fromJson({
+        ...sample(
+          altitudeMeters: 400,
+          altitudeSource: AltitudeSource.gnss,
+          altitudeDatum: AltitudeDatum.wgs84Geoid,
+        ).toJson(),
+        'altitudeDatum': 'marsAreoid',
+      });
+
+      expect(decoded.altitudeMeters, 400);
+      expect(decoded.altitudeDatum, AltitudeDatum.unknown);
+    });
+
     test('a source or accuracy arriving without a reading is dropped', () {
       final decoded = LocationSample.fromJson({
         'position': somewhere.toJson(),
         'recordedAt': at.toIso8601String(),
         'accuracyMeters': 5.0,
         'altitudeSource': 'barometric',
+        'altitudeDatum': 'wgs84Geoid',
         'altitudeAccuracyMeters': 2.0,
       });
 
       expect(decoded.hasAltitude, isFalse);
       expect(decoded.altitudeSource, AltitudeSource.unknown);
+      expect(decoded.altitudeDatum, AltitudeDatum.unknown);
       expect(decoded.altitudeAccuracyMeters, isNull);
     });
   });

--- a/apps/mobile/test/services/device_location_source_test.dart
+++ b/apps/mobile/test/services/device_location_source_test.dart
@@ -53,6 +53,35 @@ void main() {
         );
       }
     });
+
+    test('native altitude keeps the platform datum explicit', () {
+      final position = Position(
+        longitude: -2.59,
+        latitude: 51.45,
+        timestamp: DateTime.utc(2026, 8, 20),
+        accuracy: 4,
+        altitude: 123,
+        altitudeAccuracy: 6,
+        heading: 90,
+        headingAccuracy: 2,
+        speed: 4,
+        speedAccuracy: 1,
+      );
+
+      final apple = GeolocatorDeviceLocationPlatform.locationSampleFromPosition(
+        position,
+        TargetPlatform.iOS,
+      );
+      final android =
+          GeolocatorDeviceLocationPlatform.locationSampleFromPosition(
+            position,
+            TargetPlatform.android,
+          );
+
+      expect(apple.altitudeDatum, AltitudeDatum.wgs84Geoid);
+      expect(android.altitudeDatum, AltitudeDatum.wgs84Ellipsoid);
+      expect(apple.altitudeMeters, android.altitudeMeters);
+    });
   });
 
   test('inspection reports denial without prompting', () async {

--- a/apps/mobile/test/services/gpx_exporter_test.dart
+++ b/apps/mobile/test/services/gpx_exporter_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:balloon_crumbs/domain/altitude.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/services/gpx_exporter.dart';
 import 'package:balloon_crumbs/services/gpx_parser.dart';
@@ -23,6 +24,9 @@ void main() {
               latitude: 53.1,
               longitude: -1.2,
               elevationMeters: 240,
+              altitudeSource: AltitudeSource.gnss,
+              altitudeDatum: AltitudeDatum.wgs84Geoid,
+              altitudeAccuracyMeters: 5.5,
               recordedAt: DateTime.utc(2026, 7, 16, 8, 1),
             ),
             const GeoPoint(latitude: 53.2, longitude: -1.3),
@@ -52,9 +56,23 @@ void main() {
     );
 
     expect(exported, contains('xmlns="http://www.topografix.com/GPX/1/1"'));
+    expect(exported, contains('xmlns:bc='));
+    expect(
+      exported,
+      contains(
+        '<bc:altitude source="gnss" datum="wgs84Geoid" '
+        'accuracy-meters="5.500"/>',
+      ),
+    );
     expect(parsed.paths, hasLength(2));
     expect(parsed.pathPointCount, 3);
     expect(parsed.waypoints.single.name, 'Fuel & food');
+    expect(parsed.paths.first.points.first.altitudeSource, AltitudeSource.gnss);
+    expect(
+      parsed.paths.first.points.first.altitudeDatum,
+      AltitudeDatum.wgs84Geoid,
+    );
+    expect(parsed.paths.first.points.first.altitudeAccuracyMeters, 5.5);
     expect(exporter.fileName(route), 'peaks-dales.gpx');
   });
 }

--- a/apps/mobile/test/services/gpx_parser_test.dart
+++ b/apps/mobile/test/services/gpx_parser_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:balloon_crumbs/domain/altitude.dart';
 import 'package:balloon_crumbs/services/gpx_parser.dart';
 
 void main() {
@@ -33,8 +34,96 @@ void main() {
     expect(route.paths, hasLength(2));
     expect(route.pathPointCount, 3);
     expect(route.paths.first.points.first.elevationMeters, 200);
+    expect(
+      route.paths.first.points.first.altitudeSource,
+      AltitudeSource.unknown,
+      reason: 'a third-party <ele> does not state how it was measured',
+    );
+    expect(
+      route.paths.first.points.first.altitudeDatum,
+      AltitudeDatum.unknown,
+      reason: 'the parser must not fabricate a geoid/ellipsoid datum',
+    );
+    expect(route.paths.first.points.first.altitudeAccuracyMeters, isNull);
     expect(route.paths.first.points.first.recordedAt, isNotNull);
     expect(route.waypoints.single.name, 'Fuel');
+  });
+
+  test('round-trips Balloon Crumbs altitude evidence per point', () {
+    final route = parser.parse(
+      _bytes('''
+        <gpx version="1.1"
+             xmlns="http://www.topografix.com/GPX/1/1"
+             xmlns:bc="https://balloon-crumbs.tailendcharlie.app/gpx/1">
+          <trk><trkseg>
+            <trkpt lat="51.45" lon="-2.59">
+              <ele>123.4</ele>
+              <extensions>
+                <bc:altitude source="gnss" datum="wgs84Ellipsoid"
+                             accuracy-meters="7.25"/>
+              </extensions>
+            </trkpt>
+          </trkseg></trk>
+        </gpx>
+      '''),
+      routeId: 'altitude',
+      sourceFileName: 'altitude.gpx',
+      importedAt: DateTime.utc(2026, 8, 20),
+    );
+
+    final point = route.paths.single.points.single;
+    expect(point.elevationMeters, 123.4);
+    expect(point.altitudeSource, AltitudeSource.gnss);
+    expect(point.altitudeDatum, AltitudeDatum.wgs84Ellipsoid);
+    expect(point.altitudeAccuracyMeters, 7.25);
+  });
+
+  test('malformed altitude evidence degrades without losing <ele>', () {
+    final route = parser.parse(
+      _bytes('''
+        <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1"
+             xmlns:bc="https://balloon-crumbs.tailendcharlie.app/gpx/1">
+          <trk><trkseg><trkpt lat="51.45" lon="-2.59">
+            <ele>123.4</ele>
+            <extensions><bc:altitude source="future-sensor"
+              datum="future-datum" accuracy-meters="-4"/></extensions>
+          </trkpt></trkseg></trk>
+        </gpx>
+      '''),
+      routeId: 'future',
+      sourceFileName: 'future.gpx',
+      importedAt: DateTime.utc(2026, 8, 20),
+    );
+
+    final point = route.paths.single.points.single;
+    expect(point.elevationMeters, 123.4);
+    expect(point.altitudeSource, AltitudeSource.unknown);
+    expect(point.altitudeDatum, AltitudeDatum.unknown);
+    expect(point.altitudeAccuracyMeters, isNull);
+  });
+
+  test('does not mistake another vendor altitude extension for ours', () {
+    final route = parser.parse(
+      _bytes('''
+        <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1"
+             xmlns:other="https://example.com/gpx">
+          <trk><trkseg><trkpt lat="51.45" lon="-2.59">
+            <ele>123.4</ele>
+            <extensions><other:altitude source="gnss"
+              datum="wgs84Geoid" accuracy-meters="1"/></extensions>
+          </trkpt></trkseg></trk>
+        </gpx>
+      '''),
+      routeId: 'other-vendor',
+      sourceFileName: 'other.gpx',
+      importedAt: DateTime.utc(2026, 8, 20),
+    );
+
+    final point = route.paths.single.points.single;
+    expect(point.elevationMeters, 123.4);
+    expect(point.altitudeSource, AltitudeSource.unknown);
+    expect(point.altitudeDatum, AltitudeDatum.unknown);
+    expect(point.altitudeAccuracyMeters, isNull);
   });
 
   test('rejects invalid coordinates and excessive point counts', () {

--- a/apps/mobile/test/services/ride_summary_altitude_test.dart
+++ b/apps/mobile/test/services/ride_summary_altitude_test.dart
@@ -1,7 +1,12 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:balloon_crumbs/domain/altitude.dart';
 import 'package:balloon_crumbs/domain/ride_event.dart';
 import 'package:balloon_crumbs/domain/ride_role.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
 import 'package:balloon_crumbs/services/gpx_exporter.dart';
+import 'package:balloon_crumbs/services/gpx_parser.dart';
 import 'package:balloon_crumbs/services/ride_summary_exporter.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -43,6 +48,7 @@ void main() {
           if (altitude != null) ...{
             'altitudeMeters': altitude,
             'altitudeSource': 'gnss',
+            'altitudeDatum': 'wgs84Geoid',
             'altitudeAccuracyMeters': 6,
           },
         },
@@ -76,6 +82,17 @@ void main() {
     final gpx = const GpxExporter().export(route);
     expect(gpx, contains('<ele>60.000</ele>'));
     expect(gpx, contains('<ele>240.000</ele>'));
+
+    final imported = const GpxParser().parse(
+      Uint8List.fromList(utf8.encode(gpx)),
+      routeId: 'round-trip',
+      sourceFileName: 'flight.gpx',
+      importedAt: startedAt.add(const Duration(minutes: 2)),
+    );
+    final points = imported.paths.single.points;
+    expect(points.first.altitudeSource, AltitudeSource.gnss);
+    expect(points.first.altitudeDatum, AltitudeDatum.wgs84Geoid);
+    expect(points.first.altitudeAccuracyMeters, 6);
   });
 
   test('a fix with no altitude exports no <ele>, rather than zero', () {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -7,7 +7,7 @@ not a claim that every P0 item is small. Work packages are defined in
 | Order | Priority | Work | WP | Depends on |
 |---:|:---:|---|:---:|---|
 | 1 | P0 | ~~Isolate inherited TEC baseline and keep CI green~~ **done** | WP1 | — |
-| 2 | P0 | Balloon-capable telemetry: altitude, source, vertical speed | WP2 | 1 |
+| 2 | P0 | ~~Balloon-capable telemetry: altitude, source, datum, accuracy, vertical speed~~ **done** | WP2 | 1 |
 | 3 | P0 | Craft model, flight roles, and pilot authority | WP3 | 2 |
 | 4 | P0 | ~~Delete the motorcycle domain~~ **done**; vocabulary rename deferred to after 6, 7 | WP4 | 3 |
 | 4a | P0 | Replace the 15 motorcycle map markers with craft icons (#18) | WP4 | 6, 7 |
@@ -21,7 +21,7 @@ not a claim that every P0 item is small. Work packages are defined in
 | 10 | P0 | Landing-phase basemap (OS topographic / aerial) | WP6b | 6 |
 | 11 | P0 | Balloon/chase simulator and replay matrix | WP10 | 3–9 |
 | 12 | P0 | Security, privacy, retention, and field-test gates | WP12 | 3–11 |
-| 13 | P1 | Carry balloon altitude through GPX export and import (#16) | WP5 | 2 |
+| 13 | P1 | ~~Carry balloon altitude through GPX export and import (#16)~~ **done** | WP5 | 2 |
 | 14 | P1 | Retarget speed limits, camera and enforcement alerts at the chase driver | WP7 | 3 |
 | 15 | P1 | Pilot aeronautical context: airspace, notices, restrictions | WP10b | 5 |
 | 16 | P1 | Flight plan / notification: research the UK position, then attach or generate | WP10b | 15 |

--- a/docs/delivery-plan.md
+++ b/docs/delivery-plan.md
@@ -28,10 +28,13 @@ currently the larger half of the app.
 ### Already done
 
 - **WP1** — the Tail End Charlie sweep role is deleted, on both client and relay.
-- **WP2 (part)** — `LocationSample` carries altitude, altitude source, vertical
-  accuracy and vertical speed; capture gates on vertical accuracy so a missing
-  altitude is never presented as a measured zero; Ride Lab flies a real climb /
-  cruise / descent profile.
+- **WP2** — `LocationSample` carries altitude, source, datum, vertical accuracy
+  and vertical speed; capture gates on vertical accuracy so a missing altitude
+  is never presented as a measured zero; Ride Lab flies a real climb / cruise /
+  descent profile. Native capture keeps Core Location's mean-sea-level datum
+  distinct from Android's WGS84-ellipsoid datum. Flight GPX preserves source,
+  datum and accuracy per fix in the `bc:` extension, while a third-party `<ele>`
+  without that evidence stays explicitly unknown.
 - The product, bundle identifiers, packages and icon are renamed.
 
 ## Who the app is for
@@ -478,10 +481,12 @@ artwork nobody has seen.
 
 ### WP5 — Altitude, the ground track, and the crumb trail
 
-The feature the product is named after. Finishes WP2.
+The feature the product is named after. Builds the first visible surface on the
+completed WP2 telemetry.
 
-- Altitude into the recorded track so flight GPX carries `<ele>` (issue #16);
-  altitude source and accuracy in the GPX extension namespace.
+- **Landed:** altitude reaches the recorded track and flight GPX `<ele>`; source,
+  datum and accuracy round-trip per point in the GPX extension namespace
+  (issue #16).
 - Ground track coloured by altitude, with a documented palette, a non-colour cue
   and a legend that tracks metric/imperial.
 - A segment may only be coloured when both endpoints have valid altitude.


### PR DESCRIPTION
## What changed

- added an explicit altitude datum alongside source, accuracy, and vertical speed
- preserved Core Location mean-sea-level readings separately from Android WGS84-ellipsoid readings
- carried source, datum, and accuracy per point through the event journal, recorded-flight export, Balloon Crumbs GPX extensions, import, and persisted route JSON
- kept third-party `<ele>` useful while leaving source, datum, and accuracy unknown
- rejected foreign and malformed altitude extensions without losing valid elevation
- marked WP2 and the GPX altitude backlog item complete

Per-point metadata is deliberate: a craft telemetry election or sensor change can switch the reporting device/source during one track, so a track-level value would become false.

## Verification

- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` — 1,690 passed, 24 expected skips

Closes #16