### PR TITLE
feat: add Android Play deployment workflow

### DIFF
--- a/.github/workflows/android-internal.yml
+++ b/.github/workflows/android-internal.yml
@@ -1,0 +1,313 @@
+name: Android closed testing
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: Optional unique Play version code (defaults above the pubspec build)
+        required: false
+        type: string
+      promote_to:
+        description: Promote to closed alpha, or upload to internal only
+        required: true
+        default: alpha
+        type: choice
+        options:
+          - alpha
+          - none
+      notification_mode:
+        description: Render the tester mail only, or send it when SMTP is configured
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - auto
+
+permissions:
+  contents: read
+  actions: read
+
+# Two uploads must not race for the same Play version code.
+concurrency:
+  group: android-internal-upload
+  cancel-in-progress: false
+
+env:
+  FLUTTER_VERSION: 3.44.6
+  FASTLANE_VERSION: 2.228.0
+  MOBILE_DIR: apps/mobile
+  PACKAGE_NAME: dev.osholt.ballooncrumbs
+
+jobs:
+  upload:
+    name: Build and upload Android tester release
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment: android-internal
+    defaults:
+      run:
+        working-directory: ${{ env.MOBILE_DIR }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 50
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Install and check release signing materials
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for required in KEYSTORE_BASE64 KEY_ALIAS KEY_PASSWORD STORE_PASSWORD; do
+            if test -z "${!required}"; then
+              echo "::error::Missing Android signing secret $required. See docs/android-internal-testing.md." >&2
+              exit 1
+            fi
+          done
+          keystore_path="$RUNNER_TEMP/balloon-crumbs-upload.jks"
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
+          keytool -list -keystore "$keystore_path" -storepass "$STORE_PASSWORD" \
+            -alias "$KEY_ALIAS" -keypass "$KEY_PASSWORD" >/dev/null
+          cat > android/key.properties <<PROPERTIES
+          storeFile=$keystore_path
+          storePassword=$STORE_PASSWORD
+          keyAlias=$KEY_ALIAS
+          keyPassword=$KEY_PASSWORD
+          PROPERTIES
+          echo "KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
+
+      - name: Resolve build identity
+        env:
+          REQUESTED_BUILD_NUMBER: ${{ inputs.build_number }}
+          PROMOTE_TO: ${{ inputs.promote_to }}
+        run: |
+          set -euo pipefail
+          if test -n "${REQUESTED_BUILD_NUMBER:-}"; then
+            build_number="$REQUESTED_BUILD_NUMBER"
+          else
+            pubspec_build="$(sed -n 's/^version:.*+\([0-9][0-9]*\).*/\1/p' pubspec.yaml | head -1)"
+            test -n "$pubspec_build"
+            build_number="$((pubspec_build + GITHUB_RUN_NUMBER))"
+          fi
+          destination_track=internal
+          if test "$PROMOTE_TO" = alpha; then
+            destination_track=alpha
+          fi
+          "$GITHUB_WORKSPACE/tools/build-identity.sh" \
+            pubspec.yaml "$destination_track" "$build_number" | tee -a "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+
+      - name: Build signed App Bundle
+        env:
+          TESTER_NOTES_URL: https://github.com/${{ github.repository }}/blob/${{ github.sha }}/docs/tester-release-notes.md
+          BALLOON_CRUMBS_API_BASE_URL: ${{ vars.BALLOON_CRUMBS_API_BASE_URL }}
+          BALLOON_CRUMBS_FIREBASE_API_KEY: ${{ vars.BALLOON_CRUMBS_FIREBASE_API_KEY }}
+          BALLOON_CRUMBS_FIREBASE_PROJECT_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_PROJECT_ID }}
+          BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID }}
+          BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID }}
+        run: |
+          set -euo pipefail
+          if test -z "${BALLOON_CRUMBS_API_BASE_URL:-}"; then
+            echo "::warning::No BALLOON_CRUMBS_API_BASE_URL repository variable; this build has nearby transport but no relay."
+          fi
+          push_enabled=false
+          if test -n "${BALLOON_CRUMBS_FIREBASE_API_KEY:-}" \
+            && test -n "${BALLOON_CRUMBS_FIREBASE_PROJECT_ID:-}" \
+            && test -n "${BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID:-}" \
+            && test -n "${BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID:-}"; then
+            push_enabled=true
+          fi
+          flutter pub get
+          flutter build appbundle --release \
+            --build-name="$BALLOON_CRUMBS_APP_VERSION" \
+            --build-number="$BALLOON_CRUMBS_APP_BUILD" \
+            --dart-define=BALLOON_CRUMBS_APP_VERSION="$BALLOON_CRUMBS_APP_VERSION" \
+            --dart-define=BALLOON_CRUMBS_APP_BUILD="$BALLOON_CRUMBS_APP_BUILD" \
+            --dart-define=BALLOON_CRUMBS_DISTRIBUTION_TRACK="$BALLOON_CRUMBS_DISTRIBUTION_TRACK" \
+            --dart-define=BALLOON_CRUMBS_BUILD_TIMESTAMP="$BALLOON_CRUMBS_BUILD_TIMESTAMP" \
+            --dart-define=BALLOON_CRUMBS_TESTER_NOTES_URL="$TESTER_NOTES_URL" \
+            --dart-define=BALLOON_CRUMBS_API_BASE_URL="${BALLOON_CRUMBS_API_BASE_URL:-}" \
+            --dart-define=BALLOON_CRUMBS_PUSH_ENABLED="$push_enabled" \
+            --dart-define=BALLOON_CRUMBS_FIREBASE_API_KEY="${BALLOON_CRUMBS_FIREBASE_API_KEY:-}" \
+            --dart-define=BALLOON_CRUMBS_FIREBASE_PROJECT_ID="${BALLOON_CRUMBS_FIREBASE_PROJECT_ID:-}" \
+            --dart-define=BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID="${BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID:-}" \
+            --dart-define=BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID="${BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID:-}" \
+            --dart-define=BALLOON_CRUMBS_RIDE_DIAGNOSTICS=true
+
+      - name: Verify App Bundle signature
+        env:
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          bundle=build/app/outputs/bundle/release/app-release.aab
+          # Android upload keys are normally self-signed, so `-strict` would
+          # reject the expected trust chain. The fingerprint comparison below
+          # proves the bundle uses the configured key.
+          jarsigner -verify "$bundle" >/dev/null
+          expected="$(keytool -list -v -keystore "$KEYSTORE_PATH" \
+            -storepass "$STORE_PASSWORD" -alias "$KEY_ALIAS" -keypass "$KEY_PASSWORD" \
+            | sed -n 's/^[[:space:]]*SHA256: //p' | head -1)"
+          actual="$(keytool -printcert -jarfile "$bundle" \
+            | sed -n 's/^[[:space:]]*SHA256: //p' | head -1)"
+          if test -z "$expected" || test "$actual" != "$expected"; then
+            echo "::error::The App Bundle is not signed by the configured Play upload key." >&2
+            exit 1
+          fi
+          echo "App Bundle signature matches the configured upload key."
+
+      - name: Validate Play service account secret
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          test -n "$SERVICE_ACCOUNT_JSON" || {
+            echo "::error::Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON. See docs/android-internal-testing.md." >&2
+            exit 1
+          }
+
+      - name: Upload to Play internal testing
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ env.PACKAGE_NAME }}
+          releaseFiles: ${{ env.MOBILE_DIR }}/build/app/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
+
+      - name: Install Fastlane
+        if: ${{ success() && inputs.promote_to == 'alpha' }}
+        run: |
+          set -euo pipefail
+          gem install fastlane \
+            --version "$FASTLANE_VERSION" \
+            --no-document \
+            --user-install
+          echo "$(ruby -e 'puts Gem.user_dir')/bin" >> "$GITHUB_PATH"
+
+      - name: Promote to closed alpha testing
+        id: promote
+        if: ${{ success() && inputs.promote_to == 'alpha' }}
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          json_key_path="$RUNNER_TEMP/play-service-account.json"
+          umask 077
+          printf '%s' "$SERVICE_ACCOUNT_JSON" > "$json_key_path"
+          fastlane supply \
+            --json_key "$json_key_path" \
+            --package_name "$PACKAGE_NAME" \
+            --track internal \
+            --track_promote_to alpha \
+            --track_promote_release_status completed \
+            --deactivate_on_promote false \
+            --version_code "$BUILD_NUMBER"
+
+      - name: Collect changes since the previous tester release
+        if: ${{ success() && inputs.promote_to == 'alpha' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          changes_file="$RUNNER_TEMP/tester-changes.md"
+          previous_sha="$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow android-internal.yml \
+            --status success \
+            --limit 20 \
+            --json databaseId,headSha \
+            --jq "[.[] | select(.databaseId < $RUN_ID) | .headSha] | first // \"\"" \
+            2>/dev/null | tr -d '"' || true)"
+          if test -n "$previous_sha" && git cat-file -e "$previous_sha^{commit}" 2>/dev/null; then
+            baseline="the last released build (commit ${previous_sha:0:7})"
+            git log --no-merges --pretty='- %s (%h)' "$previous_sha..HEAD" > "$changes_file"
+          else
+            baseline="the last 20 commits (no previous Android release was found)"
+            git log --no-merges --max-count=20 --pretty='- %s (%h)' > "$changes_file"
+          fi
+          echo "TESTER_CHANGES_FILE=$changes_file" >> "$GITHUB_ENV"
+          echo "TESTER_CHANGES_BASELINE=$baseline" >> "$GITHUB_ENV"
+
+      - name: Notify the closed tester group
+        if: ${{ success() && inputs.promote_to == 'alpha' }}
+        continue-on-error: true
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TESTER_GROUP: ${{ vars.BALLOON_CRUMBS_ANDROID_TESTER_GROUP }}
+          TESTER_NOTIFY_FROM: ${{ vars.BALLOON_CRUMBS_TESTER_NOTIFY_FROM }}
+          TESTER_NOTIFY_SMTP_HOST: ${{ vars.BALLOON_CRUMBS_TESTER_NOTIFY_SMTP_HOST }}
+          TESTER_NOTIFY_SMTP_PORT: ${{ vars.BALLOON_CRUMBS_TESTER_NOTIFY_SMTP_PORT }}
+          TESTER_NOTIFY_SMTP_USERNAME: ${{ secrets.BALLOON_CRUMBS_TESTER_NOTIFY_SMTP_USERNAME }}
+          TESTER_NOTIFY_SMTP_PASSWORD: ${{ secrets.BALLOON_CRUMBS_TESTER_NOTIFY_SMTP_PASSWORD }}
+        run: |
+          set -euo pipefail
+          python3 "$GITHUB_WORKSPACE/tools/tester_notify/notify_testers.py" \
+            --track alpha \
+            --app-version "$BALLOON_CRUMBS_APP_VERSION" \
+            --build-number "$BALLOON_CRUMBS_APP_BUILD" \
+            --commit "$GITHUB_SHA" \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-url "$RUN_URL" \
+            --changes-file "${TESTER_CHANGES_FILE:-}" \
+            --changes-baseline "${TESTER_CHANGES_BASELINE:-}" \
+            --recipient "$TESTER_GROUP" \
+            --mode "${{ inputs.notification_mode }}"
+
+      - name: Publish release summary
+        if: always()
+        env:
+          PROMOTE_TO: ${{ inputs.promote_to }}
+          PROMOTION_OUTCOME: ${{ steps.promote.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          notes="$RUNNER_TEMP/tester-release-notes.md"
+          if test "$PROMOTE_TO" = none; then
+            reach='**No closed tester has this build.** It was uploaded to `internal` only.'
+          elif test "$PROMOTION_OUTCOME" = success; then
+            reach='**Closed alpha testers can install this build once Google Play finishes processing it.**'
+          else
+            reach="**No closed tester has this build:** promotion to alpha was ${PROMOTION_OUTCOME:-not reached}."
+          fi
+          {
+            printf '# Android tester build %s\n\n' "${BALLOON_CRUMBS_APP_BUILD:-unknown}"
+            printf -- '- App version: `%s`\n' "${BALLOON_CRUMBS_APP_VERSION:-unknown}"
+            printf -- '- Play version code: `%s`\n' "${BALLOON_CRUMBS_APP_BUILD:-unknown}"
+            printf -- '- Uploaded to: `internal`\n'
+            printf -- '- Stamped track: `%s`\n' "${BALLOON_CRUMBS_DISTRIBUTION_TRACK:-unknown}"
+            printf -- '- Commit: `%s`\n' "$GITHUB_SHA"
+            printf -- '- Workflow run: %s\n\n' "$RUN_URL"
+            printf '%s\n\n' "$reach"
+            printf '## Recent commits\n\n'
+            git log --no-merges --max-count=20 --pretty='- %s (%h)' || true
+          } > "$notes"
+          cat "$notes" >> "$GITHUB_STEP_SUMMARY"
+          cp "$notes" "$GITHUB_WORKSPACE/tester-release-notes.md"
+
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: balloon-crumbs-android-app-bundle
+          path: ${{ env.MOBILE_DIR }}/build/app/outputs/bundle/release/*.aab
+          if-no-files-found: ignore
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: balloon-crumbs-android-release-notes
+          path: tester-release-notes.md
+          if-no-files-found: ignore

--- a/.github/workflows/android-play-status.yml
+++ b/.github/workflows/android-play-status.yml
@@ -1,0 +1,87 @@
+# Reports what Google Play is actually serving without committing an edit.
+name: Play track status
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-play-status
+  cancel-in-progress: false
+
+jobs:
+  status:
+    name: Report Play track status
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: android-internal
+    env:
+      PACKAGE_NAME: dev.osholt.ballooncrumbs
+    steps:
+      - name: Validate Play service account secret
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          test -n "$SERVICE_ACCOUNT_JSON" || {
+            echo "::error::Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON. See docs/android-internal-testing.md." >&2
+            exit 1
+          }
+      - name: Install Google API client
+        run: pip install --quiet google-auth google-auth-httplib2 google-api-python-client
+      - name: Report every track
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s' "$SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play.json"
+          python - <<'PY'
+          import os
+
+          from google.oauth2 import service_account
+          from googleapiclient.discovery import build
+
+          package = os.environ["PACKAGE_NAME"]
+          credentials = service_account.Credentials.from_service_account_file(
+              os.path.join(os.environ["RUNNER_TEMP"], "play.json"),
+              scopes=["https://www.googleapis.com/auth/androidpublisher"],
+          )
+          service = build("androidpublisher", "v3", credentials=credentials)
+          edits = service.edits()
+          edit_id = edits.insert(packageName=package, body={}).execute()["id"]
+          try:
+              tracks = edits.tracks().list(
+                  packageName=package, editId=edit_id
+              ).execute().get("tracks", [])
+          finally:
+              edits.delete(packageName=package, editId=edit_id).execute()
+
+          if not tracks:
+              raise SystemExit("No Play tracks were returned for " + package)
+
+          summary = []
+          for track in sorted(tracks, key=lambda item: item["track"]):
+              name = track["track"]
+              releases = track.get("releases", [])
+              if not releases:
+                  summary.append((name, None, []))
+                  continue
+              for release in releases:
+                  summary.append(
+                      (name, release.get("status"), release.get("versionCodes") or [])
+                  )
+
+          print(f"{package}: {len(tracks)} tracks")
+          for name, status, codes in summary:
+              codes_text = ",".join(codes) if codes else "-"
+              print(f"{name:24s} status={status or '-':12s} codes={codes_text}")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("| Track | Status | Version codes |\n")
+              handle.write("| --- | --- | --- |\n")
+              for name, status, codes in summary:
+                  codes_text = ", ".join(codes) if codes else "—"
+                  handle.write(f"| `{name}` | {status or '—'} | {codes_text} |\n")
+          PY

--- a/.github/workflows/android-promote.yml
+++ b/.github/workflows/android-promote.yml
@@ -1,0 +1,70 @@
+# Recovery path for a bundle that reached internal but failed to promote.
+name: Promote Android tester release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_code:
+        description: Existing internal-track Play version code
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-testing-promotion
+  cancel-in-progress: false
+
+env:
+  FASTLANE_VERSION: 2.228.0
+  PACKAGE_NAME: dev.osholt.ballooncrumbs
+
+jobs:
+  promote:
+    name: Promote internal release to closed alpha
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: android-internal
+    steps:
+      - name: Install Fastlane
+        run: |
+          set -euo pipefail
+          gem install fastlane \
+            --version "$FASTLANE_VERSION" \
+            --no-document \
+            --user-install
+          echo "$(ruby -e 'puts Gem.user_dir')/bin" >> "$GITHUB_PATH"
+      - name: Promote release
+        id: promote
+        env:
+          SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          VERSION_CODE: ${{ inputs.version_code }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVICE_ACCOUNT_JSON"
+          printf '%s' "$VERSION_CODE" | grep -Eq '^[1-9][0-9]*$'
+          json_key_path="$RUNNER_TEMP/play-service-account.json"
+          umask 077
+          printf '%s' "$SERVICE_ACCOUNT_JSON" > "$json_key_path"
+          fastlane supply \
+            --json_key "$json_key_path" \
+            --package_name "$PACKAGE_NAME" \
+            --track internal \
+            --track_promote_to alpha \
+            --track_promote_release_status completed \
+            --deactivate_on_promote false \
+            --version_code "$VERSION_CODE"
+      - name: Summarise promotion
+        if: always()
+        env:
+          PROMOTION_OUTCOME: ${{ steps.promote.outcome }}
+          VERSION_CODE: ${{ inputs.version_code }}
+        run: |
+          {
+            printf '# Promotion of Android version code %s\n\n' "$VERSION_CODE"
+            printf -- '- From: `internal`\n'
+            printf -- '- To: closed `alpha`\n'
+            printf -- '- Result: `%s`\n\n' "${PROMOTION_OUTCOME:-not reached}"
+            printf 'No tester mail is sent here because this recovery workflow cannot prove which commit produced the existing bundle.\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ work, not balloon features.
 See [PLAN.md](PLAN.md), [docs/architecture.md](docs/architecture.md), and
 [docs/backlog.md](docs/backlog.md).
 
+Tester release setup is documented for
+[TestFlight](docs/testflight.md) and
+[Google Play closed testing](docs/android-internal-testing.md).
+
 ## Repository layout
 
 ```text

--- a/apps/mobile/lib/services/build_identity.dart
+++ b/apps/mobile/lib/services/build_identity.dart
@@ -150,7 +150,7 @@ class BuildIdentity {
   static const testFlightUrl = 'https://testflight.apple.com/';
 
   static const defaultTesterNotesUrl =
-      'https://github.com/osholt/tailendcharlie/blob/main/docs/tester-release-notes.md';
+      'https://github.com/osholt/balloon-crumbs/blob/main/docs/tester-release-notes.md';
 
   final String appVersion;
   final String appBuild;

--- a/docs/android-internal-testing.md
+++ b/docs/android-internal-testing.md
@@ -1,0 +1,117 @@
+# Android closed testing
+
+Balloon Crumbs follows Tail End Charlie's release path: one manual
+**Android closed testing** workflow builds a signed App Bundle, uploads it to
+Google Play's `internal` track, and promotes that exact bundle to the closed
+`alpha` track. The upload remains on `internal` as a recovery source.
+
+This is deliberately not triggered by every merge. A release is a maintainer
+decision, just like the TestFlight workflow.
+
+## One-time account setup
+
+These are the only steps that cannot be committed to the repository:
+
+1. In Google Play Console, create **Balloon Crumbs** with package name
+   `dev.osholt.ballooncrumbs`. The package name cannot be changed after the
+   first upload. Enrol it in Play App Signing.
+2. Complete Play Console's required app-content and testing declarations. A
+   bundle can upload before every store-listing field is finished, but Play may
+   block a closed-track rollout until its required declarations are complete.
+3. Create a dedicated upload key; do not reuse Tail End Charlie's key:
+
+   ```bash
+   keytool -genkeypair -v -keystore balloon-crumbs-upload.jks \
+     -alias balloon-crumbs-upload -keyalg RSA -keysize 2048 -validity 10000
+   ```
+
+   Keep an encrypted backup. Google holds the app-signing key; this keystore is
+   the replaceable upload key, but losing it still interrupts releases.
+4. Create a Google Cloud service account, enable the **Google Play Android
+   Developer API** in that Cloud project, and download one JSON key.
+5. In Play Console's **Users and permissions**, invite the JSON key's
+   `client_email`, scope it to Balloon Crumbs only, and grant **Release apps to
+   testing tracks**. Creating it in Google Cloud alone gives it no Play access.
+6. Create a closed-testing track named **Alpha**, add the intended tester list,
+   and keep managed publishing off unless every release will also be published
+   manually in the Console.
+
+The tester opt-in page will be:
+`https://play.google.com/apps/testing/dev.osholt.ballooncrumbs`.
+
+## GitHub environment
+
+Create an Actions environment named `android-internal` and add these environment
+secrets. The repository environment is already restricted to workflow runs from
+`main`:
+
+| Secret | Value |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | `base64 -i balloon-crumbs-upload.jks` |
+| `ANDROID_KEYSTORE_PASSWORD` | Upload keystore password |
+| `ANDROID_KEY_ALIAS` | `balloon-crumbs-upload`, or the alias chosen above |
+| `ANDROID_KEY_PASSWORD` | Upload-key password |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Full service-account JSON key |
+
+On macOS, `base64 -i balloon-crumbs-upload.jks | pbcopy` copies the first value
+without writing another file. Never commit the keystore, passwords, or JSON.
+
+Optional repository variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `BALLOON_CRUMBS_API_BASE_URL` | HTTPS relay base URL; unset builds remain nearby/offline-only and say so |
+| `BALLOON_CRUMBS_FIREBASE_API_KEY` | Android Firebase configuration |
+| `BALLOON_CRUMBS_FIREBASE_PROJECT_ID` | Android Firebase configuration |
+| `BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID` | Android Firebase configuration |
+| `BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID` | Android Firebase configuration |
+
+Push is enabled only when all four Firebase variables are present. Tester email
+configuration is also optional and is documented in the workflow's variable
+names; the default release mode is `dry-run`, so no mail can be sent during the
+first setup run.
+
+## Releasing
+
+Run **Android closed testing** from the Actions tab, normally with:
+
+- `promote_to: alpha`
+- `notification_mode: dry-run` until the rendered mail is approved
+- an explicit `build_number` if any App Bundle has ever been uploaded outside
+  this workflow
+
+With no explicit build number, the workflow adds its GitHub run number to the
+build in `pubspec.yaml`; the first run therefore starts above the inherited
+`+22` baseline. Google Play version codes must be unique and greater than every
+version already served to a user. If Play is ahead, run **Play track status**,
+choose a number above the highest reported code, and pass it explicitly.
+
+If upload succeeds but promotion fails, run **Promote Android tester release**
+with that version code. It promotes the existing internal bundle and does not
+rebuild it.
+
+After a release:
+
+1. Run **Play track status** and confirm the version code is on `alpha`.
+2. Open the opt-in page on a physical Android phone using a tester account.
+3. Install/update, then confirm **Settings -> About & build** shows the same
+   version code and `Play closed testing (alpha)`.
+
+The status workflow is read-only: it opens a Play edit, lists tracks, and deletes
+the uncommitted edit. API success still cannot prove that a tester's phone has
+received the update, so the physical-phone check remains part of the first
+release setup.
+
+## Track safety
+
+The Console and API use confusing names:
+
+| Console surface | API track |
+| --- | --- |
+| Internal testing | `internal` |
+| Closed testing - Alpha | `alpha` |
+| Open testing | `beta` |
+| Production | `production` |
+
+The workflow exposes only `alpha` or `none`; it does not offer `beta`, because
+that would make a private tester build joinable as open testing.

--- a/docs/tester-release-notes.md
+++ b/docs/tester-release-notes.md
@@ -1,0 +1,8 @@
+# Tester release notes
+
+Android workflow runs attach a generated release summary containing the app
+version, Play version code, commit, destination track, and recent changes. Copy
+the tester-facing entry here after each release so an installed build can be
+matched to its changes.
+
+No Android tester build has been published for Balloon Crumbs yet.

--- a/docs/tester-update-guide.md
+++ b/docs/tester-update-guide.md
@@ -1,0 +1,17 @@
+# Android tester update guide
+
+Use the Google account that was added to the Balloon Crumbs closed-test list.
+
+1. Open the [closed-testing opt-in page](https://play.google.com/apps/testing/dev.osholt.ballooncrumbs)
+   on the Android phone you test with.
+2. Accept the invitation if prompted, then choose **Download it on Google Play**.
+3. In Google Play, choose **Install** or **Update**. A new build can take several
+   minutes to appear; if necessary, refresh **Manage apps & device -> Updates
+   available**.
+4. In Balloon Crumbs, open the gear menu and **About & build**. Include the app
+   version, build number, and distribution track in every bug report.
+
+The expected track for invited Android testers is
+`Play closed testing (alpha)`. If the opt-in page says the account is not
+eligible, check which Google account Play is using before reporting a release
+problem.

--- a/tools/tester_notify/notify_testers.py
+++ b/tools/tester_notify/notify_testers.py
@@ -22,8 +22,8 @@ Usage:
 
     python3 tools/tester_notify/notify_testers.py \\
       --track alpha --app-version 1.0.1 --build-number 31 \\
-      --commit "$GITHUB_SHA" --repository osholt/tailendcharlie \\
-      --run-url https://github.com/osholt/tailendcharlie/actions/runs/1 \\
+      --commit "$GITHUB_SHA" --repository osholt/balloon-crumbs \\
+      --run-url https://github.com/osholt/balloon-crumbs/actions/runs/1 \\
       --changes-file changes.md --changes-baseline 'build 30' \\
       --recipient "$TESTER_GROUP" --mode auto
 """

--- a/tools/tester_notify/tests/test_notify_testers.py
+++ b/tools/tester_notify/tests/test_notify_testers.py
@@ -131,8 +131,7 @@ class RenderingTest(unittest.TestCase):
             "the mail and the in-app update button must use one opt-in URL",
         )
         self.assertIn(
-            "'https://github.com/osholt/balloon-crumbs/blob/main/docs/"
-            "tester-release-notes.md'",
+            "'https://github.com/osholt/balloon-crumbs/blob/main/docs/tester-release-notes.md'",
             dart,
         )
 

--- a/tools/tester_notify/tests/test_notify_testers.py
+++ b/tools/tester_notify/tests/test_notify_testers.py
@@ -30,7 +30,7 @@ from tools.tester_notify.notify_testers import (  # noqa: E402
 # stores one. Named so no scanner mistakes it for real material.
 FAKE_LOGIN_VALUE = "placeholder-value-never-a-credential"
 LOGIN_ENV = "TESTER_NOTIFY_SMTP_PASSWORD"
-RECIPIENT = "tailendcharlie-testers@example.invalid"
+RECIPIENT = "balloon-crumbs-testers@example.invalid"
 
 
 def smtp_env(**overrides: str) -> dict:
@@ -51,8 +51,8 @@ def context(**overrides) -> ReleaseContext:
         "app_version": "1.0.1",
         "build_number": "31",
         "commit": "ce39e51ab0d4f6e8c1b2a3d4e5f60718293a4b5c",
-        "repository": "osholt/tailendcharlie",
-        "run_url": "https://github.com/osholt/tailendcharlie/actions/runs/12345",
+        "repository": "osholt/balloon-crumbs",
+        "run_url": "https://github.com/osholt/balloon-crumbs/actions/runs/12345",
         "changes": (
             "- reroute off-course riders back to the route (ce39e51)",
             "- correct roundabout and lane guidance (6b56c7b)",
@@ -69,8 +69,8 @@ def cli_args(**overrides) -> list:
         "--app-version": "1.0.1",
         "--build-number": "31",
         "--commit": "ce39e51ab0d4f6e8c1b2a3d4e5f60718293a4b5c",
-        "--repository": "osholt/tailendcharlie",
-        "--run-url": "https://github.com/osholt/tailendcharlie/actions/runs/1",
+        "--repository": "osholt/balloon-crumbs",
+        "--run-url": "https://github.com/osholt/balloon-crumbs/actions/runs/1",
         "--recipient": RECIPIENT,
         "--mode": "auto",
     }
@@ -96,7 +96,7 @@ class RenderingTest(unittest.TestCase):
             "Android",
             "Play closed testing (alpha)",
             "ce39e51",
-            "https://github.com/osholt/tailendcharlie/commit/ce39e51",
+            "https://github.com/osholt/balloon-crumbs/commit/ce39e51",
             "https://play.google.com/apps/testing/dev.osholt.ballooncrumbs",
             "About & build",
             "Distribution track  Play closed testing (alpha)",
@@ -130,6 +130,11 @@ class RenderingTest(unittest.TestCase):
             dart,
             "the mail and the in-app update button must use one opt-in URL",
         )
+        self.assertIn(
+            "'https://github.com/osholt/balloon-crumbs/blob/main/docs/"
+            "tester-release-notes.md'",
+            dart,
+        )
 
 
 class SafetyTest(unittest.TestCase):
@@ -145,7 +150,7 @@ class SafetyTest(unittest.TestCase):
         with self.assertRaises(UnsafeContentError):
             assert_safe("http://play.google.com/apps/testing/dev.osholt.ballooncrumbs")
         with self.assertRaises(UnsafeContentError):
-            assert_safe("https://user:pass@github.com/osholt/tailendcharlie")
+            assert_safe("https://user:pass@github.com/osholt/balloon-crumbs")
 
     def test_a_relay_url_smuggled_through_the_changelog_is_caught(self) -> None:
         with self.assertRaises(UnsafeContentError):
@@ -284,7 +289,7 @@ class MainTest(unittest.TestCase):
         output = self.out.getvalue()
         self.assertNotIn(FAKE_LOGIN_VALUE, output)
         self.assertNotIn(RECIPIENT, output)
-        self.assertIn("t***@example.invalid", output)
+        self.assertIn("b***@example.invalid", output)
 
     def test_refuses_to_mail_an_unidentified_build(self) -> None:
         code = main(
@@ -320,7 +325,7 @@ class MainTest(unittest.TestCase):
         )
 
         self.assertNotIn(RECIPIENT, markdown)
-        self.assertIn("t***@example.invalid", markdown)
+        self.assertIn("b***@example.invalid", markdown)
         self.assertIn("Sent to", markdown)
 
     def test_builds_a_plain_text_message(self) -> None:


### PR DESCRIPTION
## Summary
- mirror TEC's manual Android internal-upload and closed-alpha promotion path
- verify the signed AAB, add recovery promotion and read-only track status workflows
- document Play Console, signing, tester, and GitHub environment setup

## Verification
- built a release Android App Bundle with stamped closed-alpha identity
- ran targeted Flutter build-identity tests
- ran 23 tester-notifier unit tests
- parsed every workflow YAML file and syntax-checked every embedded shell block
- matched the built AAB certificate to the configured local build key