### PR TITLE
feat: add balloon flight map and OpenAIP layer

### DIFF
--- a/.github/workflows/android-internal.yml
+++ b/.github/workflows/android-internal.yml
@@ -1,4 +1,4 @@
-name: Android closed testing
+name: Android internal testing
 
 on:
   workflow_dispatch:
@@ -10,11 +10,11 @@ on:
       promote_to:
         description: Promote to closed alpha, or upload to internal only
         required: true
-        default: alpha
+        default: none
         type: choice
         options:
-          - alpha
           - none
+          - alpha
       notification_mode:
         description: Render the tester mail only, or send it when SMTP is configured
         required: true
@@ -114,6 +114,7 @@ jobs:
         env:
           TESTER_NOTES_URL: https://github.com/${{ github.repository }}/blob/${{ github.sha }}/docs/tester-release-notes.md
           BALLOON_CRUMBS_API_BASE_URL: ${{ vars.BALLOON_CRUMBS_API_BASE_URL }}
+          BALLOON_CRUMBS_OPENAIP_API_KEY: ${{ secrets.BALLOON_CRUMBS_OPENAIP_API_KEY }}
           BALLOON_CRUMBS_FIREBASE_API_KEY: ${{ vars.BALLOON_CRUMBS_FIREBASE_API_KEY }}
           BALLOON_CRUMBS_FIREBASE_PROJECT_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_PROJECT_ID }}
           BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID }}
@@ -122,6 +123,10 @@ jobs:
           set -euo pipefail
           if test -z "${BALLOON_CRUMBS_API_BASE_URL:-}"; then
             echo "::warning::No BALLOON_CRUMBS_API_BASE_URL repository variable; this build has nearby transport but no relay."
+          fi
+          if test -z "${BALLOON_CRUMBS_OPENAIP_API_KEY:-}"; then
+            echo "::error::Missing BALLOON_CRUMBS_OPENAIP_API_KEY; tester releases must include the selected advisory airspace layer." >&2
+            exit 1
           fi
           push_enabled=false
           if test -n "${BALLOON_CRUMBS_FIREBASE_API_KEY:-}" \
@@ -140,6 +145,7 @@ jobs:
             --dart-define=BALLOON_CRUMBS_BUILD_TIMESTAMP="$BALLOON_CRUMBS_BUILD_TIMESTAMP" \
             --dart-define=BALLOON_CRUMBS_TESTER_NOTES_URL="$TESTER_NOTES_URL" \
             --dart-define=BALLOON_CRUMBS_API_BASE_URL="${BALLOON_CRUMBS_API_BASE_URL:-}" \
+            --dart-define=BALLOON_CRUMBS_OPENAIP_API_KEY="$BALLOON_CRUMBS_OPENAIP_API_KEY" \
             --dart-define=BALLOON_CRUMBS_PUSH_ENABLED="$push_enabled" \
             --dart-define=BALLOON_CRUMBS_FIREBASE_API_KEY="${BALLOON_CRUMBS_FIREBASE_API_KEY:-}" \
             --dart-define=BALLOON_CRUMBS_FIREBASE_PROJECT_ID="${BALLOON_CRUMBS_FIREBASE_PROJECT_ID:-}" \

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -112,11 +112,16 @@ jobs:
         working-directory: ${{ env.MOBILE_DIR }}
         env:
           BALLOON_CRUMBS_API_BASE_URL: ${{ vars.BALLOON_CRUMBS_API_BASE_URL }}
+          BALLOON_CRUMBS_OPENAIP_API_KEY: ${{ secrets.BALLOON_CRUMBS_OPENAIP_API_KEY }}
         run: |
           set -euo pipefail
           eval "$("$GITHUB_WORKSPACE/tools/build-identity.sh" pubspec.yaml testflight "$BUILD_NUMBER" | sed 's/^/export /')"
           if [ -z "${BALLOON_CRUMBS_API_BASE_URL:-}" ]; then
             echo "::warning::No BALLOON_CRUMBS_API_BASE_URL repository variable; this build cannot reach a relay. Nearby transport still works and the app says so on its status card."
+          fi
+          if [ -z "${BALLOON_CRUMBS_OPENAIP_API_KEY:-}" ]; then
+            echo "::error::Missing BALLOON_CRUMBS_OPENAIP_API_KEY; tester releases must include the selected advisory airspace layer." >&2
+            exit 1
           fi
           flutter pub get
           flutter build ios --release --no-codesign \
@@ -127,6 +132,7 @@ jobs:
             --dart-define=BALLOON_CRUMBS_DISTRIBUTION_TRACK="$BALLOON_CRUMBS_DISTRIBUTION_TRACK" \
             --dart-define=BALLOON_CRUMBS_BUILD_TIMESTAMP="$BALLOON_CRUMBS_BUILD_TIMESTAMP" \
             --dart-define=BALLOON_CRUMBS_API_BASE_URL="${BALLOON_CRUMBS_API_BASE_URL:-}" \
