### PR TITLE
feat: improve balloon map altitude context

### DIFF
--- a/apps/mobile/lib/controllers/ride_simulation_controller.dart
+++ b/apps/mobile/lib/controllers/ride_simulation_controller.dart
@@ -33,6 +33,8 @@ class SimulatedRiderSnapshot {
     required this.travelTrail,
     required this.motorcycleStyle,
     required this.riderColor,
+    this.altitudeMeters,
+    this.verticalSpeedMetersPerSecond,
     this.riderSymbol = riderSymbolDefault,
   });
 
@@ -48,6 +50,8 @@ class SimulatedRiderSnapshot {
   final CraftIconStyle motorcycleStyle;
   final RiderSymbol riderSymbol;
   final RiderColor riderColor;
+  final double? altitudeMeters;
+  final double? verticalSpeedMetersPerSecond;
 
   /// Ephemeral visual trace for the current simulation run. Keeping this out
   /// of the durable awareness history prevents an older demo route from being
@@ -89,12 +93,6 @@ class RideSimulationController extends ChangeNotifier {
        _selectedLocalRole = session.role {
     _agents = _buildAgents(_routeSampler.totalDistanceMeters * 0.06);
   }
-
-  /// Ashton Court's field is about 60 m above sea level, and a GNSS fix reports
-  /// altitude above the ellipsoid, not above the launch field. The flight
-  /// carries height above launch because that is what a pilot flies and what
-  /// goes out over the radio, so this is added back to make the fix honest.
-  static const _launchElevationMetres = 60.0;
 
   static const offRouteRiderId = 'ride-lab-alex';
   static const backRiderId = 'ride-lab-charlie';
@@ -147,6 +145,7 @@ class RideSimulationController extends ChangeNotifier {
   List<SimulatedRiderSnapshot> get riders => List.unmodifiable(
     _agents.map((agent) {
       final sampled = _sampleAgent(agent);
+      final flight = _balloonFlightAt(agent);
       return SimulatedRiderSnapshot(
         id: agent.id,
         displayName: agent.isLocal ? _localPerspectiveName : agent.displayName,
@@ -162,6 +161,8 @@ class RideSimulationController extends ChangeNotifier {
         motorcycleStyle: agent.motorcycleStyle,
         riderSymbol: agent.riderSymbol,
         riderColor: agent.riderColor,
+        altitudeMeters: flight?.altitudeMeters,
+        verticalSpeedMetersPerSecond: flight?.verticalSpeedMetersPerSecond,
       );
     }),
   );
@@ -401,9 +402,11 @@ class RideSimulationController extends ChangeNotifier {
       _recordTravelTrail(agent);
       if (agent.isOffRoute) _recordOffRouteTrail(agent);
     }
-    final completed = _agents.every(
-      (agent) => agent.progressMeters >= routeDistanceMeters,
-    );
+    final flightCompleted =
+        _balloonFlight == null || _simulatedElapsed >= _balloonFlight.duration;
+    final completed =
+        flightCompleted &&
+        _agents.every((agent) => agent.progressMeters >= routeDistanceMeters);
     if (completed) _state = RideSimulationState.completed;
     if (completed) {
       _timer?.cancel();
@@ -576,7 +579,7 @@ class RideSimulationController extends ChangeNotifier {
           (after.elapsed - before.elapsed).inMicroseconds /
           Duration.microsecondsPerSecond;
       return (
-        altitudeMeters: height + _launchElevationMetres,
+        altitudeMeters: height,
         // Measured from the flight rather than asserted: a climb rate the
         // track does not actually show would put a number on screen that the
         // altitude trail contradicts.
@@ -659,7 +662,6 @@ class RideSimulationController extends ChangeNotifier {
     if (trail.isEmpty ||
         GeoCalculations.distanceMeters(trail.last, point) >= 2) {
       trail.add(point);
-      if (trail.length > 180) trail.removeRange(0, trail.length - 180);
     }
   }
 

--- a/apps/mobile/lib/features/map/balloon_altitude_style.dart
+++ b/apps/mobile/lib/features/map/balloon_altitude_style.dart
@@ -1,0 +1,101 @@
+import 'dart:ui';
+
+import '../../domain/imported_route.dart';
+
+/// One colour band in the balloon ground-track legend.
+class BalloonAltitudeBand {
+  const BalloonAltitudeBand({
+    required this.minimumMeters,
+    required this.label,
+    required this.color,
+  });
+
+  final double minimumMeters;
+  final String label;
+  final Color color;
+}
+
+/// One drawable ground-track leg.
+///
+/// A leg only receives an altitude colour when both of its fixes carry a valid
+/// altitude. A neutral line is used across missing data rather than inventing a
+/// height between one known endpoint and one unknown endpoint.
+class BalloonAltitudeSegment {
+  const BalloonAltitudeSegment({
+    required this.points,
+    required this.color,
+    required this.altitudeMeters,
+  });
+
+  final List<GeoPoint> points;
+  final Color color;
+  final double? altitudeMeters;
+
+  bool get hasAltitude => altitudeMeters != null;
+}
+
+/// Metric altitude palette shared by both map renderers and the legend.
+class BalloonAltitudeStyle {
+  const BalloonAltitudeStyle._();
+
+  static const unknownColor = Color(0xFFB7C4D1);
+
+  static const bands = <BalloonAltitudeBand>[
+    BalloonAltitudeBand(
+      minimumMeters: double.negativeInfinity,
+      label: '<150 m',
+      color: Color(0xFF00E5FF),
+    ),
+    BalloonAltitudeBand(
+      minimumMeters: 150,
+      label: '150–299 m',
+      color: Color(0xFF55E05B),
+    ),
+    BalloonAltitudeBand(
+      minimumMeters: 300,
+      label: '300–599 m',
+      color: Color(0xFFFFE45E),
+    ),
+    BalloonAltitudeBand(
+      minimumMeters: 600,
+      label: '600–899 m',
+      color: Color(0xFFFF9F43),
+    ),
+    BalloonAltitudeBand(
+      minimumMeters: 900,
+      label: '900+ m',
+      color: Color(0xFFFF4FA3),
+    ),
+  ];
+
+  static Color colorForMeters(double meters) {
+    var selected = bands.first.color;
+    for (final band in bands) {
+      if (meters < band.minimumMeters) break;
+      selected = band.color;
+    }
+    return selected;
+  }
+
+  static List<BalloonAltitudeSegment> segments(List<GeoPoint> points) => [
+    for (var index = 1; index < points.length; index += 1)
+      _segment(points[index - 1], points[index]),
+  ];
+
+  static BalloonAltitudeSegment _segment(GeoPoint start, GeoPoint end) {
+    final startAltitude = start.elevationMeters;
+    final endAltitude = end.elevationMeters;
+    final altitude =
+        startAltitude != null &&
+            startAltitude.isFinite &&
+            endAltitude != null &&
+            endAltitude.isFinite
+        ? (startAltitude + endAltitude) / 2
+        : null;
+    return BalloonAltitudeSegment(
+      points: [start, end],
+      color: altitude == null ? unknownColor : colorForMeters(altitude),
+      altitudeMeters: altitude,
+    );
+  }
+}

--- a/apps/mobile/lib/features/map/ride_map.dart
+++ b/apps/mobile/lib/features/map/ride_map.dart
@@ -2,6 +2,7 @@ export 'ride_map_feature.dart'
     show
         MapNavigationPosition,
         MapEmergencyContact,
+        MapLandingZone,
         GroupMiniMapRenderer,
         MapOverlayMarker,
         MapOverlayTrace,
@@ -19,6 +20,8 @@ export 'ride_map_feature.dart'
         quickMessageIcon;
 export 'route_trail_style.dart'
     show RouteLineStyle, RouteTrailStyle, contrastRatio, relativeLuminance;
+export 'balloon_altitude_style.dart'
+    show BalloonAltitudeBand, BalloonAltitudeSegment, BalloonAltitudeStyle;
 export '../../services/navigation_export.dart'
     show NavigationExportCoordinator, NavigationExportResult, NavigationTarget;
 export '../../services/rider_trail_recorder.dart'

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -63,6 +63,7 @@ import '../../services/speed_limit.dart';
 import '../../services/stored_route_library.dart';
 import '../../services/trail_direction_arrows.dart';
 import 'destination_route_sheet.dart';
+import 'balloon_altitude_style.dart';
 import 'hazard_map_symbol.dart';
 import 'map_camera_guard.dart';
 import 'maneuver_list_screen.dart';
@@ -113,6 +114,43 @@ enum _ImportedTrackChoice { cancel, followOriginal, generateNavigable }
 /// to the balloon (or the explicit Ride Lab balloon perspective) gets the
 /// aviation presentation.
 enum RideMapPerspective { chase, balloon }
+
+/// A deliberately approximate area where the balloon intends or is expected
+/// to land.
+///
+/// The label must name the source/quality (for example, "Simulated landing
+/// zone") so a map never upgrades a forecast or rehearsal area into a known
+/// touchdown point.
+class MapLandingZone {
+  const MapLandingZone({
+    required this.center,
+    required this.label,
+    this.radiusMeters = 250,
+  }) : assert(radiusMeters > 0);
+
+  final GeoPoint center;
+  final String label;
+  final double radiusMeters;
+
+  List<GeoPoint> get boundary {
+    const pointCount = 48;
+    final latitudeRadians = center.latitude * math.pi / 180;
+    final longitudeScale = math.cos(latitudeRadians).abs().clamp(0.01, 1.0);
+    final points = <GeoPoint>[];
+    for (var index = 0; index < pointCount; index += 1) {
+      final angle = index * 2 * math.pi / pointCount;
+      points.add(
+        GeoPoint(
+          latitude: center.latitude + math.cos(angle) * radiusMeters / 111320,
+          longitude:
+              center.longitude +
+              math.sin(angle) * radiusMeters / (111320 * longitudeScale),
+        ),
+      );
+    }
+    return List.unmodifiable([...points, points.first]);
+  }
+}
 
 @visibleForTesting
 Color groupMiniMapBackgroundColor(Brightness brightness) =>
@@ -177,6 +215,7 @@ class RideMapFeature extends StatefulWidget {
     this.navigationPosition,
     this.overlayMarkers,
     this.riderTrails,
+    this.landingZone,
     this.groupRiderCount,
     this.onOpenRoster,
     this.enforcementAlert,
@@ -240,6 +279,7 @@ class RideMapFeature extends StatefulWidget {
     ValueListenable<MapNavigationPosition?>? navigationPosition,
     ValueListenable<List<MapOverlayMarker>>? overlayMarkers,
     ValueListenable<List<MapOverlayTrace>>? riderTrails,
+    MapLandingZone? landingZone,
     int? groupRiderCount,
     VoidCallback? onOpenRoster,
     ValueListenable<EnforcementAlert?>? enforcementAlert,
@@ -298,6 +338,7 @@ class RideMapFeature extends StatefulWidget {
     navigationPosition: navigationPosition,
     overlayMarkers: overlayMarkers,
     riderTrails: riderTrails,
+    landingZone: landingZone,
     groupRiderCount: groupRiderCount,
     onOpenRoster: onOpenRoster,
     enforcementAlert: enforcementAlert,
@@ -359,6 +400,7 @@ class RideMapFeature extends StatefulWidget {
   final ValueListenable<MapNavigationPosition?>? navigationPosition;
   final ValueListenable<List<MapOverlayMarker>>? overlayMarkers;
   final ValueListenable<List<MapOverlayTrace>>? riderTrails;
+  final MapLandingZone? landingZone;
 
   /// Which way the gap to the TEC is going (#181). Null where no trend is
   /// tracked, in which case the gap card shows the distance alone.
@@ -560,6 +602,7 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         navigationPosition: widget.navigationPosition,
         overlayMarkers: widget.overlayMarkers,
         riderTrails: widget.riderTrails,
+        landingZone: widget.landingZone,
         groupRiderCount: widget.groupRiderCount,
         onOpenRoster: widget.onOpenRoster,
         enforcementAlert: widget.enforcementAlert,
@@ -645,6 +688,7 @@ class RideMapScreen extends StatefulWidget {
     this.navigationPosition,
     this.overlayMarkers,
     this.riderTrails,
+    this.landingZone,
     this.groupRiderCount,
     this.onOpenRoster,
     this.enforcementAlert,
@@ -728,6 +772,7 @@ class RideMapScreen extends StatefulWidget {
   final ValueListenable<MapNavigationPosition?>? navigationPosition;
   final ValueListenable<List<MapOverlayMarker>>? overlayMarkers;
   final ValueListenable<List<MapOverlayTrace>>? riderTrails;
+  final MapLandingZone? landingZone;
 
   /// Which way the gap to the TEC is going (#181). Null where no trend is
   /// tracked, in which case the gap card shows the distance alone.
@@ -838,6 +883,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
   static const _waypointSource = 'balloon-crumbs-waypoints';
   static const _positionSource = 'balloon-crumbs-position';
   static const _overlaySource = 'balloon-crumbs-overlays';
+  static const _landingZoneSource = 'balloon-crumbs-landing-zone';
+  static const _landingZoneImage = 'balloon-crumbs-landing-zone-flag';
   static const _aeronauticalChartSource = 'balloon-crumbs-aeronautical-chart';
   static const _aeronauticalChartLayer =
       'balloon-crumbs-aeronautical-chart-layer';
@@ -1524,12 +1571,17 @@ class _RideMapScreenState extends State<RideMapScreen> {
                     key: const Key('balloon-altitude-position'),
                     left: overlayLeft + 12,
                     top: overlayTop + 12,
-                    child: ValueListenableBuilder<MapNavigationPosition?>(
-                      valueListenable: widget.navigationPosition!,
-                      builder: (context, fix, _) => _BalloonAltitudeCard(
-                        fix: fix,
-                        distanceUnit: widget.distanceUnit,
-                      ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ValueListenableBuilder<MapNavigationPosition?>(
+                          valueListenable: widget.navigationPosition!,
+                          builder: (context, fix, _) =>
+                              _BalloonAltitudeCard(fix: fix),
+                        ),
+                        const SizedBox(height: 8),
+                        const _BalloonAltitudeLegend(),
+                      ],
                     ),
                   ),
                 if (_isBalloonView)
@@ -2417,9 +2469,12 @@ class _RideMapScreenState extends State<RideMapScreen> {
     if (_basemap.usesMapLibre) return _buildMapLibreMap();
 
     final route = _isBalloonView ? null : _route;
-    final framingPoints = _isBalloonView
-        ? _balloonGroundTrackPoints
-        : route?.allPoints.toList(growable: false) ?? const <GeoPoint>[];
+    final framingPoints = <GeoPoint>[
+      ...(_isBalloonView
+          ? _balloonGroundTrackPoints
+          : route?.allPoints.toList(growable: false) ?? const <GeoPoint>[]),
+      ...?widget.landingZone?.boundary,
+    ];
     final points = framingPoints.map(_latLng).toList(growable: false);
     // With no route the rider's own position is the framing (#124); the UK-wide
     // overview is only for a map that has neither.
@@ -2465,8 +2520,24 @@ class _RideMapScreenState extends State<RideMapScreen> {
             urlTemplate: widget.aeronauticalChartConfiguration.tileUrlTemplate,
             userAgentPackageName: 'me.osholt.balloon_crumbs',
             tms: widget.aeronauticalChartConfiguration.usesTms,
-            tileBuilder: (context, tile, _) =>
-                Opacity(opacity: 0.82, child: tile),
+            // The combined OpenAIP layer is the aeronautical chart, including
+            // its own cartographic background. Blending it with the ordinary
+            // road map made the two views look effectively identical.
+            tileBuilder: (context, tile, _) => tile,
+          ),
+        if (widget.landingZone case final zone?)
+          CircleLayer(
+            key: const Key('landing-zone-area-layer'),
+            circles: [
+              CircleMarker(
+                point: _latLng(zone.center),
+                radius: zone.radiusMeters,
+                useRadiusInMeter: true,
+                color: const Color(0x38FFC857),
+                borderColor: const Color(0xFFFFC857),
+                borderStrokeWidth: 3,
+              ),
+            ],
           ),
         // Actual travelled trails are drawn whether or not a route is loaded,
         // and the leader's trail sits under the remaining planned route so both
@@ -2578,6 +2649,25 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   .toList(growable: false),
             ),
           ),
+        if (widget.landingZone case final zone?)
+          MarkerLayer(
+            key: const Key('landing-zone-marker-layer'),
+            markers: [
+              Marker(
+                point: _latLng(zone.center),
+                width: 42,
+                height: 42,
+                child: Tooltip(
+                  message: zone.label,
+                  child: const _IconBadge(
+                    icon: Icons.flag_rounded,
+                    badgeColor: Color(0xFFFFC857),
+                    size: 34,
+                  ),
+                ),
+              ),
+            ],
+          ),
       ],
     );
 
@@ -2618,9 +2708,12 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }
 
   Widget _buildMapLibreMap() {
-    final planned = _isBalloonView
-        ? _balloonGroundTrackPoints
-        : _route?.allPoints.toList(growable: false) ?? const [];
+    final planned = <GeoPoint>[
+      ...(_isBalloonView
+          ? _balloonGroundTrackPoints
+          : _route?.allPoints.toList(growable: false) ?? const []),
+      ...?widget.landingZone?.boundary,
+    ];
     // As above: no route still frames the rider rather than the whole country.
     final routePoints = planned.isNotEmpty ? planned : [?_effectivePosition];
     final initial = routePoints.isEmpty
@@ -3878,6 +3971,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
       await rasterizeIconGlyphPng(Icons.navigation_rounded),
       true,
     );
+    await controller.addImage(
+      _landingZoneImage,
+      await rasterizeIconGlyphPng(Icons.flag_rounded),
+      true,
+    );
     _markerImagesRegistered = true;
     await _ensureRiderSymbolImages(controller);
   }
@@ -3934,9 +4032,48 @@ class _RideMapScreenState extends State<RideMapScreen> {
         await controller.addRasterLayer(
           _aeronauticalChartSource,
           _aeronauticalChartLayer,
-          const ml.RasterLayerProperties(rasterOpacity: 0.82),
+          const ml.RasterLayerProperties(rasterOpacity: 1),
         );
       }
+      await controller.addGeoJsonSource(
+        _landingZoneSource,
+        _landingZoneGeoJson(),
+      );
+      await controller.addFillLayer(
+        _landingZoneSource,
+        'balloon-crumbs-landing-zone-fill',
+        const ml.FillLayerProperties(fillColor: '#FFC857', fillOpacity: 0.22),
+        filter: const ['==', r'$type', 'Polygon'],
+        enableInteraction: false,
+      );
+      await controller.addLineLayer(
+        _landingZoneSource,
+        'balloon-crumbs-landing-zone-outline',
+        const ml.LineLayerProperties(
+          lineColor: '#FFC857',
+          lineWidth: 3,
+          lineDasharray: [3, 2],
+          lineCap: 'round',
+          lineJoin: 'round',
+        ),
+        filter: const ['==', r'$type', 'Polygon'],
+        enableInteraction: false,
+      );
+      await controller.addSymbolLayer(
+        _landingZoneSource,
+        'balloon-crumbs-landing-zone-marker',
+        const ml.SymbolLayerProperties(
+          iconImage: _landingZoneImage,
+          iconColor: RouteTrailStyle.markerGlyphHex,
+          iconHaloColor: '#FFC857',
+          iconHaloWidth: 7,
+          iconSize: 0.18,
+          iconAllowOverlap: true,
+          iconIgnorePlacement: true,
+        ),
+        filter: const ['==', r'$type', 'Point'],
+        enableInteraction: false,
+      );
       // Solid trails are drawn before the planned route so the leader's wider
       // trail reads as a corridor beneath it rather than hiding it.
       await controller.addGeoJsonSource(
@@ -4141,7 +4278,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _riderTrailSource,
       'balloon-crumbs-trail-${kind.name}-line',
       ml.LineLayerProperties(
-        lineColor: _hexColor(style.color),
+        lineColor: kind == RiderTrailKind.balloonGroundTrack
+            ? const ['get', 'color']
+            : _hexColor(style.color),
         lineWidth: style.widthPixels,
         lineDasharray: style.maplibreDashArray,
         lineCap: 'round',
@@ -4164,6 +4303,10 @@ class _RideMapScreenState extends State<RideMapScreen> {
       await controller.setGeoJsonSource(
         _riderTrailSource,
         _riderTrailGeoJson(),
+      );
+      await controller.setGeoJsonSource(
+        _landingZoneSource,
+        _landingZoneGeoJson(),
       );
       await controller.setGeoJsonSource(
         _trailDirectionArrowSource,
@@ -4303,7 +4446,31 @@ class _RideMapScreenState extends State<RideMapScreen> {
               (first, second) =>
                   second.style.widthPixels.compareTo(first.style.widthPixels),
             ))
-          .map((trace) => _routePolyline(trace.points, trace.style));
+          .expand(
+            (trace) => _renderedTrailParts(trace).map(
+              (part) => _routePolyline(
+                part.points,
+                trace.style.withColor(part.color),
+              ),
+            ),
+          );
+
+  Iterable<({String id, List<GeoPoint> points, Color color})>
+  _renderedTrailParts(MapOverlayTrace trace) sync* {
+    if (trace.kind != RiderTrailKind.balloonGroundTrack) {
+      yield (id: trace.id, points: trace.points, color: trace.style.color);
+      return;
+    }
+    for (final (index, segment) in BalloonAltitudeStyle.segments(
+      trace.points,
+    ).indexed) {
+      yield (
+        id: '${trace.id}-altitude-$index',
+        points: segment.points,
+        color: segment.color,
+      );
+    }
+  }
 
   /// Which lines carry direction arrows, in priority order.
   ///
@@ -4385,21 +4552,61 @@ class _RideMapScreenState extends State<RideMapScreen> {
     'type': 'FeatureCollection',
     'features': [
       for (final trace in _visibleRiderTrails)
+        for (final part in _renderedTrailParts(trace))
+          {
+            'type': 'Feature',
+            'id': part.id,
+            // The kind selects the layer, which carries the whole style.
+            'properties': {
+              'kind': trace.kind.name,
+              'label': trace.label,
+              'color': _hexColor(part.color),
+            },
+            'geometry': {
+              'type': 'LineString',
+              'coordinates': [
+                for (final point in part.points)
+                  [point.longitude, point.latitude],
+              ],
+            },
+          },
+    ],
+  };
+
+  Map<String, dynamic> _landingZoneGeoJson() {
+    final zone = widget.landingZone;
+    if (zone == null) {
+      return const {'type': 'FeatureCollection', 'features': <Object>[]};
+    }
+    return {
+      'type': 'FeatureCollection',
+      'features': [
         {
           'type': 'Feature',
-          'id': trace.id,
-          // The kind selects the layer, which carries the whole style.
-          'properties': {'kind': trace.kind.name, 'label': trace.label},
+          'id': 'landing-zone-area',
+          'properties': {'label': zone.label},
           'geometry': {
-            'type': 'LineString',
+            'type': 'Polygon',
             'coordinates': [
-              for (final point in trace.points)
-                [point.longitude, point.latitude],
+              [
+                for (final point in zone.boundary)
+                  [point.longitude, point.latitude],
+              ],
             ],
           },
         },
-    ],
-  };
+        {
+          'type': 'Feature',
+          'id': 'landing-zone-centre',
+          'properties': {'label': zone.label},
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [zone.center.longitude, zone.center.latitude],
+          },
+        },
+      ],
+    };
+  }
 
   Map<String, dynamic> _waypointGeoJson() => MapGeoJson.points(
     (_isBalloonView ? null : _route)?.waypoints
@@ -5031,9 +5238,12 @@ class _RideMapScreenState extends State<RideMapScreen> {
   /// fallback a route-less ride opened on a UK-wide overview and stayed there
   /// until the bike moved fast enough to arm the follow camera (#124).
   void _fitRoute() {
-    final planned = _isBalloonView
-        ? _balloonGroundTrackPoints
-        : _route?.allPoints.toList(growable: false) ?? const [];
+    final planned = <GeoPoint>[
+      ...(_isBalloonView
+          ? _balloonGroundTrackPoints
+          : _route?.allPoints.toList(growable: false) ?? const []),
+      ...?widget.landingZone?.boundary,
+    ];
     final routePoints = planned.isNotEmpty ? planned : [?_effectivePosition];
     if (_basemap.usesMapLibre) {
       final controller = _mapLibreController;
@@ -7996,11 +8206,76 @@ class _AeronauticalChartBadge extends StatelessWidget {
   }
 }
 
+class _BalloonAltitudeLegend extends StatelessWidget {
+  const _BalloonAltitudeLegend();
+
+  @override
+  Widget build(BuildContext context) => Semantics(
+    label:
+        'Balloon track altitude in metres: ${BalloonAltitudeStyle.bands.map((band) => band.label).join(', ')}. Grey means altitude unavailable.',
+    child: Card(
+      key: const Key('balloon-altitude-legend'),
+      color: const Color(0xE6252E39),
+      margin: EdgeInsets.zero,
+      child: SizedBox(
+        width: 248,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'TRACK ALTITUDE · METRES',
+                style: TextStyle(
+                  color: Color(0xFFCED6DF),
+                  fontSize: 10,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0.5,
+                ),
+              ),
+              const SizedBox(height: 5),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: Row(
+                  children: [
+                    for (final band in BalloonAltitudeStyle.bands)
+                      Expanded(
+                        child: ColoredBox(
+                          color: band.color,
+                          child: const SizedBox(height: 8),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 3),
+              const Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text('<150', style: TextStyle(fontSize: 9)),
+                  Text('300', style: TextStyle(fontSize: 9)),
+                  Text('600', style: TextStyle(fontSize: 9)),
+                  Text('900+ m', style: TextStyle(fontSize: 9)),
+                ],
+              ),
+              const SizedBox(height: 2),
+              const Text(
+                'Grey = altitude unavailable',
+                style: TextStyle(color: Color(0xFFB7C4D1), fontSize: 9),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 class _BalloonAltitudeCard extends StatelessWidget {
-  const _BalloonAltitudeCard({required this.fix, required this.distanceUnit});
+  const _BalloonAltitudeCard({required this.fix});
 
   final MapNavigationPosition? fix;
-  final DistanceUnit distanceUnit;
 
   @override
   Widget build(BuildContext context) {
@@ -8013,18 +8288,13 @@ class _BalloonAltitudeCard extends StatelessWidget {
               .abs();
     final primary = altitude == null
         ? 'Altitude unavailable'
-        : distanceUnit == DistanceUnit.miles
-        ? '${(altitude * 3.28084).round()} ft'
         : '${altitude.round()} m';
     final trend = _trend(reading?.verticalSpeedMetersPerSecond);
     final accuracy = reading?.altitudeAccuracyMeters;
     final details = [
       if (reading != null && altitude != null) _source(reading.altitudeSource),
       if (reading != null && altitude != null) _datum(reading.altitudeDatum),
-      if (accuracy != null)
-        distanceUnit == DistanceUnit.miles
-            ? '±${(accuracy * 3.28084).round()} ft'
-            : '±${accuracy.round()} m',
+      if (accuracy != null) '±${accuracy.round()} m',
       if (age != null) _age(age),
     ];
     return Semantics(
@@ -8118,9 +8388,7 @@ class _BalloonAltitudeCard extends StatelessWidget {
         ? '↓'
         : '→';
     final magnitude = metresPerSecond.abs();
-    return distanceUnit == DistanceUnit.miles
-        ? '$arrow ${(magnitude * 196.8504).round()} ft/min'
-        : '$arrow ${magnitude.toStringAsFixed(1)} m/s';
+    return '$arrow ${magnitude.toStringAsFixed(1)} m/s';
   }
 
   static String _source(AltitudeSource source) => switch (source) {

--- a/apps/mobile/lib/features/map/route_trail_style.dart
+++ b/apps/mobile/lib/features/map/route_trail_style.dart
@@ -24,6 +24,13 @@ class RouteLineStyle {
 
   bool get isDashed => dashPixels != null;
 
+  RouteLineStyle withColor(Color nextColor) => RouteLineStyle(
+    color: nextColor,
+    widthPixels: widthPixels,
+    casingWidthPixels: casingWidthPixels,
+    dashPixels: dashPixels,
+  );
+
   /// MapLibre expresses `line-dasharray` in multiples of the line width, so the
   /// pixel run lengths are converted here rather than being restated per layer.
   List<double>? get maplibreDashArray => _dashArrayFor(widthPixels);

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -971,6 +971,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   final _carPlayRouteProgressTracker = RouteProgressTracker();
   final _carPlayJourneyProgressTracker = RouteJourneyProgressTracker();
   final _trailSimplifier = const TrailDisplaySimplifier();
+  final _balloonTrailSimplifier = const TrailDisplaySimplifier(
+    preserveAltitudeProfile: true,
+  );
   final _enforcementAlert = ValueNotifier<EnforcementAlert?>(null);
 
   /// The arrival being offered to the rider, or null when there is nothing to
@@ -2207,6 +2210,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                             : location.motorcycleStyle,
                         riderSymbol: location.riderSymbol,
                         riderColor: location.riderColor,
+                        altitudeMeters: location.sample.altitudeMeters,
                         point: route_domain.GeoPoint(
                           latitude: location.sample.position.latitude,
                           longitude: location.sample.position.longitude,
@@ -2226,6 +2230,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                             : rider.motorcycleStyle,
                         riderSymbol: rider.riderSymbol,
                         riderColor: rider.riderColor,
+                        altitudeMeters: rider.altitudeMeters,
                         point: route_domain.GeoPoint(
                           latitude: rider.position.latitude,
                           longitude: rider.position.longitude,
@@ -2263,6 +2268,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             final label = [
               location.displayName,
               ?roleSuffix,
+              if (isBalloonCraft && location.altitudeMeters != null)
+                '${location.altitudeMeters!.round()} m',
               ?ageSuffix,
             ].join(' · ');
             // The roster, both maps and trails share this one identity colour.
@@ -2768,7 +2775,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   MapOverlayTrace _simplifiedForDisplay(MapOverlayTrace trace) {
-    final simplified = _trailSimplifier.simplify(trace.points);
+    final simplified =
+        (trace.kind == RiderTrailKind.balloonGroundTrack
+                ? _balloonTrailSimplifier
+                : _trailSimplifier)
+            .simplify(trace.points);
     if (simplified.length == trace.points.length) return trace;
     return MapOverlayTrace(
       id: trace.id,
@@ -3347,6 +3358,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       navigationPosition: _mapNavigationPosition,
       overlayMarkers: _mapOverlays,
       riderTrails: _riderTrails,
+      landingZone: _isSimulation && _balloonFlight != null
+          ? MapLandingZone(
+              center: route_domain.GeoPoint(
+                latitude: _balloonFlight!.landing.latitude,
+                longitude: _balloonFlight!.landing.longitude,
+              ),
+              label: 'Simulated landing zone · wind-model endpoint',
+            )
+          : null,
       groupRiderCount: widget.rideController.liveParticipants.length,
       onOpenRoster: _openRoster,
       // Deliberately not `onOpenRideMenu`. The control that reaches the other

--- a/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
+++ b/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
@@ -345,7 +345,8 @@ class _FleetCard extends StatelessWidget {
                       ),
                       Text(
                         '${rider.role.label} · '
-                        '${MeasurementFormatter(distanceUnit).speed(rider.speedMetersPerSecond)}',
+                        '${MeasurementFormatter(distanceUnit).speed(rider.speedMetersPerSecond)}'
+                        '${rider.altitudeMeters == null ? '' : ' · ${rider.altitudeMeters!.round()} m'}',
                         style: const TextStyle(
                           color: Color(0xFF8F9BAA),
                           fontSize: 12,

--- a/apps/mobile/lib/services/aeronautical_chart_configuration.dart
+++ b/apps/mobile/lib/services/aeronautical_chart_configuration.dart
@@ -42,7 +42,11 @@ class AeronauticalChartConfiguration {
           'Advisory community data. It may be incomplete or omit current '
           'NOTAMs and temporary restrictions. Verify the official NATS AIS '
           'briefing before flight. Not for primary navigation.',
-      tileScheme: AeronauticalTileScheme.tms,
+      // OpenAIP calls this a TMS service in its API description, but its own
+      // current MapLibre style consumes these z/x/y coordinates as ordinary
+      // XYZ tiles. Flipping Y here requested the wrong hemisphere and made the
+      // chart look indistinguishable from the basemap underneath it.
+      tileScheme: AeronauticalTileScheme.xyz,
     );
   }
 

--- a/apps/mobile/lib/services/trail_display_simplifier.dart
+++ b/apps/mobile/lib/services/trail_display_simplifier.dart
@@ -18,6 +18,7 @@ class TrailDisplaySimplifier {
   const TrailDisplaySimplifier({
     this.toleranceMeters = defaultToleranceMeters,
     this.maximumPoints = defaultMaximumPoints,
+    this.preserveAltitudeProfile = false,
   }) : assert(toleranceMeters > 0),
        assert(maximumPoints >= 2);
 
@@ -38,6 +39,7 @@ class TrailDisplaySimplifier {
 
   final double toleranceMeters;
   final int maximumPoints;
+  final bool preserveAltitudeProfile;
 
   /// The trail as it should be drawn. The first and last points are always
   /// kept, so a trail never appears to start or stop somewhere the rider was
@@ -114,6 +116,19 @@ class TrailDisplaySimplifier {
           final nearestX = offsetX - projection * spanX;
           final nearestY = offsetY - projection * spanY;
           distance = math.sqrt(nearestX * nearestX + nearestY * nearestY);
+        }
+        if (preserveAltitudeProfile) {
+          final startAltitude = points[first].elevationMeters;
+          final endAltitude = points[last].elevationMeters;
+          final altitude = points[index].elevationMeters;
+          if (startAltitude != null &&
+              endAltitude != null &&
+              altitude != null) {
+            final fraction = (index - first) / (last - first);
+            final interpolated =
+                startAltitude + (endAltitude - startAltitude) * fraction;
+            distance = math.max(distance, (altitude - interpolated).abs());
+          }
         }
         if (distance > farthestDistance) {
           farthestDistance = distance;

--- a/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
+++ b/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
@@ -134,6 +134,37 @@ void main() {
     );
   });
 
+  test('the balloon climbs and descends in metric altitude', () async {
+    final simulation = await build();
+    addTearDown(simulation.dispose);
+
+    double? altitude() => simulation.riders
+        .firstWhere((rider) => rider.role == RideRole.lead)
+        .altitudeMeters;
+
+    expect(altitude(), 0);
+    await simulation.advance(const Duration(minutes: 26));
+    expect(altitude(), closeTo(180, 0.1));
+    await simulation.advance(const Duration(minutes: 26));
+    expect(altitude(), closeTo(0, 0.1));
+  });
+
+  test('a chase trail keeps more than the old 180-point window', () async {
+    final simulation = await build();
+    addTearDown(simulation.dispose);
+    simulation.setBaseSpeedMetersPerSecond(25);
+
+    for (var index = 0; index < 220; index += 1) {
+      await simulation.advance(const Duration(seconds: 1));
+    }
+
+    final longestChaseTrail = simulation.riders
+        .where((rider) => rider.role != RideRole.lead)
+        .map((rider) => rider.travelTrail.length)
+        .reduce((first, second) => first > second ? first : second);
+    expect(longestChaseTrail, greaterThan(180));
+  });
+
   test('the balloon lands where the winds put it, and stays down', () async {
     final simulation = await build();
     addTearDown(simulation.dispose);

--- a/apps/mobile/test/features/map/balloon_altitude_style_test.dart
+++ b/apps/mobile/test/features/map/balloon_altitude_style_test.dart
@@ -1,0 +1,29 @@
+import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/features/map/balloon_altitude_style.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('colours each leg from the mean of two known metric altitudes', () {
+    final segments = BalloonAltitudeStyle.segments(const [
+      GeoPoint(latitude: 51, longitude: -2, elevationMeters: 50),
+      GeoPoint(latitude: 51.01, longitude: -2, elevationMeters: 250),
+      GeoPoint(latitude: 51.02, longitude: -2, elevationMeters: 950),
+    ]);
+
+    expect(segments, hasLength(2));
+    expect(segments.first.altitudeMeters, 150);
+    expect(segments.first.color, BalloonAltitudeStyle.bands[1].color);
+    expect(segments.last.altitudeMeters, 600);
+    expect(segments.last.color, BalloonAltitudeStyle.bands[3].color);
+  });
+
+  test('does not infer altitude when either endpoint is unknown', () {
+    final segments = BalloonAltitudeStyle.segments(const [
+      GeoPoint(latitude: 51, longitude: -2, elevationMeters: 100),
+      GeoPoint(latitude: 51.01, longitude: -2),
+    ]);
+
+    expect(segments.single.hasAltitude, isFalse);
+    expect(segments.single.color, BalloonAltitudeStyle.unknownColor);
+  });
+}

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:balloon_crumbs/domain/altitude.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/domain/route_store.dart';
+import 'package:balloon_crumbs/domain/distance_unit.dart';
 import 'package:balloon_crumbs/features/map/craft_icon.dart';
 import 'package:balloon_crumbs/features/map/ride_map.dart';
 import 'package:balloon_crumbs/services/basemap_configuration.dart';
@@ -41,8 +42,14 @@ void main() {
           label: 'Balloon ground track',
           kind: RiderTrailKind.balloonGroundTrack,
           points: [
-            GeoPoint(latitude: 51.4459, longitude: -2.6413),
-            GeoPoint(latitude: 51.43, longitude: -2.70),
+            GeoPoint(
+              latitude: 51.4459,
+              longitude: -2.6413,
+              elevationMeters: 50,
+            ),
+            GeoPoint(latitude: 51.44, longitude: -2.66, elevationMeters: 250),
+            GeoPoint(latitude: 51.435, longitude: -2.68, elevationMeters: 650),
+            GeoPoint(latitude: 51.43, longitude: -2.70, elevationMeters: 1150),
           ],
         ),
       ]);
@@ -64,8 +71,13 @@ void main() {
             offlineTileCache: cache,
             navigationPosition: navigation,
             riderTrails: trails,
+            landingZone: const MapLandingZone(
+              center: GeoPoint(latitude: 51.4128, longitude: -2.7584),
+              label: 'Simulated landing zone',
+            ),
             rideStarted: true,
             perspective: RideMapPerspective.balloon,
+            distanceUnit: DistanceUnit.miles,
             localMotorcycleStyle: CraftIconStyle.fourByFour,
           ),
         ),
@@ -83,13 +95,32 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('AIRSPACE UNAVAILABLE'), findsOneWidget);
+      expect(find.byKey(const Key('balloon-altitude-legend')), findsOneWidget);
+      expect(find.text('TRACK ALTITUDE · METRES'), findsOneWidget);
+      expect(find.byKey(const Key('landing-zone-area-layer')), findsOneWidget);
+      expect(
+        find.byKey(const Key('landing-zone-marker-layer')),
+        findsOneWidget,
+      );
 
       final trackLayer = tester.widget<PolylineLayer>(
         find.byType(PolylineLayer),
       );
       expect(
         trackLayer.polylines.any(
-          (line) => line.color == RouteTrailStyle.balloonGroundTrack.color,
+          (line) => line.color == const Color(0xFF55E05B),
+        ),
+        isTrue,
+      );
+      expect(
+        trackLayer.polylines.any(
+          (line) => line.color == const Color(0xFFFFE45E),
+        ),
+        isTrue,
+      );
+      expect(
+        trackLayer.polylines.any(
+          (line) => line.color == const Color(0xFFFF4FA3),
         ),
         isTrue,
       );

--- a/apps/mobile/test/services/aeronautical_chart_configuration_test.dart
+++ b/apps/mobile/test/services/aeronautical_chart_configuration_test.dart
@@ -49,23 +49,29 @@ void main() {
     expect(stale.explanationAt(now), contains('hidden until refreshed'));
   });
 
-  test('OpenAIP is selected with TMS tiles and a bounded build lifetime', () {
-    final configured = DateTime.utc(2026, 8, 20, 9, 30);
-    final openAip = AeronauticalChartConfiguration.openAip(
-      apiKey: 'key with symbols/+',
-      configuredAt: configured,
-    );
+  test(
+    'OpenAIP uses its current XYZ contract and a bounded build lifetime',
+    () {
+      final configured = DateTime.utc(2026, 8, 20, 9, 30);
+      final openAip = AeronauticalChartConfiguration.openAip(
+        apiKey: 'key with symbols/+',
+        configuredAt: configured,
+      );
 
-    expect(openAip.providerName, 'openAIP');
-    expect(openAip.tileScheme, AeronauticalTileScheme.tms);
-    expect(openAip.tileUrlTemplate, contains('/openaip/{z}/{x}/{y}.png'));
-    expect(openAip.tileUrlTemplate, contains('apiKey=key+with+symbols%2F%2B'));
-    expect(openAip.attribution, contains('CC BY-NC 4.0'));
-    expect(openAip.expiresAt, configured.add(const Duration(days: 28)));
-    expect(openAip.isCurrentAt(DateTime.utc(2026, 9, 1)), isTrue);
-    expect(openAip.limitations, contains('NOTAMs'));
-    expect(openAip.limitations, contains('Not for primary navigation'));
-  });
+      expect(openAip.providerName, 'openAIP');
+      expect(openAip.tileScheme, AeronauticalTileScheme.xyz);
+      expect(openAip.tileUrlTemplate, contains('/openaip/{z}/{x}/{y}.png'));
+      expect(
+        openAip.tileUrlTemplate,
+        contains('apiKey=key+with+symbols%2F%2B'),
+      );
+      expect(openAip.attribution, contains('CC BY-NC 4.0'));
+      expect(openAip.expiresAt, configured.add(const Duration(days: 28)));
+      expect(openAip.isCurrentAt(DateTime.utc(2026, 9, 1)), isTrue);
+      expect(openAip.limitations, contains('NOTAMs'));
+      expect(openAip.limitations, contains('Not for primary navigation'));
+    },
+  );
 
   test('OpenAIP remains unavailable without an API key or build timestamp', () {
     expect(

--- a/apps/mobile/test/services/ride_end_cost_test.dart
+++ b/apps/mobile/test/services/ride_end_cost_test.dart
@@ -209,6 +209,38 @@ void main() {
 
       expect(const TrailDisplaySimplifier().simplify(points), same(points));
     });
+
+    test(
+      'balloon simplification retains a vertical profile on a straight track',
+      () {
+        const simplifier = TrailDisplaySimplifier(
+          preserveAltitudeProfile: true,
+        );
+        final points = [
+          const route_domain.GeoPoint(
+            latitude: 51,
+            longitude: -2,
+            elevationMeters: 0,
+          ),
+          const route_domain.GeoPoint(
+            latitude: 51,
+            longitude: -1.99,
+            elevationMeters: 600,
+          ),
+          const route_domain.GeoPoint(
+            latitude: 51,
+            longitude: -1.98,
+            elevationMeters: 0,
+          ),
+        ];
+
+        expect(simplifier.simplify(points), points);
+        expect(const TrailDisplaySimplifier().simplify(points), [
+          points.first,
+          points.last,
+        ]);
+      },
+    );
   });
 }
 

--- a/docs/aeronautical-chart-source.md
+++ b/docs/aeronautical-chart-source.md
@@ -1,8 +1,13 @@
 # Aeronautical chart source
 
 OpenAIP is the selected advisory aeronautical layer for tester builds. The app
-uses OpenAIP's combined raster TMS layer and visibly attributes it as
+uses OpenAIP's combined raster aeronautical chart and visibly attributes it as
 `© openAIP contributors · CC BY-NC 4.0`.
+
+The service describes itself as TMS, but OpenAIP's current first-party
+MapLibre style consumes the published `{z}/{x}/{y}` coordinates as XYZ. The app
+matches that live contract and renders the combined chart opaquely instead of
+blending it into the ordinary road basemap.
 
 Release workflows require this Actions secret:
 

--- a/docs/tester-release-notes.md
+++ b/docs/tester-release-notes.md
@@ -5,4 +5,18 @@ version, Play version code, commit, destination track, and recent changes. Copy
 the tester-facing entry here after each release so an installed build can be
 matched to its changes.
 
-No Android tester build has been published for Balloon Crumbs yet.
+## 1.0.1 (Play build 25) — 20 August 2026
+
+- Colours each balloon ground-track leg by measured altitude and shows a metric
+  altitude legend; unavailable altitude remains grey.
+- Shows the simulated landing zone and keeps it inside the balloon/chase map
+  framing.
+- Corrects OpenAIP chart addressing and renders the selected aeronautical chart
+  without blending it into the road basemap.
+- Makes the simulator climb, cruise, descend, and land rather than remaining at
+  one altitude.
+- Keeps the complete recorded chase-crew trail instead of discarding its oldest
+  samples after a short distance.
+- Displays balloon altitude in metres independently of the road-distance unit.
+
+OpenAIP remains advisory context rather than an authoritative navigation source.


### PR DESCRIPTION
## Summary

- colour balloon ground-track segments by measured altitude with an accessible metric legend
- show the simulated landing zone and correct OpenAIP XYZ/full-chart rendering
- simulate ascent and descent while retaining complete chase-crew trail history
- keep altitude profile detail through display simplification and add tester release notes

## Verification

- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- complete `flutter test --reporter compact` suite
- `git diff --check`

Closes #34

Relates to #6, #10, and #17.