+            --dart-define=BALLOON_CRUMBS_OPENAIP_API_KEY="$BALLOON_CRUMBS_OPENAIP_API_KEY" \
             --dart-define=BALLOON_CRUMBS_PUSH_ENABLED=false \
             --dart-define=BALLOON_CRUMBS_RIDE_DIAGNOSTICS=true
 

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -65,7 +65,10 @@ class SituationalAwarenessController extends ChangeNotifier {
   final Map<String, RiderLocation> _locations = {};
   final Map<String, RiderLocationEvidence> _locationEvidence = {};
   final Map<String, HazardReport> _hazards = {};
-  final List<({DateTime recordedAt, GeoPoint position})> _leaderTrail = [];
+  // Keep the complete fix here. Reducing this to position plus timestamp threw
+  // away the balloon altitude before the map could colour or describe its
+  // ground track.
+  final List<LocationSample> _leaderTrail = [];
   bool _busy = false;
   bool _refreshingStaleness = false;
   String? _errorMessage;
@@ -82,7 +85,18 @@ class SituationalAwarenessController extends ChangeNotifier {
   /// rendering can break an unknown interval instead of inventing a straight
   /// line across it (#205).
   List<({DateTime recordedAt, GeoPoint position})> get leaderTrailSamples =>
-      _leaderTrailSamplesCache ??= List.unmodifiable(_leaderTrail);
+      _leaderTrailSamplesCache ??= List.unmodifiable([
+        for (final sample in _leaderTrail)
+          (recordedAt: sample.recordedAt, position: sample.position),
+      ]);
+
+  /// Complete balloon/leader fixes for telemetry-aware map surfaces.
+  ///
+  /// The compatibility getters above intentionally remain position-only for
+  /// route-alert callers. This is the path that retains altitude source, datum,
+  /// accuracy and vertical speed for the balloon ground track.
+  List<LocationSample> get leaderLocationSamples =>
+      _leaderLocationSamplesCache ??= List.unmodifiable(_leaderTrail);
 
   List<RiderLocation> get riderLocations {
     final values = _locations.values.toList(growable: false);
@@ -431,12 +445,10 @@ class SituationalAwarenessController extends ChangeNotifier {
         !_leaderTrail[index - 1].recordedAt.isBefore(sample.recordedAt)) {
       return;
     }
-    _leaderTrail.insert(index, (
-      recordedAt: sample.recordedAt,
-      position: sample.position,
-    ));
+    _leaderTrail.insert(index, sample);
     _leaderTrailPointsCache = null;
     _leaderTrailSamplesCache = null;
+    _leaderLocationSamplesCache = null;
     // A runaway guard, not a display policy. The trail used to be truncated to
     // a 600-point recent-track limit here, which cost a
     // tester the tail of a 6 h 4 m, 112 mile ride: 600 points is roughly the
@@ -458,6 +470,7 @@ class SituationalAwarenessController extends ChangeNotifier {
 
   List<GeoPoint>? _leaderTrailPointsCache;
   List<({DateTime recordedAt, GeoPoint position})>? _leaderTrailSamplesCache;
+  List<LocationSample>? _leaderLocationSamplesCache;
 
   /// Built once per change rather than per read.
   ///
@@ -469,7 +482,7 @@ class SituationalAwarenessController extends ChangeNotifier {
   /// every follower position update. Caching it removes the per-update cost
   /// without deleting any history.
   List<GeoPoint> get _leaderTrailPoints => _leaderTrailPointsCache ??=
-      List.unmodifiable([for (final point in _leaderTrail) point.position]);
+      List.unmodifiable([for (final sample in _leaderTrail) sample.position]);
 
   void _removeExpiredHazards() {
     final now = _clock();

--- a/apps/mobile/lib/features/map/ride_map.dart
+++ b/apps/mobile/lib/features/map/ride_map.dart
@@ -5,6 +5,7 @@ export 'ride_map_feature.dart'
         GroupMiniMapRenderer,
         MapOverlayMarker,
         MapOverlayTrace,
+        RideMapPerspective,
         RideMapFeature,
         RideMapScreen,
         describeQuickMessageOrigin,

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -18,6 +18,7 @@ import '../../data/json_file_completed_ride_store.dart';
 import '../../data/json_file_recorded_route_store.dart';
 import '../../data/json_file_route_store.dart';
 import '../../domain/completed_ride_store.dart';
+import '../../domain/altitude.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/hazard.dart';
 import '../../domain/imported_route.dart';
@@ -28,6 +29,7 @@ import '../../domain/rider_color.dart';
 import '../../domain/route_store.dart';
 import '../../internet/plan_directory.dart';
 import '../../services/basemap_configuration.dart';
+import '../../services/aeronautical_chart_configuration.dart';
 import '../../services/basemap_status.dart';
 import '../../services/demo_route_loader.dart';
 import '../../services/enforcement_alert_detector.dart';
@@ -103,6 +105,14 @@ enum GroupMiniMapRenderer {
 }
 
 enum _ImportedTrackChoice { cancel, followOriginal, generateNavigable }
+
+/// Which craft owns this map viewport.
+///
+/// This is deliberately separate from the inherited ride leader role. A route
+/// coordinator can be a leader without being airborne; only a device attached
+/// to the balloon (or the explicit Ride Lab balloon perspective) gets the
+/// aviation presentation.
+enum RideMapPerspective { chase, balloon }
 
 @visibleForTesting
 Color groupMiniMapBackgroundColor(Brightness brightness) =>
@@ -219,6 +229,9 @@ class RideMapFeature extends StatefulWidget {
     this.localRiderSymbol = riderSymbolDefault,
     this.localDisplayName = 'You',
     this.localBadgeColor = const Color(0xFF2F80ED),
+    this.perspective = RideMapPerspective.chase,
+    this.aeronauticalChartConfiguration =
+        const AeronauticalChartConfiguration(),
   });
 
   factory RideMapFeature.fromEnvironment({
@@ -277,6 +290,8 @@ class RideMapFeature extends StatefulWidget {
     RiderSymbol localRiderSymbol = riderSymbolDefault,
     String localDisplayName = 'You',
     Color localBadgeColor = const Color(0xFF2F80ED),
+    RideMapPerspective perspective = RideMapPerspective.chase,
+    AeronauticalChartConfiguration? aeronauticalChartConfiguration,
   }) => RideMapFeature(
     key: key,
     currentPosition: currentPosition,
@@ -334,6 +349,10 @@ class RideMapFeature extends StatefulWidget {
     localRiderSymbol: localRiderSymbol,
     localDisplayName: localDisplayName,
     localBadgeColor: localBadgeColor,
+    perspective: perspective,
+    aeronauticalChartConfiguration:
+        aeronauticalChartConfiguration ??
+        AeronauticalChartConfiguration.fromEnvironment(),
   );
 
   final ValueListenable<GeoPoint?>? currentPosition;
@@ -429,6 +448,8 @@ class RideMapFeature extends StatefulWidget {
   final RiderSymbol localRiderSymbol;
   final String localDisplayName;
   final Color localBadgeColor;
+  final RideMapPerspective perspective;
+  final AeronauticalChartConfiguration aeronauticalChartConfiguration;
 
   @override
   State<RideMapFeature> createState() => _RideMapFeatureState();
@@ -585,6 +606,8 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         localRiderSymbol: widget.localRiderSymbol,
         localDisplayName: widget.localDisplayName,
         localBadgeColor: widget.localBadgeColor,
+        perspective: widget.perspective,
+        aeronauticalChartConfiguration: widget.aeronauticalChartConfiguration,
       );
     },
   );
@@ -679,6 +702,9 @@ class RideMapScreen extends StatefulWidget {
     this.localRiderSymbol = riderSymbolDefault,
     this.localDisplayName = 'You',
     this.localBadgeColor = const Color(0xFF2F80ED),
+    this.perspective = RideMapPerspective.chase,
+    this.aeronauticalChartConfiguration =
+        const AeronauticalChartConfiguration(),
   });
 
   final RouteStore routeStore;
@@ -796,6 +822,8 @@ class RideMapScreen extends StatefulWidget {
   final RiderSymbol localRiderSymbol;
   final String localDisplayName;
   final Color localBadgeColor;
+  final RideMapPerspective perspective;
+  final AeronauticalChartConfiguration aeronauticalChartConfiguration;
 
   @override
   State<RideMapScreen> createState() => _RideMapScreenState();
@@ -810,8 +838,23 @@ class _RideMapScreenState extends State<RideMapScreen> {
   static const _waypointSource = 'balloon-crumbs-waypoints';
   static const _positionSource = 'balloon-crumbs-position';
   static const _overlaySource = 'balloon-crumbs-overlays';
+  static const _aeronauticalChartSource = 'balloon-crumbs-aeronautical-chart';
+  static const _aeronauticalChartLayer =
+      'balloon-crumbs-aeronautical-chart-layer';
   static const _trailDirectionArrowImage =
       'balloon-crumbs-trail-direction-arrow';
+
+  bool get _isBalloonView => widget.perspective == RideMapPerspective.balloon;
+
+  CraftIconStyle get _localCraftStyle =>
+      _isBalloonView ? CraftIconStyle.balloon : widget.localMotorcycleStyle;
+
+  bool get _showAeronauticalChart =>
+      _isBalloonView &&
+      widget.aeronauticalChartConfiguration.isCurrentAt(DateTime.now());
+
+  bool get _shouldAutoFollow =>
+      _isBalloonView ? _effectivePosition != null : _isMoving;
 
   /// How many of the direction arrows the planned route may claim before the
   /// live cues take the rest. Half the budget: enough to read the route's
@@ -1233,7 +1276,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         // Riding without a GPX is a first-class mode (#124), so following the
         // rider is driven by position and heading alone. A route changes what is
         // drawn, never whether the camera tracks the bike.
-        _navigationMode = _isMoving;
+        _navigationMode = _shouldAutoFollow;
         // A route load reframes the map, so any viewport follow mode had is gone.
         _releaseNavigationViewport();
         // Once we have a position, keep the map canvas at its navigation size.
@@ -1287,15 +1330,19 @@ class _RideMapScreenState extends State<RideMapScreen> {
     // The group mini-map owns its own ValueListenableBuilder below. This
     // avoids relying on a parent platform-map rebuild to notice rider updates,
     // which left the portrait mini-map absent in the live simulator.
-    final canShowGroupMiniMap = widget.overlayMarkers != null;
+    final canShowGroupMiniMap =
+        !_isBalloonView && widget.overlayMarkers != null;
     final groupMiniMapWidth = landscape ? 196.0 : 150.0;
     final groupMiniMapHeight = landscape ? 116.0 : 104.0;
     final showRideMenu = hideChrome && widget.onOpenRideMenu != null;
     // A route can contain manoeuvres before the device has a usable location.
     // The guidance banner is only composed into the band while guidance is
     // actually visible, so nothing reserves space for a banner that is absent.
-    final routeStartOfferDistance = _routeStartOfferDistance;
+    final routeStartOfferDistance = _isBalloonView
+        ? null
+        : _routeStartOfferDistance;
     final hasGuidance =
+        !_isBalloonView &&
         routeStartOfferDistance == null &&
         widget.rideStarted &&
         _navigationGuidance.value.isVisible;
@@ -1311,7 +1358,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
               toolbarHeight: landscape ? 42 : 52,
               titleSpacing: 12,
               title: Text(
-                _route?.name ?? 'Navigation',
+                _isBalloonView ? 'Balloon' : (_route?.name ?? 'Navigation'),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: landscape
@@ -1319,7 +1366,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                     : null,
               ),
               actions: [
-                if (widget.canEditRoute)
+                if (!_isBalloonView && widget.canEditRoute)
                   IconButton(
                     tooltip: 'Plan a destination',
                     visualDensity: compactDensity,
@@ -1333,7 +1380,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   ),
                 // Route-derived: importing is the action that creates a
                 // route, so it is offered only while there is none.
-                if (widget.canEditRoute && _route == null)
+                if (!_isBalloonView && widget.canEditRoute && _route == null)
                   IconButton(
                     tooltip: 'Import GPX route',
                     visualDensity: compactDensity,
@@ -1347,7 +1394,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   ),
                 // Route-derived: there is nothing to hand to another
                 // navigation app or write to a GPX without one.
-                if (_route != null)
+                if (!_isBalloonView && _route != null)
                   IconButton(
                     tooltip: 'Navigate or export route',
                     visualDensity: compactDensity,
@@ -1364,7 +1411,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   visualDensity: compactDensity,
                   // Route-derived: fitting the whole plan needs a plan. The
                   // rider's own framing is the follow camera's job.
-                  onPressed: _route == null ? null : _showWholeRoute,
+                  onPressed: _isBalloonView || _route == null
+                      ? null
+                      : _showWholeRoute,
                   icon: const Icon(Icons.fit_screen),
                 ),
                 PopupMenuButton<_MapAction>(
@@ -1375,7 +1424,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                       : const EdgeInsets.all(8),
                   onSelected: _handleMenuAction,
                   itemBuilder: (context) => [
-                    if (widget.canEditRoute) ...[
+                    if (!_isBalloonView && widget.canEditRoute) ...[
                       PopupMenuItem(
                         value: _MapAction.importGpx,
                         // Route-derived wording only: the action itself is
@@ -1391,26 +1440,26 @@ class _RideMapScreenState extends State<RideMapScreen> {
                         child: Text('Load demo route'),
                       ),
                     ],
-                    PopupMenuItem(
-                      value: _MapAction.speedLimitDisplay,
-                      child: Row(
-                        children: [
-                          Icon(
-                            _speedLimitDisplay.enabled
-                                ? Icons.check_box
-                                : Icons.check_box_outline_blank,
-                          ),
-                          const SizedBox(width: 10),
-                          // A popup menu constrains its items, and this label
-                          // was wide enough to be clipped without flexing.
-                          const Expanded(
-                            child: Text('Show mapped speed limit'),
-                          ),
-                        ],
+                    if (!_isBalloonView)
+                      PopupMenuItem(
+                        value: _MapAction.speedLimitDisplay,
+                        child: Row(
+                          children: [
+                            Icon(
+                              _speedLimitDisplay.enabled
+                                  ? Icons.check_box
+                                  : Icons.check_box_outline_blank,
+                            ),
+                            const SizedBox(width: 10),
+                            const Expanded(
+                              child: Text('Show mapped speed limit'),
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
                     // Route-derived: both read manoeuvres off the plan.
-                    if (_route?.maneuvers.isNotEmpty ?? false) ...[
+                    if (!_isBalloonView &&
+                        (_route?.maneuvers.isNotEmpty ?? false)) ...[
                       const PopupMenuItem(
                         value: _MapAction.maneuverList,
                         child: Text('All turns for this route'),
@@ -1424,7 +1473,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                       ),
                     // Route-derived: the offline region is the route corridor,
                     // so there is no bounded area to download without one.
-                    if (_route != null)
+                    if (!_isBalloonView && _route != null)
                       PopupMenuItem(
                         value: _MapAction.downloadOffline,
                         enabled:
@@ -1441,7 +1490,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
                       child: Text('Clear downloaded map data'),
                     ),
                     // Route-derived: nothing to remove without one.
-                    if (widget.canEditRoute && _route != null)
+                    if (!_isBalloonView &&
+                        widget.canEditRoute &&
+                        _route != null)
                       const PopupMenuItem(
                         value: _MapAction.removeRoute,
                         child: Text('Remove route'),
@@ -1468,6 +1519,34 @@ class _RideMapScreenState extends State<RideMapScreen> {
                     child: _buildMap(),
                   ),
                 ),
+                if (_isBalloonView && widget.navigationPosition != null)
+                  Positioned(
+                    key: const Key('balloon-altitude-position'),
+                    left: overlayLeft + 12,
+                    top: overlayTop + 12,
+                    child: ValueListenableBuilder<MapNavigationPosition?>(
+                      valueListenable: widget.navigationPosition!,
+                      builder: (context, fix, _) => _BalloonAltitudeCard(
+                        fix: fix,
+                        distanceUnit: widget.distanceUnit,
+                      ),
+                    ),
+                  ),
+                if (_isBalloonView)
+                  Positioned(
+                    key: const Key('aeronautical-chart-status-position'),
+                    right: overlayRight + 12,
+                    top: overlayTop + (landscape ? 12 : 118),
+                    child: _AeronauticalChartBadge(
+                      configuration: widget.aeronauticalChartConfiguration,
+                      now: DateTime.now(),
+                      onTap: () => _showMessage(
+                        widget.aeronauticalChartConfiguration.explanationAt(
+                          DateTime.now(),
+                        ),
+                      ),
+                    ),
+                  ),
                 Positioned.fill(
                   child: _buildRideChrome(
                     landscape: landscape,
@@ -1493,7 +1572,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
                 // it gives way. Route entry stays reachable from the ride
                 // menu's "Change route" and from the app bar whenever this card
                 // is showing.
-                if (_route == null &&
+                if (!_isBalloonView &&
+                    _route == null &&
                     !hideChrome &&
                     !widget.rideStarted &&
                     !_waitingRoutePromptDismissed)
@@ -1520,7 +1600,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                 // that announces it and a border that holds for the rest of the
                 // approach (#446). The announcement sits at the top-centre,
                 // clear of the rider marker and the bottom navigation rails.
-                if (widget.enforcementAlert != null)
+                if (!_isBalloonView && widget.enforcementAlert != null)
                   Positioned.fill(
                     child: ValueListenableBuilder<EnforcementAlert?>(
                       valueListenable: widget.enforcementAlert!,
@@ -1731,7 +1811,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
             )
           : null;
       final routeProgressPanel =
-          !widget.showRouteProgress ||
+          _isBalloonView ||
+              !widget.showRouteProgress ||
               _route == null ||
               _progressGeometry.totalMeters <= 0
           ? null
@@ -1955,7 +2036,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       // The speed sign owns its own slot at the edge of the band, clear of the
       // action row: portrait puts it under the actions and hard right, landscape
       // in the right-hand rail away from the centre column (#125).
-      final speedLimit = !widget.rideStarted
+      final speedLimit = !widget.rideStarted || _isBalloonView
           ? null
           : KeyedSubtree(
               key: const Key('posted-speed-limit-position'),
@@ -2319,7 +2400,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       currentPosition: _effectivePosition,
       riders: groupRiders,
       riderCount: groupSize,
-      localMotorcycleStyle: widget.localMotorcycleStyle,
+      localMotorcycleStyle: _localCraftStyle,
       localRiderSymbol: widget.localRiderSymbol,
       localDisplayName: widget.localDisplayName,
       onTap: widget.onOpenRoster,
@@ -2335,8 +2416,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
   Widget _buildMap() {
     if (_basemap.usesMapLibre) return _buildMapLibreMap();
 
-    final route = _route;
-    final points = route?.allPoints.map(_latLng).toList(growable: false) ?? [];
+    final route = _isBalloonView ? null : _route;
+    final framingPoints = _isBalloonView
+        ? _balloonGroundTrackPoints
+        : route?.allPoints.toList(growable: false) ?? const <GeoPoint>[];
+    final points = framingPoints.map(_latLng).toList(growable: false);
     // With no route the rider's own position is the framing (#124); the UK-wide
     // overview is only for a map that has neither.
     final rider = _effectivePosition;
@@ -2353,7 +2437,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
             initialCenter:
                 points.firstOrNull ??
                 (rider == null ? const LatLng(54.5, -3.2) : _latLng(rider)),
-            initialZoom: points.isEmpty && rider == null ? 5 : 14,
+            initialZoom: points.isEmpty && rider == null
+                ? 5
+                : _isBalloonView
+                ? 11
+                : 14,
             onMapEvent: _onFlutterMapEvent,
           );
 
@@ -2371,6 +2459,15 @@ class _RideMapScreenState extends State<RideMapScreen> {
               cache: widget.offlineTileCache,
             ),
           ),
+        if (_showAeronauticalChart)
+          TileLayer(
+            key: const Key('aeronautical-chart-tile-layer'),
+            urlTemplate: widget.aeronauticalChartConfiguration.tileUrlTemplate,
+            userAgentPackageName: 'me.osholt.balloon_crumbs',
+            tms: widget.aeronauticalChartConfiguration.usesTms,
+            tileBuilder: (context, tile, _) =>
+                Opacity(opacity: 0.82, child: tile),
+          ),
         // Actual travelled trails are drawn whether or not a route is loaded,
         // and the leader's trail sits under the remaining planned route so both
         // stay readable where they coincide. Completed *planned* geometry is
@@ -2380,9 +2477,10 @@ class _RideMapScreenState extends State<RideMapScreen> {
           PolylineLayer(
             polylines: [
               ..._trailPolylines(dashed: false),
-              ..._progressGeometry.remainingPaths.map(
-                (path) => _routePolyline(path, RouteTrailStyle.routeAhead),
-              ),
+              if (!_isBalloonView)
+                ..._progressGeometry.remainingPaths.map(
+                  (path) => _routePolyline(path, RouteTrailStyle.routeAhead),
+                ),
               ..._trailPolylines(dashed: true),
             ],
           ),
@@ -2447,7 +2545,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   // The marker follows the bike, not the plan (#124).
                   navigationMode: _isMoving,
                   headingDegrees: _lastHeadingDegrees,
-                  style: widget.localMotorcycleStyle,
+                  style: _localCraftStyle,
                   symbol: widget.localRiderSymbol,
                   displayName: widget.localDisplayName,
                   badgeColor: widget.localBadgeColor,
@@ -2520,7 +2618,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }
 
   Widget _buildMapLibreMap() {
-    final planned = _route?.allPoints.toList(growable: false) ?? const [];
+    final planned = _isBalloonView
+        ? _balloonGroundTrackPoints
+        : _route?.allPoints.toList(growable: false) ?? const [];
     // As above: no route still frames the rider rather than the whole country.
     final routePoints = planned.isNotEmpty ? planned : [?_effectivePosition];
     final initial = routePoints.isEmpty
@@ -2530,7 +2630,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
               routePoints.first.latitude,
               routePoints.first.longitude,
             ),
-            zoom: routePoints.length == 1 ? 14 : 11,
+            zoom: routePoints.length == 1 ? (_isBalloonView ? 11 : 14) : 11,
           );
     return Stack(
       children: [
@@ -3065,14 +3165,14 @@ class _RideMapScreenState extends State<RideMapScreen> {
             const Duration(milliseconds: 250);
     if (refreshMapLibrePosition) _lastMapLibrePositionSyncAt = progressNow;
 
-    if (!_isMoving) _autoFollowSuppressed = false;
+    if (!_shouldAutoFollow) _autoFollowSuppressed = false;
     final offerEmergencyActions =
         _emergencyAlertSent &&
         !_isMoving &&
         !_emergencyActionsOpen &&
         !_emergencyActionsDismissed;
     // Both are driven by the bike, not by whether a route was imported (#124).
-    final autoFollow = _isMoving && !_autoFollowSuppressed;
+    final autoFollow = _shouldAutoFollow && !_autoFollowSuppressed;
     final enableNavigationMode = autoFollow && !_navigationMode;
     final activateNavigationCanvas =
         position != null && !_navigationCanvasActive;
@@ -3127,6 +3227,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
   /// reported accuracy and heading, and a position without them cannot be tested
   /// for confidence at all (#126).
   void _observeSpeedLimit(MapNavigationPosition? fix) {
+    if (_isBalloonView) return;
     if (fix == null) return;
     final location = SpeedLimitLocation(
       point: fix.point,
@@ -3144,6 +3245,14 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }
 
   void _updateNavigationGuidance(GeoPoint? position) {
+    if (_isBalloonView) {
+      final current = _navigationGuidance.value;
+      if (current.state != NavigationGuidanceState.noRoute) {
+        _navigationGuidance.value =
+            const NavigationGuidanceAssessment.noRoute();
+      }
+      return;
+    }
     final navigationRoute = _connectorRoute ?? _route;
     final next = _navigationGuidancePlanner.assess(
       route: navigationRoute,
@@ -3190,7 +3299,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
             event.source == MapEventSource.multiFingerGestureStart ||
             event.source == MapEventSource.doubleTap ||
             event.source == MapEventSource.scrollWheel)) {
-      _stopFollowing(suppressAutomatic: _isMoving);
+      _stopFollowing(suppressAutomatic: _shouldAutoFollow);
     }
     // Every camera change, including the ones this app asked for: the framing is
     // measured, so the button appears and disappears from where the map actually
@@ -3230,13 +3339,13 @@ class _RideMapScreenState extends State<RideMapScreen> {
 
   void _suppressFollowForMapGesture() {
     if (_navigationMode) {
-      _stopFollowing(suppressAutomatic: _isMoving);
+      _stopFollowing(suppressAutomatic: _shouldAutoFollow);
     }
   }
 
   Future<void> _toggleNavigationMode() async {
     if (_navigationMode) {
-      _stopFollowing(suppressAutomatic: _isMoving);
+      _stopFollowing(suppressAutomatic: _shouldAutoFollow);
       return;
     }
     if (_effectivePosition == null) {
@@ -3484,7 +3593,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }
 
   void _showWholeRoute() {
-    _stopFollowing(suppressAutomatic: _isMoving);
+    _stopFollowing(suppressAutomatic: _shouldAutoFollow);
     _fitRoute();
   }
 
@@ -3492,6 +3601,12 @@ class _RideMapScreenState extends State<RideMapScreen> {
     bool force = false,
     Duration? transitionDuration,
   }) async {
+    if (_isBalloonView) {
+      return _followBalloonCamera(
+        force: force,
+        transitionDuration: transitionDuration,
+      );
+    }
     if (!_navigationMode) return;
     final position = _effectivePosition;
     if (position == null) return;
@@ -3617,6 +3732,86 @@ class _RideMapScreenState extends State<RideMapScreen> {
     }
   }
 
+  /// A balloon needs geographic context, not a tilted road corridor. It stays
+  /// north-up at a deliberately wider scale, centred on the aircraft, while a
+  /// pan still hands control back to the pilot until they tap Follow me.
+  Future<void> _followBalloonCamera({
+    bool force = false,
+    Duration? transitionDuration,
+  }) async {
+    if (!_navigationMode) return;
+    final position = _effectivePosition;
+    if (position == null) return;
+    if (_cameraUpdateInFlight) {
+      _cameraUpdateQueued = true;
+      return;
+    }
+    final now = DateTime.now();
+    final previous = _lastCameraUpdateAt;
+    if (!force &&
+        previous != null &&
+        now.difference(previous) < const Duration(milliseconds: 700)) {
+      return;
+    }
+    _lastCameraUpdateAt = now;
+    _cameraUpdateInFlight = true;
+    const zoom = 11.0;
+    _commandedViewport = (target: position, zoom: zoom);
+    widget.onNavigationViewportChanged?.call(
+      NavigationCameraViewport(
+        latitude: position.latitude,
+        longitude: position.longitude,
+        zoom: zoom,
+        tilt: 0,
+        bearing: 0,
+        sourceViewportHeightPixels: _mapViewportHeightPixels,
+        sourceViewportWidthPixels: _mapViewportWidthPixels,
+        riderViewportFraction: 0.5,
+        riderHorizontalViewportFraction: 0.5,
+        leftHandTraffic: true,
+        mapStyleUrl: _basemap.styleUrl,
+        mapStyleJson: widget.mapStyleString,
+      ),
+    );
+    try {
+      if (_basemap.usesMapLibre) {
+        final controller = _mapLibreController;
+        if (controller == null) return;
+        await controller.easeCamera(
+          ml.CameraUpdate.newCameraPosition(
+            ml.CameraPosition(
+              target: ml.LatLng(position.latitude, position.longitude),
+              zoom: zoom,
+              tilt: 0,
+              bearing: 0,
+            ),
+          ),
+          duration: transitionDuration ?? const Duration(milliseconds: 480),
+        );
+      } else {
+        _mapController.moveAndRotateAnimatedRaw(
+          _latLng(position),
+          zoom,
+          0,
+          offset: Offset.zero,
+          duration: transitionDuration ?? const Duration(milliseconds: 480),
+          curve: Curves.easeInOutCubic,
+          hasGesture: false,
+          source: MapEventSource.mapController,
+        );
+      }
+    } on StateError {
+      // The first fix can precede attachment of the fallback map.
+    } finally {
+      _cameraUpdateInFlight = false;
+      _scheduleCameraFramingRefresh();
+      if (_cameraUpdateQueued) {
+        _cameraUpdateQueued = false;
+        if (mounted) unawaited(_followBalloonCamera(force: true));
+      }
+    }
+  }
+
   /// The badge for one overlay marker in the flutter_map fallback.
   ///
   /// A reported hazard draws [HazardMapSymbolPainter] - the same painter the
@@ -3695,7 +3890,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
           (
             symbol: widget.localRiderSymbol,
             displayName: widget.localDisplayName,
-            style: widget.localMotorcycleStyle,
+            style: _localCraftStyle,
           ),
           for (final overlay
               in widget.overlayMarkers?.value ?? const <MapOverlayMarker>[])
@@ -3725,6 +3920,23 @@ class _RideMapScreenState extends State<RideMapScreen> {
     _mapLibreStyleReady = false;
     try {
       await _registerMarkerImages(controller);
+      if (_showAeronauticalChart) {
+        final chart = widget.aeronauticalChartConfiguration;
+        await controller.addSource(
+          _aeronauticalChartSource,
+          ml.RasterSourceProperties(
+            tiles: [chart.tileUrlTemplate],
+            tileSize: 256,
+            scheme: chart.tileScheme.mapLibreValue,
+            attribution: chart.attribution,
+          ),
+        );
+        await controller.addRasterLayer(
+          _aeronauticalChartSource,
+          _aeronauticalChartLayer,
+          const ml.RasterLayerProperties(rasterOpacity: 0.82),
+        );
+      }
       // Solid trails are drawn before the planned route so the leader's wider
       // trail reads as a corridor beneath it rather than hiding it.
       await controller.addGeoJsonSource(
@@ -3732,6 +3944,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         _riderTrailGeoJson(),
       );
       await _addTrailLayers(controller, RiderTrailKind.leader);
+      await _addTrailLayers(controller, RiderTrailKind.balloonGroundTrack);
       await _addTrailLayers(controller, RiderTrailKind.rider);
       await controller.addGeoJsonSource(
         _remainingRouteSource,
@@ -3816,7 +4029,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         ml.SymbolLayerProperties(
           iconImage: widget.localRiderSymbol.imageName(
             widget.localDisplayName,
-            widget.localMotorcycleStyle,
+            _localCraftStyle,
           ),
           // Dark on a light badge: see [RouteTrailStyle.markerGlyph] (#133).
           iconColor: RouteTrailStyle.markerGlyphHex,
@@ -4037,7 +4250,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }
 
   Map<String, dynamic> _remainingRouteGeoJson() => MapGeoJson.lines(
-    _progressGeometry.remainingPaths,
+    _isBalloonView
+        ? const <List<GeoPoint>>[]
+        : _progressGeometry.remainingPaths,
     idPrefix: 'remaining-route',
   );
 
@@ -4047,7 +4262,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     final connector = _routeStartConnector;
     return [
       ...(widget.riderTrails?.value ?? const <MapOverlayTrace>[]),
-      if (connector != null)
+      if (!_isBalloonView && connector != null)
         MapOverlayTrace(
           id: 'route-start-connector',
           points: connector.paths
@@ -4058,6 +4273,13 @@ class _RideMapScreenState extends State<RideMapScreen> {
         ),
     ].where((trace) => trace.points.length >= 2).toList(growable: false);
   }
+
+  /// The aircraft's actual path projected onto the ground, never the chase
+  /// road route. This is the geometry the wider balloon viewport frames.
+  List<GeoPoint> get _balloonGroundTrackPoints => [
+    for (final trace in _visibleRiderTrails)
+      if (trace.kind == RiderTrailKind.balloonGroundTrack) ...trace.points,
+  ];
 
   Polyline _routePolyline(List<GeoPoint> path, RouteLineStyle style) =>
       Polyline(
@@ -4105,15 +4327,16 @@ class _RideMapScreenState extends State<RideMapScreen> {
     final selected = selectTrailDirectionArrows<_TrailArrowStyle>(
       sampler: _trailDirectionArrowSampler,
       sources: [
-        TrailDirectionArrowSource(
-          paths: _progressGeometry.remainingPaths,
-          reserve: _plannedRouteArrowReserve,
-          style: _TrailArrowStyle(
-            color: RouteTrailStyle.routeAhead.color,
-            idPrefix: 'route-ahead',
-            semanticLabel: 'Route direction',
+        if (!_isBalloonView)
+          TrailDirectionArrowSource(
+            paths: _progressGeometry.remainingPaths,
+            reserve: _plannedRouteArrowReserve,
+            style: _TrailArrowStyle(
+              color: RouteTrailStyle.routeAhead.color,
+              idPrefix: 'route-ahead',
+              semanticLabel: 'Route direction',
+            ),
           ),
-        ),
         for (final trace in byImportance)
           TrailDirectionArrowSource(
             paths: [trace.points],
@@ -4140,6 +4363,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     // The route-start connector is the rider's own live instruction, so its
     // direction arrows are the last thing the budget may drop.
     RiderTrailKind.routeStartConnector => 0,
+    RiderTrailKind.balloonGroundTrack => 1,
     RiderTrailKind.leader => 1,
     RiderTrailKind.rider => 3,
   };
@@ -4178,7 +4402,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
   };
 
   Map<String, dynamic> _waypointGeoJson() => MapGeoJson.points(
-    _route?.waypoints
+    (_isBalloonView ? null : _route)?.waypoints
             .take(500)
             .indexed
             .map(
@@ -4641,7 +4865,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         _effectivePosition,
       );
       _initialCameraPositioned = false;
-      if (_isMoving && !_autoFollowSuppressed) {
+      if (_shouldAutoFollow && !_autoFollowSuppressed) {
         _navigationMode = true;
         _navigationCanvasActive = true;
       }
@@ -4807,7 +5031,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
   /// fallback a route-less ride opened on a UK-wide overview and stayed there
   /// until the bike moved fast enough to arm the follow camera (#124).
   void _fitRoute() {
-    final planned = _route?.allPoints.toList(growable: false) ?? const [];
+    final planned = _isBalloonView
+        ? _balloonGroundTrackPoints
+        : _route?.allPoints.toList(growable: false) ?? const [];
     final routePoints = planned.isNotEmpty ? planned : [?_effectivePosition];
     if (_basemap.usesMapLibre) {
       final controller = _mapLibreController;
@@ -4818,7 +5044,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         if (!MapCameraCommand.isUsable(
           latitude: only.latitude,
           longitude: only.longitude,
-          zoom: 14,
+          zoom: _isBalloonView ? 11 : 14,
         )) {
           return;
         }
@@ -4826,7 +5052,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
           controller.animateCamera(
             ml.CameraUpdate.newLatLngZoom(
               ml.LatLng(only.latitude, only.longitude),
-              14,
+              _isBalloonView ? 11 : 14,
             ),
           ),
         );
@@ -4851,7 +5077,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     if (points.isEmpty) return;
     _initialCameraPositioned = true;
     if (points.length == 1) {
-      _mapController.move(points.single, 14);
+      _mapController.move(points.single, _isBalloonView ? 11 : 14);
     } else {
       _mapController.fitCamera(
         CameraFit.bounds(
@@ -5301,6 +5527,12 @@ class MapNavigationPosition {
     this.speedMetersPerSecond,
     this.headingDegrees,
     this.accuracyMeters,
+    this.altitudeMeters,
+    this.altitudeSource = AltitudeSource.unknown,
+    this.altitudeDatum = AltitudeDatum.unknown,
+    this.altitudeAccuracyMeters,
+    this.verticalSpeedMetersPerSecond,
+    this.altitudeRecordedAt,
   });
 
   final GeoPoint point;
@@ -5308,6 +5540,12 @@ class MapNavigationPosition {
   final double? speedMetersPerSecond;
   final double? headingDegrees;
   final double? accuracyMeters;
+  final double? altitudeMeters;
+  final AltitudeSource altitudeSource;
+  final AltitudeDatum altitudeDatum;
+  final double? altitudeAccuracyMeters;
+  final double? verticalSpeedMetersPerSecond;
+  final DateTime? altitudeRecordedAt;
 
   bool get isMoving => (speedMetersPerSecond ?? 0) >= 2.5;
 
@@ -5319,7 +5557,13 @@ class MapNavigationPosition {
       recordedAt == other.recordedAt &&
       speedMetersPerSecond == other.speedMetersPerSecond &&
       headingDegrees == other.headingDegrees &&
-      accuracyMeters == other.accuracyMeters;
+      accuracyMeters == other.accuracyMeters &&
+      altitudeMeters == other.altitudeMeters &&
+      altitudeSource == other.altitudeSource &&
+      altitudeDatum == other.altitudeDatum &&
+      altitudeAccuracyMeters == other.altitudeAccuracyMeters &&
+      verticalSpeedMetersPerSecond == other.verticalSpeedMetersPerSecond &&
+      altitudeRecordedAt == other.altitudeRecordedAt;
 
   @override
   int get hashCode => Object.hash(
@@ -5329,6 +5573,12 @@ class MapNavigationPosition {
     speedMetersPerSecond,
     headingDegrees,
     accuracyMeters,
+    altitudeMeters,
+    altitudeSource,
+    altitudeDatum,
+    altitudeAccuracyMeters,
+    verticalSpeedMetersPerSecond,
+    altitudeRecordedAt,
   );
 }
 
@@ -7665,6 +7915,232 @@ class _EnforcementEmphasis extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _AeronauticalChartBadge extends StatelessWidget {
+  const _AeronauticalChartBadge({
+    required this.configuration,
+    required this.now,
+    required this.onTap,
+  });
+
+  final AeronauticalChartConfiguration configuration;
+  final DateTime now;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final current = configuration.isCurrentAt(now);
+    return Semantics(
+      button: true,
+      label: configuration.explanationAt(now),
+      child: Material(
+        key: const Key('aeronautical-chart-status'),
+        color: current ? const Color(0xE6252E39) : const Color(0xE63B3030),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 170),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        current ? Icons.layers_outlined : Icons.layers_clear,
+                        size: 16,
+                        color: current
+                            ? const Color(0xFF6ED89A)
+                            : const Color(0xFFFFC857),
+                      ),
+                      const SizedBox(width: 6),
+                      Flexible(
+                        child: Text(
+                          configuration.statusLabelAt(now),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 10,
+                            fontWeight: FontWeight.w800,
+                            letterSpacing: 0.4,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (current) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      configuration.attribution,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFFC6D0DA),
+                        fontSize: 9,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BalloonAltitudeCard extends StatelessWidget {
+  const _BalloonAltitudeCard({required this.fix, required this.distanceUnit});
+
+  final MapNavigationPosition? fix;
+  final DistanceUnit distanceUnit;
+
+  @override
+  Widget build(BuildContext context) {
+    final reading = fix;
+    final altitude = reading?.altitudeMeters;
+    final age = reading == null
+        ? null
+        : DateTime.now()
+              .difference(reading.altitudeRecordedAt ?? reading.recordedAt)
+              .abs();
+    final primary = altitude == null
+        ? 'Altitude unavailable'
+        : distanceUnit == DistanceUnit.miles
+        ? '${(altitude * 3.28084).round()} ft'
+        : '${altitude.round()} m';
+    final trend = _trend(reading?.verticalSpeedMetersPerSecond);
+    final accuracy = reading?.altitudeAccuracyMeters;
+    final details = [
+      if (reading != null && altitude != null) _source(reading.altitudeSource),
+      if (reading != null && altitude != null) _datum(reading.altitudeDatum),
+      if (accuracy != null)
+        distanceUnit == DistanceUnit.miles
+            ? '±${(accuracy * 3.28084).round()} ft'
+            : '±${accuracy.round()} m',
+      if (age != null) _age(age),
+    ];
+    return Semantics(
+      container: true,
+      label: [
+        'Balloon altitude $primary',
+        ?trend,
+        ...details,
+        'Not terrain clearance',
+      ].join(', '),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 248),
+        child: Card(
+          key: const Key('balloon-altitude-card'),
+          color: const Color(0xE6252E39),
+          margin: EdgeInsets.zero,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(14, 11, 14, 10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'BALLOON ALTITUDE',
+                  style: TextStyle(
+                    color: Color(0xFF9EABB9),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0.8,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
+                  children: [
+                    Flexible(
+                      child: Text(
+                        primary,
+                        key: const Key('balloon-altitude-value'),
+                        style: Theme.of(context).textTheme.headlineSmall
+                            ?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w800,
+                            ),
+                      ),
+                    ),
+                    if (trend != null) ...[
+                      const SizedBox(width: 10),
+                      Text(
+                        trend,
+                        key: const Key('balloon-vertical-trend'),
+                        style: const TextStyle(
+                          color: Color(0xFF6ED89A),
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                if (details.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    details.join(' · '),
+                    key: const Key('balloon-altitude-quality'),
+                    style: const TextStyle(
+                      color: Color(0xFFD3DAE2),
+                      fontSize: 11,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 3),
+                const Text(
+                  'Not terrain clearance',
+                  style: TextStyle(color: Color(0xFFFFC857), fontSize: 10),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String? _trend(double? metresPerSecond) {
+    if (metresPerSecond == null) return null;
+    final arrow = metresPerSecond > 0.15
+        ? '↑'
+        : metresPerSecond < -0.15
+        ? '↓'
+        : '→';
+    final magnitude = metresPerSecond.abs();
+    return distanceUnit == DistanceUnit.miles
+        ? '$arrow ${(magnitude * 196.8504).round()} ft/min'
+        : '$arrow ${magnitude.toStringAsFixed(1)} m/s';
+  }
+
+  static String _source(AltitudeSource source) => switch (source) {
+    AltitudeSource.gnss => 'GNSS',
+    AltitudeSource.barometric => 'barometric',
+    AltitudeSource.unknown => 'source unknown',
+  };
+
+  static String _datum(AltitudeDatum datum) => switch (datum) {
+    AltitudeDatum.wgs84Geoid => 'MSL geoid',
+    AltitudeDatum.wgs84Ellipsoid => 'WGS84 ellipsoid',
+    AltitudeDatum.relativeToLaunch => 'relative to launch',
+    AltitudeDatum.unknown => 'datum unknown',
+  };
+
+  static String _age(Duration age) {
+    if (age.inSeconds < 2) return 'fix now';
+    if (age.inMinutes < 1) return 'fix ${age.inSeconds}s ago';
+    if (age.inHours < 1) return 'fix ${age.inMinutes}m ago';
+    return 'fix ${age.inHours}h ago';
   }
 }
 

--- a/apps/mobile/lib/features/map/route_trail_style.dart
+++ b/apps/mobile/lib/features/map/route_trail_style.dart
@@ -148,6 +148,15 @@ class RouteTrailStyle {
     casingWidthPixels: 12,
   );
 
+  /// The balloon's travelled path over the ground. Bright cyan remains legible
+  /// over both configured basemap themes; the extra width and direction arrows
+  /// are the non-colour cue that distinguishes it from chase trails.
+  static const balloonGroundTrack = RouteLineStyle(
+    color: Color(0xFF00E5FF),
+    widthPixels: 7,
+    casingWidthPixels: 11,
+  );
+
   /// The road route to the start of the planned route (#133), which claimed this
   /// cyan and renders it dashed. Declared here so the palette stays one table and
   /// the widths and dash runs stay distinct from every other line.
@@ -174,6 +183,7 @@ class RouteTrailStyle {
   static RouteLineStyle forTrail(RiderTrailKind kind) => switch (kind) {
     RiderTrailKind.rider => travelled,
     RiderTrailKind.leader => leaderTrail,
+    RiderTrailKind.balloonGroundTrack => balloonGroundTrack,
     RiderTrailKind.routeStartConnector => routeStartConnectorLine,
   };
 
@@ -228,6 +238,7 @@ class RouteTrailStyle {
     'route ahead': routeAhead,
     'travelled': travelled,
     'leader trail': leaderTrail,
+    'balloon ground track': balloonGroundTrack,
     'route start connector': routeStartConnectorLine,
   };
 

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -2035,6 +2035,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }) {
     final awareness = _awarenessController;
     if (awareness == null) return;
+    final balloonDeviceIds = _isSimulation
+        ? const <String>{}
+        : (widget.rideController
+                  .resolveCraftRoster()
+                  .balloon
+                  ?.deviceIds
+                  .toSet() ??
+              const <String>{});
     // One reconciled model for both ride phases and both transports, so nobody
     // disappears at the `rideStarted` transition, a late joiner appears at once,
     // and the count can never disagree with the drawn markers (#132).
@@ -2090,12 +2098,23 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         ? route_domain.GeoPoint(
             latitude: simulatedLocal.position.latitude,
             longitude: simulatedLocal.position.longitude,
+            elevationMeters: localMapSample?.altitudeMeters,
+            altitudeSource:
+                localMapSample?.altitudeSource ?? AltitudeSource.unknown,
+            altitudeDatum:
+                localMapSample?.altitudeDatum ?? AltitudeDatum.unknown,
+            altitudeAccuracyMeters: localMapSample?.altitudeAccuracyMeters,
+            recordedAt: localMapSample?.recordedAt,
           )
         : localMapSample == null
         ? null
         : route_domain.GeoPoint(
             latitude: localMapSample.position.latitude,
             longitude: localMapSample.position.longitude,
+            elevationMeters: localMapSample.altitudeMeters,
+            altitudeSource: localMapSample.altitudeSource,
+            altitudeDatum: localMapSample.altitudeDatum,
+            altitudeAccuracyMeters: localMapSample.altitudeAccuracyMeters,
             recordedAt: localMapSample.recordedAt,
           );
     final navigationRecordedAt = simulatedLocal == null
@@ -2127,6 +2146,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                   simulatedLocal?.headingDegrees ??
                   localMapSample!.headingDegrees,
               accuracyMeters: localMapSample?.accuracyMeters,
+              altitudeMeters: localMapSample?.altitudeMeters,
+              altitudeSource:
+                  localMapSample?.altitudeSource ?? AltitudeSource.unknown,
+              altitudeDatum:
+                  localMapSample?.altitudeDatum ?? AltitudeDatum.unknown,
+              altitudeAccuracyMeters: localMapSample?.altitudeAccuracyMeters,
+              verticalSpeedMetersPerSecond:
+                  localMapSample?.verticalSpeedMetersPerSecond,
+              altitudeRecordedAt: localMapSample?.recordedAt,
             );
       _mapPosition.value = mapPoint;
     }
@@ -2173,7 +2201,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                         riderId: location.riderId,
                         displayName: location.displayName,
                         role: location.role,
-                        motorcycleStyle: location.motorcycleStyle,
+                        motorcycleStyle:
+                            balloonDeviceIds.contains(location.riderId)
+                            ? CraftIconStyle.balloon
+                            : location.motorcycleStyle,
                         riderSymbol: location.riderSymbol,
                         riderColor: location.riderColor,
                         point: route_domain.GeoPoint(
@@ -2190,7 +2221,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                         riderId: rider.id,
                         displayName: rider.displayName,
                         role: rider.role,
-                        motorcycleStyle: rider.motorcycleStyle,
+                        motorcycleStyle: rider.role == RideRole.lead
+                            ? CraftIconStyle.balloon
+                            : rider.motorcycleStyle,
                         riderSymbol: rider.riderSymbol,
                         riderColor: rider.riderColor,
                         point: route_domain.GeoPoint(
@@ -2201,6 +2234,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                     ))
           .map((location) {
             final isLead = location.role == RideRole.lead;
+            final isBalloonCraft = _isSimulation
+                ? isLead
+                : balloonDeviceIds.contains(location.riderId);
             // A position past its freshness threshold is demoted explicitly in
             // the label. The identity fill remains stable across surfaces.
             final freshness =
@@ -2219,6 +2255,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             final raised = quickMessagesBySender[location.riderId];
             final roleSuffix = raised != null
                 ? raised.label
+                : isBalloonCraft
+                ? 'Balloon'
                 : isLead
                 ? 'Lead'
                 : null;
@@ -2583,19 +2621,28 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   /// Ride Lab drives the same trail model as a real ride, so the simulator can
   /// no longer show a leader track the live path never builds (#100).
-  void _updateSimulationRiderTrails(
-    List<SimulatedRiderSnapshot> riders,
-  ) => _publishRiderTrails([
-    for (final rider in riders)
-      RiderTrail(
-        riderId: rider.id,
-        displayName: rider.displayName,
-        kind: RiderTrailRecorder.kindFor(isLeader: rider.role == RideRole.lead),
-        // Ride Lab maintains its own ephemeral history; the same per-rider
-        // cap is applied here so the simulator and a real ride agree.
-        points: _trailRecorder.boundedTrail(_routePoints(rider.travelTrail)),
-      ),
-  ]);
+  void _updateSimulationRiderTrails(List<SimulatedRiderSnapshot> riders) {
+    final balloonSamples =
+        _awarenessController?.leaderLocationSamples ?? const <LocationSample>[];
+    _publishRiderTrails([
+      for (final rider in riders)
+        RiderTrail(
+          riderId: rider.id,
+          displayName: rider.displayName,
+          kind: rider.role == RideRole.lead
+              ? RiderTrailKind.balloonGroundTrack
+              : RiderTrailKind.rider,
+          // The balloon uses its authenticated emitted fixes rather than the
+          // chase route's synthetic display trail. Besides showing where it
+          // really drifted, this retains altitude metadata for the map.
+          points: _trailRecorder.boundedTrail(
+            rider.role == RideRole.lead
+                ? _locationSamplePoints(balloonSamples)
+                : _routePoints(rider.travelTrail),
+          ),
+        ),
+    ]);
+  }
 
   /// Records and publishes every eligible rider's travelled trail from position
   /// history alone.
@@ -2611,6 +2658,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       _publishRiderTrails(const []);
       return;
     }
+    final balloonDeviceIds =
+        widget.rideController.resolveCraftRoster().balloon?.deviceIds.toSet() ??
+        const <String>{};
     _publishRiderTrails(
       _trailRecorder.update([
         for (final location in awareness.riderLocations)
@@ -2620,9 +2670,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             position: route_domain.GeoPoint(
               latitude: location.sample.position.latitude,
               longitude: location.sample.position.longitude,
+              elevationMeters: location.sample.altitudeMeters,
+              altitudeSource: location.sample.altitudeSource,
+              altitudeDatum: location.sample.altitudeDatum,
+              altitudeAccuracyMeters: location.sample.altitudeAccuracyMeters,
               recordedAt: location.sample.recordedAt,
             ),
             isLeader: location.role == RideRole.lead,
+            isBalloon: balloonDeviceIds.contains(location.riderId),
             isEligible:
                 widget.rideController
                     .participantFor(location.riderId)
@@ -2630,10 +2685,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 true,
             journalTrail: location.role == RideRole.lead
                 ? [
-                    for (final sample in awareness.leaderTrailSamples)
+                    for (final sample in awareness.leaderLocationSamples)
                       route_domain.GeoPoint(
                         latitude: sample.position.latitude,
                         longitude: sample.position.longitude,
+                        elevationMeters: sample.altitudeMeters,
+                        altitudeSource: sample.altitudeSource,
+                        altitudeDatum: sample.altitudeDatum,
+                        altitudeAccuracyMeters: sample.altitudeAccuracyMeters,
                         recordedAt: sample.recordedAt,
                       ),
                   ]
@@ -2653,6 +2712,21 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       ),
   ];
 
+  static List<route_domain.GeoPoint> _locationSamplePoints(
+    Iterable<LocationSample> samples,
+  ) => [
+    for (final sample in samples)
+      route_domain.GeoPoint(
+        latitude: sample.position.latitude,
+        longitude: sample.position.longitude,
+        elevationMeters: sample.altitudeMeters,
+        altitudeSource: sample.altitudeSource,
+        altitudeDatum: sample.altitudeDatum,
+        altitudeAccuracyMeters: sample.altitudeAccuracyMeters,
+        recordedAt: sample.recordedAt,
+      ),
+  ];
+
   void _publishRiderTrails(List<RiderTrail> trails) {
     _recordedTrailTraces = List.unmodifiable([
       for (final trail in trails.where((trail) => trail.isRenderable))
@@ -2668,6 +2742,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             points: points,
             label: switch (trail.kind) {
               RiderTrailKind.leader => '${trail.displayName} leader trail',
+              RiderTrailKind.balloonGroundTrack =>
+                '${trail.displayName} balloon ground track',
               RiderTrailKind.rider => '${trail.displayName} trail',
               // RiderTrailRecorder only records where riders have been, so it
               // never produces a route-start connector; the map composes that
@@ -3256,10 +3332,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (routeStore == null) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
+    final session = widget.rideController.session;
+    final isBalloonView = _isSimulation
+        ? session?.role == RideRole.lead
+        : widget.rideController.localCraft?.isBalloon == true;
     return RideMapFeature.fromEnvironment(
       key: ValueKey(
         'ride-map:${_appliedAuthoritativeRouteRevision ?? 'local'}:'
-        '${_activeRoute?.id ?? 'none'}',
+        '${_activeRoute?.id ?? 'none'}:'
+        '${isBalloonView ? 'balloon' : 'chase'}',
       ),
       currentPosition: _mapPosition,
       completedRideStore: widget.completedRideStore,
@@ -3270,7 +3351,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       onOpenRoster: _openRoster,
       // Deliberately not `onOpenRideMenu`. The control that reaches the other
       // tabs is rendered by this shell instead — see _openRideMenu and #404.
-      enforcementAlert: _enforcementAlert,
+      enforcementAlert: isBalloonView ? null : _enforcementAlert,
       rideCompletionSuggestion: _rideCompletionSuggestion,
       onEndRideForEveryone: _endRideFromCompletionSuggestion,
       onDismissRideCompletion: _dismissRideCompletionSuggestion,
@@ -3285,7 +3366,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       initialRouteStartConnector: _routeStartConnector,
       onRouteStartConnectorChanged: (connector) =>
           _routeStartConnector = connector,
-      onReportHazard: _awarenessController == null
+      onReportHazard: isBalloonView || _awarenessController == null
           ? null
           : _reportHazardFromMap,
       emergencyContacts: _emergencyContacts,
@@ -3297,11 +3378,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       rideStarted: widget.rideController.rideStarted,
       onLeaveRide: _confirmLeaveRideFromMap,
       onRouteCommitted: _onRouteChanged,
-      onNavigationGuidanceChanged: _onNavigationGuidanceChanged,
-      onNavigationViewportChanged: (viewport) {
-        final bridge = _carPlayBridge;
-        if (bridge != null) unawaited(bridge.publishViewport(viewport));
-      },
+      onNavigationGuidanceChanged: isBalloonView
+          ? null
+          : _onNavigationGuidanceChanged,
+      onNavigationViewportChanged: isBalloonView
+          ? null
+          : (viewport) {
+              final bridge = _carPlayBridge;
+              if (bridge != null) unawaited(bridge.publishViewport(viewport));
+            },
       onMapStyleResolved: (styleJson) {
         if (!mounted) return;
         _carPlayMapStyleJson = styleJson;
@@ -3329,23 +3414,29 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           ? () async => _mapPosition.value
           : _acquireCurrentPosition,
       routeStore: routeStore,
-      canEditRoute: _isSimulation || widget.rideController.isLocalRideLeader,
+      canEditRoute:
+          !isBalloonView &&
+          (_isSimulation || widget.rideController.isLocalRideLeader),
       distanceUnit: widget.distanceUnits.value,
-      speedLimitDisplay: widget.speedLimitDisplay,
+      speedLimitDisplay: isBalloonView ? null : widget.speedLimitDisplay,
       chaseVehicle: widget.chaseVehicle?.vehicle ?? ChaseVehicle.unspecified,
-      showRouteProgress: widget.routeProgressDisplay?.enabled ?? true,
+      showRouteProgress:
+          !isBalloonView && (widget.routeProgressDisplay?.enabled ?? true),
       darkMapStyle: widget.mapStyleMode.resolveDark(
         MediaQuery.platformBrightnessOf(context),
       ),
       restrainedLightMapStyle:
           widget.mapStyleMode.dayStyle == DayMapStyle.restrained,
-      localMotorcycleStyle:
-          widget.rideController.session?.motorcycleStyle ??
-          craftIconStyleDefault,
+      localMotorcycleStyle: isBalloonView
+          ? CraftIconStyle.balloon
+          : session?.motorcycleStyle ?? craftIconStyleDefault,
       localRiderSymbol:
           widget.rideController.session?.riderSymbol ?? riderSymbolDefault,
       localDisplayName: widget.rideController.session?.displayName ?? 'You',
       localBadgeColor: _localBadgeColor,
+      perspective: isBalloonView
+          ? RideMapPerspective.balloon
+          : RideMapPerspective.chase,
     );
   }
 
@@ -4553,6 +4644,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final controller = _simulationController;
     if (controller == null) return;
     controller.setLocalRole(role);
+    if (role == RideRole.lead) {
+      _latestNavigationGuidance = null;
+      _guidanceManeuverIdentity = null;
+      _lastGuidanceManeuverPosition = null;
+      _passedManeuverPosition = null;
+      unawaited(_spokenGuidance?.stop());
+    }
     await widget.rideController.setRole(role);
   }
 

--- a/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
+++ b/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
@@ -7,6 +7,7 @@ import '../../domain/distance_unit.dart';
 import '../../domain/ride_role.dart';
 import '../../domain/ride_session.dart';
 import '../../services/measurement_formatter.dart';
+import '../map/craft_icon.dart';
 
 class RideSimulationScreen extends StatelessWidget {
   const RideSimulationScreen({
@@ -122,7 +123,7 @@ class _SimulationControls extends StatelessWidget {
                 const SizedBox(width: 10),
                 Expanded(
                   child: Text(
-                    'SYNTHETIC RIDE',
+                    'SYNTHETIC FLIGHT',
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
                 ),
@@ -152,13 +153,21 @@ class _SimulationControls extends StatelessWidget {
               segments: const [
                 ButtonSegment(
                   value: RideRole.lead,
-                  icon: Icon(Icons.flag_outlined),
-                  label: Text('Leader'),
+                  icon: CraftIcon(
+                    style: CraftIconStyle.balloon,
+                    color: Colors.white,
+                    size: 22,
+                  ),
+                  label: Text('Balloon'),
                 ),
                 ButtonSegment(
                   value: RideRole.rider,
-                  icon: Icon(Icons.two_wheeler),
-                  label: Text('Follower'),
+                  icon: CraftIcon(
+                    style: CraftIconStyle.fourByFour,
+                    color: Colors.white,
+                    size: 22,
+                  ),
+                  label: Text('Chase'),
                 ),
               ],
               selected: {controller.localRole},
@@ -316,11 +325,14 @@ class _FleetCard extends StatelessWidget {
           for (final rider in controller.riders) ...[
             Row(
               children: [
-                Icon(
-                  rider.isLocal ? Icons.navigation : Icons.two_wheeler,
+                CraftIcon(
+                  style: rider.role == RideRole.lead
+                      ? CraftIconStyle.balloon
+                      : rider.motorcycleStyle,
                   color: rider.isOffRoute
                       ? const Color(0xFFFF4FA3)
                       : const Color(0xFF6ED89A),
+                  size: 24,
                 ),
                 const SizedBox(width: 10),
                 Expanded(

--- a/apps/mobile/lib/services/aeronautical_chart_configuration.dart
+++ b/apps/mobile/lib/services/aeronautical_chart_configuration.dart
@@ -1,0 +1,110 @@
+enum AeronauticalTileScheme {
+  xyz('xyz'),
+  tms('tms');
+
+  const AeronauticalTileScheme(this.mapLibreValue);
+
+  final String mapLibreValue;
+}
+
+/// The selected, timestamped advisory aeronautical chart.
+///
+/// OpenAIP is deliberately presented as an advisory community layer. UK
+/// temporary restrictions and NOTAMs still require an official briefing, and a
+/// tester build stops rendering the layer once its configuration is stale.
+class AeronauticalChartConfiguration {
+  const AeronauticalChartConfiguration({
+    this.tileUrlTemplate = '',
+    this.providerName = '',
+    this.attribution = '',
+    this.effectiveAt,
+    this.expiresAt,
+    this.limitations = '',
+    this.tileScheme = AeronauticalTileScheme.xyz,
+  });
+
+  factory AeronauticalChartConfiguration.openAip({
+    required String apiKey,
+    required DateTime? configuredAt,
+  }) {
+    final key = apiKey.trim();
+    final configured = configuredAt?.toUtc();
+    return AeronauticalChartConfiguration(
+      tileUrlTemplate: key.isEmpty
+          ? ''
+          : 'https://api.tiles.openaip.net/api/data/openaip/'
+                '{z}/{x}/{y}.png?apiKey=${Uri.encodeQueryComponent(key)}',
+      providerName: 'openAIP',
+      attribution: '© openAIP contributors · CC BY-NC 4.0',
+      effectiveAt: configured,
+      expiresAt: configured?.add(const Duration(days: 28)),
+      limitations:
+          'Advisory community data. It may be incomplete or omit current '
+          'NOTAMs and temporary restrictions. Verify the official NATS AIS '
+          'briefing before flight. Not for primary navigation.',
+      tileScheme: AeronauticalTileScheme.tms,
+    );
+  }
+
+  factory AeronauticalChartConfiguration.fromEnvironment() =>
+      AeronauticalChartConfiguration.openAip(
+        apiKey: const String.fromEnvironment('BALLOON_CRUMBS_OPENAIP_API_KEY'),
+        configuredAt: DateTime.tryParse(
+          const String.fromEnvironment('BALLOON_CRUMBS_BUILD_TIMESTAMP'),
+        ),
+      );
+
+  final String tileUrlTemplate;
+  final String providerName;
+  final String attribution;
+  final DateTime? effectiveAt;
+  final DateTime? expiresAt;
+  final String limitations;
+  final AeronauticalTileScheme tileScheme;
+
+  bool get usesTms => tileScheme == AeronauticalTileScheme.tms;
+
+  bool get isComplete =>
+      tileUrlTemplate.isNotEmpty &&
+      tileUrlTemplate.contains('{z}') &&
+      tileUrlTemplate.contains('{x}') &&
+      tileUrlTemplate.contains('{y}') &&
+      providerName.isNotEmpty &&
+      attribution.isNotEmpty &&
+      limitations.isNotEmpty &&
+      effectiveAt != null &&
+      expiresAt != null &&
+      expiresAt!.isAfter(effectiveAt!);
+
+  bool isCurrentAt(DateTime now) {
+    if (!isComplete) return false;
+    final utc = now.toUtc();
+    return !utc.isBefore(effectiveAt!) && utc.isBefore(expiresAt!);
+  }
+
+  String statusLabelAt(DateTime now) {
+    if (!isComplete) return 'AIRSPACE UNAVAILABLE';
+    if (!isCurrentAt(now)) return 'AIRSPACE STALE';
+    return 'AIRSPACE · $providerName';
+  }
+
+  String explanationAt(DateTime now) {
+    if (!isComplete) {
+      return 'No licensed, dated aeronautical chart source is configured. '
+          'Check the current official AIP and NOTAM briefing before flight.';
+    }
+    final validity =
+        'Configured ${_date(effectiveAt!)}; refresh by ${_date(expiresAt!)} UTC.';
+    if (!isCurrentAt(now)) {
+      return '$providerName chart configuration is stale. $validity '
+          'It is hidden until refreshed. $limitations';
+    }
+    return '$providerName. $validity $limitations';
+  }
+
+  static String _date(DateTime value) {
+    final utc = value.toUtc();
+    String two(int part) => part.toString().padLeft(2, '0');
+    return '${utc.year}-${two(utc.month)}-${two(utc.day)}';
+  }
+}

--- a/apps/mobile/lib/services/rider_trail_recorder.dart
+++ b/apps/mobile/lib/services/rider_trail_recorder.dart
@@ -14,6 +14,12 @@ enum RiderTrailKind {
   /// and is rendered on every participant's map.
   leader,
 
+  /// The aircraft's travelled path projected onto the ground.
+  ///
+  /// Kept separate from the inherited leader trail so it cannot disappear
+  /// underneath a road route or be mistaken for a chase vehicle's path.
+  balloonGroundTrack,
+
   /// The road route from where the rider is to the start of the planned route
   /// (#133). The one kind that is not recorded history: it is where the routing
   /// engine says to go next, which is why it is never produced by
@@ -51,6 +57,7 @@ class RiderTrailUpdate {
     required this.displayName,
     this.position,
     this.isLeader = false,
+    this.isBalloon = false,
     this.isEligible = true,
     this.journalTrail,
   });
@@ -62,6 +69,7 @@ class RiderTrailUpdate {
   final GeoPoint? position;
 
   final bool isLeader;
+  final bool isBalloon;
 
   /// Whether the rider's route alert says they are off route. Styling only.
 
@@ -169,7 +177,7 @@ class RiderTrailRecorder {
         RiderTrail(
           riderId: rider.riderId,
           displayName: rider.displayName,
-          kind: kindFor(isLeader: rider.isLeader),
+          kind: kindFor(isLeader: rider.isLeader, isBalloon: rider.isBalloon),
           points: journal != null && journal.length > recorded.length
               ? boundedTrail(journal)
               : recorded,
@@ -212,8 +220,14 @@ class RiderTrailRecorder {
 
   /// The leader's trail is the group's ground truth, so it is styled apart from
   /// every other craft's.
-  static RiderTrailKind kindFor({required bool isLeader}) =>
-      isLeader ? RiderTrailKind.leader : RiderTrailKind.rider;
+  static RiderTrailKind kindFor({
+    required bool isLeader,
+    bool isBalloon = false,
+  }) => isBalloon
+      ? RiderTrailKind.balloonGroundTrack
+      : isLeader
+      ? RiderTrailKind.leader
+      : RiderTrailKind.rider;
 
   /// Records [point] for [riderId] and reports whether it extended the trail.
   ///

--- a/apps/mobile/test/controllers/situational_awareness_controller_test.dart
+++ b/apps/mobile/test/controllers/situational_awareness_controller_test.dart
@@ -42,6 +42,28 @@ void main() {
     );
   });
 
+  test('the balloon trail retains complete altitude evidence', () async {
+    await controller.recordLocalLocation(
+      LocationSample(
+        position: const GeoPoint(latitude: 51.002, longitude: -0.995),
+        recordedAt: now,
+        accuracyMeters: 5,
+        altitudeMeters: 226,
+        altitudeSource: AltitudeSource.gnss,
+        altitudeDatum: AltitudeDatum.wgs84Geoid,
+        altitudeAccuracyMeters: 6,
+        verticalSpeedMetersPerSecond: 1.2,
+      ),
+    );
+
+    final fix = controller.leaderLocationSamples.single;
+    expect(fix.altitudeMeters, 226);
+    expect(fix.altitudeSource, AltitudeSource.gnss);
+    expect(fix.altitudeDatum, AltitudeDatum.wgs84Geoid);
+    expect(fix.altitudeAccuracyMeters, 6);
+    expect(fix.verticalSpeedMetersPerSecond, 1.2);
+  });
+
   test(
     'stored situational events are projected into the shared journal',
     () async {

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:balloon_crumbs/domain/altitude.dart';
+import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/domain/route_store.dart';
+import 'package:balloon_crumbs/features/map/craft_icon.dart';
+import 'package:balloon_crumbs/features/map/ride_map.dart';
+import 'package:balloon_crumbs/services/basemap_configuration.dart';
+import 'package:balloon_crumbs/services/gpx_import_source.dart';
+import 'package:balloon_crumbs/services/offline_tile_cache.dart';
+import 'package:balloon_crumbs/services/route_importer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  testWidgets(
+    'balloon map shows aircraft telemetry and suppresses driving chrome',
+    (tester) async {
+      final directory = Directory.systemTemp.createTempSync('balloon-map');
+      addTearDown(() => directory.deleteSync(recursive: true));
+      final navigation = ValueNotifier<MapNavigationPosition?>(
+        MapNavigationPosition(
+          point: const GeoPoint(latitude: 51.43, longitude: -2.70),
+          recordedAt: DateTime.now(),
+          speedMetersPerSecond: 7,
+          headingDegrees: 245,
+          accuracyMeters: 4,
+          altitudeMeters: 226,
+          altitudeSource: AltitudeSource.gnss,
+          altitudeDatum: AltitudeDatum.relativeToLaunch,
+          altitudeAccuracyMeters: 6,
+          verticalSpeedMetersPerSecond: 1.2,
+        ),
+      );
+      final trails = ValueNotifier<List<MapOverlayTrace>>([
+        const MapOverlayTrace(
+          id: 'balloon-track',
+          label: 'Balloon ground track',
+          kind: RiderTrailKind.balloonGroundTrack,
+          points: [
+            GeoPoint(latitude: 51.4459, longitude: -2.6413),
+            GeoPoint(latitude: 51.43, longitude: -2.70),
+          ],
+        ),
+      ]);
+      addTearDown(navigation.dispose);
+      addTearDown(trails.dispose);
+      final cache = OfflineTileCache(
+        rootDirectory: directory,
+        configuration: const BasemapConfiguration(),
+        httpClient: MockClient((_) async => http.Response('', 404)),
+      );
+      addTearDown(cache.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: RideMapScreen(
+            routeStore: InMemoryRouteStore(_roadRoute),
+            routeImporter: RouteImporter(source: const _NoFileSource()),
+            offlineTileCache: cache,
+            navigationPosition: navigation,
+            riderTrails: trails,
+            rideStarted: true,
+            perspective: RideMapPerspective.balloon,
+            localMotorcycleStyle: CraftIconStyle.fourByFour,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('balloon-altitude-card')), findsOneWidget);
+      expect(find.text('226 m'), findsOneWidget);
+      expect(find.textContaining('↑ 1.2 m/s'), findsOneWidget);
+      expect(find.textContaining('GNSS'), findsOneWidget);
+      expect(find.textContaining('relative to launch'), findsOneWidget);
+      expect(find.text('Not terrain clearance'), findsOneWidget);
+      expect(
+        find.byKey(const Key('aeronautical-chart-status')),
+        findsOneWidget,
+      );
+      expect(find.text('AIRSPACE UNAVAILABLE'), findsOneWidget);
+
+      final trackLayer = tester.widget<PolylineLayer>(
+        find.byType(PolylineLayer),
+      );
+      expect(
+        trackLayer.polylines.any(
+          (line) => line.color == RouteTrailStyle.balloonGroundTrack.color,
+        ),
+        isTrue,
+      );
+      expect(
+        trackLayer.polylines.any(
+          (line) => line.color == RouteTrailStyle.routeAhead.color,
+        ),
+        isFalse,
+        reason: 'the balloon viewport must not draw the chase road route',
+      );
+
+      for (final key in const [
+        'posted-speed-limit-position',
+        'speed-compass-cluster',
+        'navigation-guidance-banner',
+        'navigation-guidance-status-banner',
+        'route-start-guidance-banner',
+        'route-progress-panel-position',
+      ]) {
+        expect(find.byKey(Key(key)), findsNothing);
+      }
+
+      final markerBadges = tester.widgetList<RiderMarkerBadge>(
+        find.byType(RiderMarkerBadge),
+      );
+      expect(
+        markerBadges.any((badge) => badge.style == CraftIconStyle.balloon),
+        isTrue,
+        reason: 'the local aircraft must not inherit the profile 4x4 marker',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+}
+
+final _roadRoute = ImportedRoute(
+  id: 'chase-road',
+  name: 'Chase road route',
+  importedAt: DateTime.utc(2026, 8, 20),
+  sourceFileName: 'chase.gpx',
+  paths: const [
+    RoutePath(
+      kind: RoutePathKind.route,
+      points: [
+        GeoPoint(latitude: 51.4459, longitude: -2.6413),
+        GeoPoint(latitude: 51.4128, longitude: -2.7585),
+      ],
+    ),
+  ],
+  waypoints: const [],
+  maneuvers: const [
+    RouteManeuver(
+      position: GeoPoint(latitude: 51.43, longitude: -2.70),
+      type: 'turn',
+      modifier: 'right',
+      name: 'Road the balloon must not follow',
+    ),
+  ],
+);
+
+class _NoFileSource implements GpxImportSource {
+  const _NoFileSource();
+
+  @override
+  Future<PickedGpxFile?> pickGpxFile() async => null;
+}

--- a/apps/mobile/test/features/map/route_trail_style_test.dart
+++ b/apps/mobile/test/features/map/route_trail_style_test.dart
@@ -19,6 +19,7 @@ void main() {
       'route ahead': (4.11, 9.54, 10.27),
       'travelled': (2.81, 6.52, 7.02),
       'leader trail': (4.22, 9.78, 10.53),
+      'balloon ground track': (4.77, 11.06, 11.91),
       'route start connector': (4.77, 11.06, 11.91),
     };
 

--- a/apps/mobile/test/features/ride_simulation_screen_test.dart
+++ b/apps/mobile/test/features/ride_simulation_screen_test.dart
@@ -126,7 +126,8 @@ void main() {
     expect(find.text('Charlie'), findsOneWidget);
     expect(find.byKey(const Key('simulation-off-route')), findsOneWidget);
     expect(find.byKey(const Key('simulation-role')), findsOneWidget);
-    expect(find.text('Follower'), findsOneWidget);
+    expect(find.text('Chase'), findsOneWidget);
+    expect(find.text('Balloon'), findsOneWidget);
     expect(find.byKey(const Key('simulation-rider-count')), findsOneWidget);
 
     await tester.ensureVisible(find.byKey(const Key('simulation-off-route')));
@@ -135,8 +136,8 @@ void main() {
     await tester.pump();
     expect(simulation.alexOffRoute, isTrue);
 
-    await tester.ensureVisible(find.text('Follower'));
-    await tester.tap(find.text('Follower'));
+    await tester.ensureVisible(find.text('Chase'));
+    await tester.tap(find.text('Chase'));
     await tester.pump();
     expect(simulation.localRole, RideRole.rider);
 

--- a/apps/mobile/test/services/aeronautical_chart_configuration_test.dart
+++ b/apps/mobile/test/services/aeronautical_chart_configuration_test.dart
@@ -1,0 +1,86 @@
+import 'package:balloon_crumbs/services/aeronautical_chart_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final effective = DateTime.utc(2026, 8, 6);
+  final expires = DateTime.utc(2026, 9, 3);
+
+  AeronauticalChartConfiguration chart() => AeronauticalChartConfiguration(
+    tileUrlTemplate: 'https://charts.example/{z}/{x}/{y}.png',
+    providerName: 'Test AIS',
+    attribution: 'Test AIS chart data',
+    effectiveAt: effective,
+    expiresAt: expires,
+    limitations: 'Check current NOTAMs. Not for primary navigation.',
+  );
+
+  test('a complete chart only renders inside its validity window', () {
+    expect(chart().isCurrentAt(DateTime.utc(2026, 8, 20)), isTrue);
+    expect(
+      chart().isCurrentAt(effective.subtract(const Duration(seconds: 1))),
+      isFalse,
+    );
+    expect(chart().isCurrentAt(expires), isFalse);
+  });
+
+  test('missing provenance is unavailable rather than partially trusted', () {
+    const incomplete = AeronauticalChartConfiguration(
+      tileUrlTemplate: 'https://charts.example/{z}/{x}/{y}.png',
+      providerName: 'Unknown chart',
+    );
+
+    expect(incomplete.isComplete, isFalse);
+    expect(
+      incomplete.statusLabelAt(DateTime.utc(2026, 8, 20)),
+      'AIRSPACE UNAVAILABLE',
+    );
+    expect(
+      incomplete.explanationAt(DateTime.utc(2026, 8, 20)),
+      contains('official AIP and NOTAM'),
+    );
+  });
+
+  test('an expired chart is labelled stale and is not rendered', () {
+    final stale = chart();
+    final now = DateTime.utc(2026, 9, 4);
+
+    expect(stale.isCurrentAt(now), isFalse);
+    expect(stale.statusLabelAt(now), 'AIRSPACE STALE');
+    expect(stale.explanationAt(now), contains('hidden until refreshed'));
+  });
+
+  test('OpenAIP is selected with TMS tiles and a bounded build lifetime', () {
+    final configured = DateTime.utc(2026, 8, 20, 9, 30);
+    final openAip = AeronauticalChartConfiguration.openAip(
+      apiKey: 'key with symbols/+',
+      configuredAt: configured,
+    );
+
+    expect(openAip.providerName, 'openAIP');
+    expect(openAip.tileScheme, AeronauticalTileScheme.tms);
+    expect(openAip.tileUrlTemplate, contains('/openaip/{z}/{x}/{y}.png'));
+    expect(openAip.tileUrlTemplate, contains('apiKey=key+with+symbols%2F%2B'));
+    expect(openAip.attribution, contains('CC BY-NC 4.0'));
+    expect(openAip.expiresAt, configured.add(const Duration(days: 28)));
+    expect(openAip.isCurrentAt(DateTime.utc(2026, 9, 1)), isTrue);
+    expect(openAip.limitations, contains('NOTAMs'));
+    expect(openAip.limitations, contains('Not for primary navigation'));
+  });
+
+  test('OpenAIP remains unavailable without an API key or build timestamp', () {
+    expect(
+      AeronauticalChartConfiguration.openAip(
+        apiKey: '',
+        configuredAt: DateTime.utc(2026, 8, 20),
+      ).isComplete,
+      isFalse,
+    );
+    expect(
+      AeronauticalChartConfiguration.openAip(
+        apiKey: 'test-key',
+        configuredAt: null,
+      ).isComplete,
+      isFalse,
+    );
+  });
+}

--- a/apps/mobile/test/services/map_style_repository_test.dart
+++ b/apps/mobile/test/services/map_style_repository_test.dart
@@ -602,6 +602,7 @@ void main() {
         'route ahead': 10.44,
         'travelled': 7.14,
         'leader trail': 10.71,
+        'balloon ground track': 12.11,
         'route start connector': 12.11,
       };
 

--- a/apps/mobile/test/services/rider_trail_recorder_test.dart
+++ b/apps/mobile/test/services/rider_trail_recorder_test.dart
@@ -285,6 +285,10 @@ void main() {
   test('the leader trail is styled apart from every other craft', () {
     expect(RiderTrailRecorder.kindFor(isLeader: true), RiderTrailKind.leader);
     expect(RiderTrailRecorder.kindFor(isLeader: false), RiderTrailKind.rider);
+    expect(
+      RiderTrailRecorder.kindFor(isLeader: false, isBalloon: true),
+      RiderTrailKind.balloonGroundTrack,
+    );
   });
 }
 

--- a/docs/aeronautical-chart-source.md
+++ b/docs/aeronautical-chart-source.md
@@ -1,0 +1,31 @@
+# Aeronautical chart source
+
+OpenAIP is the selected advisory aeronautical layer for tester builds. The app
+uses OpenAIP's combined raster TMS layer and visibly attributes it as
+`© openAIP contributors · CC BY-NC 4.0`.
+
+Release workflows require this Actions secret:
+
+```text
+BALLOON_CRUMBS_OPENAIP_API_KEY
+```
+
+The key is a third-party application key created from the OpenAIP user profile.
+It is passed as a `--dart-define`, never committed. OpenAIP's tile endpoint is
+built into the app only because the provider has now been explicitly selected.
+
+The build timestamp starts a 28-day configuration window. An unstamped local
+build, missing key, future timestamp, or tester build beyond that window does
+not draw the chart; the balloon map labels it unavailable or stale instead.
+
+## Limitations
+
+OpenAIP is community-maintained advisory data. It can show controlled airspace,
+ATZ/MATZ, danger/prohibited areas, aerodromes, and vertical limits, but it is not
+an authoritative or complete source of current UK NOTAMs and temporary
+restrictions. The UI therefore says that directly and does not describe the
+layer as clearance, terrain clearance, or primary navigation.
+
+For UK operations, pilots must still check the current NATS UK AIS AIP and
+official NOTAM/pre-flight briefing. NATS AIRAC links are dynamic and must not be
+treated as permanent tile endpoints.

--- a/docs/android-internal-testing.md
+++ b/docs/android-internal-testing.md
@@ -1,9 +1,9 @@
-# Android closed testing
+# Android internal testing
 
 Balloon Crumbs follows Tail End Charlie's release path: one manual
-**Android closed testing** workflow builds a signed App Bundle, uploads it to
-Google Play's `internal` track, and promotes that exact bundle to the closed
-`alpha` track. The upload remains on `internal` as a recovery source.
+**Android internal testing** workflow builds a signed App Bundle and uploads it
+to Google Play's `internal` track. Promotion to the closed `alpha` track remains
+available as an explicit future choice, but the safe default is internal only.
 
 This is deliberately not triggered by every merge. A release is a maintainer
 decision, just like the TestFlight workflow.
@@ -17,7 +17,7 @@ These are the only steps that cannot be committed to the repository:
    first upload. Enrol it in Play App Signing.
 2. Complete Play Console's required app-content and testing declarations. A
    bundle can upload before every store-listing field is finished, but Play may
-   block a closed-track rollout until its required declarations are complete.
+   block a testing-track rollout until its required declarations are complete.
 3. Create a dedicated upload key; do not reuse Tail End Charlie's key:
 
    ```bash
@@ -32,9 +32,9 @@ These are the only steps that cannot be committed to the repository:
 5. In Play Console's **Users and permissions**, invite the JSON key's
    `client_email`, scope it to Balloon Crumbs only, and grant **Release apps to
    testing tracks**. Creating it in Google Cloud alone gives it no Play access.
-6. Create a closed-testing track named **Alpha**, add the intended tester list,
-   and keep managed publishing off unless every release will also be published
-   manually in the Console.
+6. Add the intended tester list to **Internal testing**, and keep managed
+   publishing off unless every release will also be published manually in the
+   Console.
 
 The tester opt-in page will be:
 `https://play.google.com/apps/testing/dev.osholt.ballooncrumbs`.
@@ -52,9 +52,13 @@ secrets. The repository environment is already restricted to workflow runs from
 | `ANDROID_KEY_ALIAS` | `balloon-crumbs-upload`, or the alias chosen above |
 | `ANDROID_KEY_PASSWORD` | Upload-key password |
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Full service-account JSON key |
+| `BALLOON_CRUMBS_OPENAIP_API_KEY` | OpenAIP third-party application key for the advisory airspace layer |
 
 On macOS, `base64 -i balloon-crumbs-upload.jks | pbcopy` copies the first value
 without writing another file. Never commit the keystore, passwords, or JSON.
+The OpenAIP key is compiled into the tester app because OpenAIP's tile API is
+designed for map clients; keep it in Actions secrets so it is absent from the
+repository and can be rotated independently.
 
 Optional repository variables:
 
@@ -73,9 +77,9 @@ first setup run.
 
 ## Releasing
 
-Run **Android closed testing** from the Actions tab, normally with:
+Run **Android internal testing** from the Actions tab, normally with:
 
-- `promote_to: alpha`
+- `promote_to: none`
 - `notification_mode: dry-run` until the rendered mail is approved
 - an explicit `build_number` if any App Bundle has ever been uploaded outside
   this workflow
@@ -86,16 +90,12 @@ build in `pubspec.yaml`; the first run therefore starts above the inherited
 version already served to a user. If Play is ahead, run **Play track status**,
 choose a number above the highest reported code, and pass it explicitly.
 
-If upload succeeds but promotion fails, run **Promote Android tester release**
-with that version code. It promotes the existing internal bundle and does not
-rebuild it.
-
 After a release:
 
-1. Run **Play track status** and confirm the version code is on `alpha`.
+1. Run **Play track status** and confirm the version code is on `internal`.
 2. Open the opt-in page on a physical Android phone using a tester account.
 3. Install/update, then confirm **Settings -> About & build** shows the same
-   version code and `Play closed testing (alpha)`.
+   version code and `Play internal testing`.
 
 The status workflow is read-only: it opens a Play edit, lists tracks, and deletes
 the uncommitted edit. API success still cannot prove that a tester's phone has
@@ -113,5 +113,6 @@ The Console and API use confusing names:
 | Open testing | `beta` |
 | Production | `production` |
 
-The workflow exposes only `alpha` or `none`; it does not offer `beta`, because
-that would make a private tester build joinable as open testing.
+The workflow defaults to `none`, which means internal only. Its future-facing
+`alpha` choice is always explicit; it does not offer `beta`, because that would
+make a private tester build joinable as open testing.

--- a/docs/tester-update-guide.md
+++ b/docs/tester-update-guide.md
@@ -1,8 +1,8 @@
 # Android tester update guide
 
-Use the Google account that was added to the Balloon Crumbs closed-test list.
+Use the Google account that was added to the Balloon Crumbs internal-test list.
 
-1. Open the [closed-testing opt-in page](https://play.google.com/apps/testing/dev.osholt.ballooncrumbs)
+1. Open the [internal-testing opt-in page](https://play.google.com/apps/testing/dev.osholt.ballooncrumbs)
    on the Android phone you test with.
 2. Accept the invitation if prompted, then choose **Download it on Google Play**.
 3. In Google Play, choose **Install** or **Update**. A new build can take several
@@ -12,6 +12,6 @@ Use the Google account that was added to the Balloon Crumbs closed-test list.
    version, build number, and distribution track in every bug report.
 
 The expected track for invited Android testers is
-`Play closed testing (alpha)`. If the opt-in page says the account is not
+`Play internal testing`. If the opt-in page says the account is not
 eligible, check which Google account Play is using before reporting a release
 problem.

--- a/docs/testflight.md
+++ b/docs/testflight.md
@@ -75,6 +75,10 @@ certificate cannot sign an App Store archive, so the first archive would have
 failed on that too. It is removed, and automatic signing picks the distribution
 certificate.
 
+The local uploader also requires `BALLOON_CRUMBS_OPENAIP_API_KEY` in its
+environment and passes it as a `--dart-define`, matching the GitHub workflow.
+Keep it transient or in a credential store; never write it into this repository.
+
 ## Why the entitlements shrank
 
 Both entitlement files claimed an Associated Domain of
@@ -147,6 +151,7 @@ Create these once, under Settings → Secrets and variables → Actions:
 | `APPSTORE_CONNECT_API_KEY_ID` | the Developer-role key's ID |
 | `APPSTORE_CONNECT_API_ISSUER_ID` | the account's issuer ID |
 | `APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64` | that key's `.p8`, base64 |
+| `BALLOON_CRUMBS_OPENAIP_API_KEY` | OpenAIP third-party application key for the advisory airspace layer |
 
 Optionally set the `BALLOON_CRUMBS_API_BASE_URL` **variable** (not a secret) to a
 deployed relay. Without it the build warns and ships without relay access, which

--- a/tools/testflight/build-and-upload.sh
+++ b/tools/testflight/build-and-upload.sh
@@ -91,6 +91,11 @@ if [ -z "${BALLOON_CRUMBS_API_BASE_URL:-}" ]; then
   echo "warning: BALLOON_CRUMBS_API_BASE_URL is unset - this build cannot reach a relay." >&2
   echo "         Nearby transport still works. Export it to point at a deployed relay." >&2
 fi
+if [ -z "${BALLOON_CRUMBS_OPENAIP_API_KEY:-}" ]; then
+  echo "build-and-upload: BALLOON_CRUMBS_OPENAIP_API_KEY is required for tester releases." >&2
+  echo "  Supply it transiently from the OpenAIP API client; never commit it." >&2
+  exit 1
+fi
 
 cd "$mobile_dir"
 flutter pub get
@@ -104,6 +109,7 @@ flutter build ipa \
   --dart-define=BALLOON_CRUMBS_DISTRIBUTION_TRACK="$BALLOON_CRUMBS_DISTRIBUTION_TRACK" \
   --dart-define=BALLOON_CRUMBS_BUILD_TIMESTAMP="$BALLOON_CRUMBS_BUILD_TIMESTAMP" \
   --dart-define=BALLOON_CRUMBS_API_BASE_URL="${BALLOON_CRUMBS_API_BASE_URL:-}" \
+  --dart-define=BALLOON_CRUMBS_OPENAIP_API_KEY="$BALLOON_CRUMBS_OPENAIP_API_KEY" \
   --dart-define=BALLOON_CRUMBS_PUSH_ENABLED=false \
   --dart-define=BALLOON_CRUMBS_RIDE_DIAGNOSTICS=true
 


### PR DESCRIPTION
## Summary

- present the balloon as an aircraft with its own wider north-up viewport, ground track, and source-aware altitude card
- remove chase-only road guidance, route progress, speed-limit, enforcement, and mini-map chrome from the balloon view
- add the selected OpenAIP raster TMS layer with attribution, bounded freshness, visible limitations, and safe unavailable/stale states
- pass the OpenAIP client key through Android, GitHub TestFlight, and local TestFlight release paths
- default Android tester releases to Play internal testing rather than closed-alpha promotion

## Safety and scope

OpenAIP remains advisory and is never treated as clearance or a replacement for the official NATS AIS/NOTAM briefing. The broader telemetry, multi-craft, and structured airspace roadmap tickets remain open.

## Verification

- `dart format` on all changed Dart files
- `flutter analyze`
- full `flutter test`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (134 passed)
- GitHub workflow YAML parsing
- `bash -n tools/testflight/build-and-upload.sh`
- `git diff --check`

Closes #30
Closes #31
Closes #32
