### PR TITLE
feat: add live wind chase demo

### DIFF
--- a/apps/mobile/lib/controllers/ride_simulation_controller.dart
+++ b/apps/mobile/lib/controllers/ride_simulation_controller.dart
@@ -13,6 +13,7 @@ import '../domain/rider_location.dart';
 import '../features/map/craft_icon.dart';
 import '../services/fiesta_flight_loader.dart';
 import '../services/geo_calculations.dart';
+import '../services/open_meteo_wind.dart';
 import '../services/situation_event_factory.dart';
 import 'situational_awareness_controller.dart';
 
@@ -64,14 +65,16 @@ class SimulatedRiderSnapshot {
 }
 
 /// Drives the production awareness pipeline with synthetic, authenticated GPS
-/// fixes. The owning shell deliberately disables internet, nearby and device
-/// location services for simulation sessions.
+/// fixes. The owning shell disables relay, nearby radio and device-location
+/// services for simulation sessions; the selected forecast provider may still
+/// be queried for advisory wind.
 class RideSimulationController extends ChangeNotifier {
   RideSimulationController(
     this._awarenessController, {
     required RideSession session,
     required List<GeoPoint> route,
     BalloonFlight? balloonFlight,
+    this.windForecastController,
     this.tickInterval = const Duration(milliseconds: 100),
     this.eventInterval = const Duration(seconds: 2),
     this.riderCount = RideSession.defaultSimulationRiderCount,
@@ -90,28 +93,32 @@ class RideSimulationController extends ChangeNotifier {
        // Keep the public constructor argument usable outside this library.
        // ignore: prefer_initializing_formals
        _balloonFlight = balloonFlight,
+       _balloonPosition = balloonFlight?.launch,
        _selectedLocalRole = session.role {
     _agents = _buildAgents(_routeSampler.totalDistanceMeters * 0.06);
   }
 
   static const offRouteRiderId = 'ride-lab-alex';
   static const backRiderId = 'ride-lab-charlie';
+  static const companionRiderId = 'ride-lab-land-rover';
 
   final SituationalAwarenessController _awarenessController;
   final RideSession _session;
-  final _RouteSampler _routeSampler;
+  _RouteSampler _routeSampler;
 
   /// The balloon's own flight, when one is bundled.
   ///
   /// The chase vehicles drive [_routeSampler], a road route, at a road speed.
-  /// The balloon does not: it has no steering and no throttle, so it is played
-  /// back against the clock from a track that was computed from measured winds.
+  /// The balloon does not: it has no steering and no throttle. Its altitude is
+  /// played against the flight clock and its horizontal motion is integrated
+  /// from the forecast wind, with the bundled air track as an offline fallback.
   /// Advancing it along the road with everyone else was the thing that made the
   /// old demo a group ride with the labels changed.
   ///
   /// Null falls back to that older behaviour, which keeps the focused tests that
   /// only care about group mechanics from having to carry a flight.
   final BalloonFlight? _balloonFlight;
+  final WindForecastController? windForecastController;
   final Duration tickInterval;
   final Duration eventInterval;
   final int riderCount;
@@ -128,6 +135,8 @@ class RideSimulationController extends ChangeNotifier {
   Duration _eventElapsed = Duration.zero;
   int _eventSequence = 0;
   DateTime? _lastRecordedAt;
+  GeoPoint? _balloonPosition;
+  double _balloonHeadingDegrees = 0;
 
   RideSimulationState get state => _state;
   Duration get simulatedElapsed => _simulatedElapsed;
@@ -136,11 +145,31 @@ class RideSimulationController extends ChangeNotifier {
   bool get backRiderDelayed => _backRiderDelayed;
   bool get rideStarted => _rideStarted;
   RideRole get localRole => _selectedLocalRole;
-  bool get alexOffRoute => _agent(offRouteRiderId).isOffRoute;
+  bool get alexOffRoute =>
+      _agents
+          .where((agent) => agent.id == offRouteRiderId)
+          .firstOrNull
+          ?.isOffRoute ??
+      false;
   bool get isRunning => _state == RideSimulationState.running;
   double get routeDistanceMeters => _routeSampler.totalDistanceMeters;
-  double get progress =>
-      (_agents.first.progressMeters / routeDistanceMeters).clamp(0, 1);
+  double get progress {
+    final flight = _balloonFlight;
+    if (_selectedLocalRole == RideRole.lead && flight != null) {
+      if (flight.duration.inMicroseconds <= 0) return 1;
+      return (_simulatedElapsed.inMicroseconds / flight.duration.inMicroseconds)
+          .clamp(0, 1);
+    }
+    final chase = _agents
+        .where((agent) => agent.role != RideRole.lead)
+        .firstOrNull;
+    return ((chase?.progressMeters ?? 0) / routeDistanceMeters).clamp(0, 1);
+  }
+
+  GeoPoint? get predictedLandingZone => _predictLandingZone();
+
+  SimulatedRiderSnapshot? get chaseVehicle =>
+      riders.where((rider) => rider.role != RideRole.lead).firstOrNull;
 
   List<SimulatedRiderSnapshot> get riders => List.unmodifiable(
     _agents.map((agent) {
@@ -168,6 +197,43 @@ class RideSimulationController extends ChangeNotifier {
   );
 
   List<_SimulatedAgent> _buildAgents(double leadStart) {
+    if (riderCount == 2) {
+      _SimulatedAgent agent({
+        required String id,
+        required String displayName,
+        required RideRole role,
+        required bool isLocal,
+      }) => _SimulatedAgent(
+        id: id,
+        displayName: displayName,
+        role: role,
+        progressMeters: 0,
+        speedFactor: 1,
+        trafficPhaseSeconds: isLocal ? 3 : 17,
+        isLocal: isLocal,
+        motorcycleStyle: CraftIconStyle.fourByFour,
+        riderSymbol: isLocal ? _session.riderSymbol : riderSymbolDefault,
+        riderColor: isLocal ? _session.riderColor : RiderColor.green,
+      );
+      return [
+        agent(
+          id: _session.localRiderId,
+          displayName: _session.displayName,
+          role: _selectedLocalRole,
+          isLocal: true,
+        ),
+        agent(
+          id: companionRiderId,
+          displayName: _selectedLocalRole == RideRole.lead
+              ? 'Land Rover'
+              : 'Balloon',
+          role: _selectedLocalRole == RideRole.lead
+              ? RideRole.rider
+              : RideRole.lead,
+          isLocal: false,
+        ),
+      ];
+    }
     final trailingSpan = math.min(860, math.max(160, leadStart * 0.82));
     double initialProgress(int index) =>
         math.max(0, leadStart - trailingSpan * index / (riderCount - 1));
@@ -256,6 +322,7 @@ class RideSimulationController extends ChangeNotifier {
   }
 
   List<GeoPoint> _displayTrailFor(_SimulatedAgent agent) {
+    if (riderCount == 2) return agent.travelTrail;
     if (agent.role != RideRole.lead) return agent.travelTrail;
     final backRider = _agent(backRiderId);
     final routeTrail = _routeSampler.pointsBetween(
@@ -320,6 +387,7 @@ class RideSimulationController extends ChangeNotifier {
   }
 
   void setAlexOffRoute(bool value) {
+    if (!_agents.any((agent) => agent.id == offRouteRiderId)) return;
     final alex = _agent(offRouteRiderId);
     if (alex.isOffRoute == value) return;
     alex.isOffRoute = value;
@@ -384,14 +452,29 @@ class RideSimulationController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Replaces only the road journey. Balloon time, altitude, position and both
+  /// travelled trails continue uninterrupted.
+  void replaceChaseRoute(List<GeoPoint> route) {
+    if (route.length < 2) return;
+    final next = _RouteSampler(route);
+    _routeSampler = next;
+    for (final agent in _agents.where((agent) => agent.role != RideRole.lead)) {
+      agent.progressMeters = 0;
+    }
+    notifyListeners();
+  }
+
   void _advanceMotion(Duration realElapsed) {
     final simulatedMicroseconds = (realElapsed.inMicroseconds * _timeScale)
         .round();
     final simulatedDelta = Duration(microseconds: simulatedMicroseconds);
+    final previousElapsed = _simulatedElapsed;
     _simulatedElapsed += simulatedDelta;
+    _advanceBalloon(previousElapsed, _simulatedElapsed);
     final seconds =
         simulatedDelta.inMicroseconds / Duration.microsecondsPerSecond;
     for (final agent in _agents) {
+      if (_balloonFlight != null && agent.role == RideRole.lead) continue;
       agent.progressMeters = math.min(
         routeDistanceMeters,
         agent.progressMeters + _speedFor(agent) * seconds,
@@ -404,9 +487,14 @@ class RideSimulationController extends ChangeNotifier {
     }
     final flightCompleted =
         _balloonFlight == null || _simulatedElapsed >= _balloonFlight.duration;
+    final roadAgents = _balloonFlight == null
+        ? _agents
+        : _agents.where((agent) => agent.role != RideRole.lead);
     final completed =
         flightCompleted &&
-        _agents.every((agent) => agent.progressMeters >= routeDistanceMeters);
+        roadAgents.every(
+          (agent) => agent.progressMeters >= routeDistanceMeters,
+        );
     if (completed) _state = RideSimulationState.completed;
     if (completed) {
       _timer?.cancel();
@@ -509,6 +597,12 @@ class RideSimulationController extends ChangeNotifier {
     if (!_rideStarted) {
       return _SimulatedPosition(position: flight.launch, headingDegrees: 0);
     }
+    if (windForecastController?.field != null && _balloonPosition != null) {
+      return _SimulatedPosition(
+        position: _balloonPosition!,
+        headingDegrees: _balloonHeadingDegrees,
+      );
+    }
     final (before, after, fraction) = _flightWindow(flight);
     final position = GeoPoint(
       latitude:
@@ -535,9 +629,13 @@ class RideSimulationController extends ChangeNotifier {
   /// missed rendezvous, so nothing here treats it as one.
   (BalloonFlightSample, BalloonFlightSample, double) _flightWindow(
     BalloonFlight flight,
+  ) => _flightWindowAt(flight, _simulatedElapsed);
+
+  (BalloonFlightSample, BalloonFlightSample, double) _flightWindowAt(
+    BalloonFlight flight,
+    Duration elapsed,
   ) {
     final samples = flight.samples;
-    final elapsed = _simulatedElapsed;
     if (elapsed >= flight.duration) {
       return (samples.last, samples.last, 0);
     }
@@ -551,6 +649,84 @@ class RideSimulationController extends ChangeNotifier {
     final span = (after.elapsed - before.elapsed).inMicroseconds.toDouble();
     final into = (elapsed - before.elapsed).inMicroseconds.toDouble();
     return (before, after, span <= 0 ? 0.0 : (into / span).clamp(0.0, 1.0));
+  }
+
+  double _heightAt(BalloonFlight flight, Duration elapsed) {
+    final (before, after, fraction) = _flightWindowAt(flight, elapsed);
+    return before.heightMetres +
+        (after.heightMetres - before.heightMetres) * fraction;
+  }
+
+  void _advanceBalloon(Duration from, Duration to) {
+    final flight = _balloonFlight;
+    final field = windForecastController?.field;
+    final initialPosition = _balloonPosition;
+    if (flight == null || field == null || initialPosition == null) return;
+    var position = initialPosition;
+    final end = to > flight.duration ? flight.duration : to;
+    var cursor = from > flight.duration ? flight.duration : from;
+    while (cursor < end) {
+      final stepEnd = cursor + const Duration(seconds: 10) < end
+          ? cursor + const Duration(seconds: 10)
+          : end;
+      final midpoint = cursor + (stepEnd - cursor) ~/ 2;
+      final altitudeMsl =
+          flight.launchElevationMetres + _heightAt(flight, midpoint);
+      final wind = field.at(position, altitudeMsl);
+      if (wind == null) break;
+      final seconds =
+          (stepEnd - cursor).inMicroseconds / Duration.microsecondsPerSecond;
+      position = _moveByWind(position, wind, seconds);
+      _balloonHeadingDegrees = wind.towardDegrees;
+      cursor = stepEnd;
+    }
+    _balloonPosition = position;
+  }
+
+  GeoPoint? _predictLandingZone() {
+    final flight = _balloonFlight;
+    final field = windForecastController?.field;
+    if (flight == null) return null;
+    if (field == null) return flight.landing;
+    var position = _balloonPosition ?? flight.launch;
+    var cursor = _simulatedElapsed;
+    if (cursor >= flight.duration) return position;
+    while (cursor < flight.duration) {
+      final stepEnd = cursor + const Duration(seconds: 30) < flight.duration
+          ? cursor + const Duration(seconds: 30)
+          : flight.duration;
+      final midpoint = cursor + (stepEnd - cursor) ~/ 2;
+      final altitudeMsl =
+          flight.launchElevationMetres + _heightAt(flight, midpoint);
+      final wind = field.at(position, altitudeMsl);
+      if (wind == null) return position;
+      final seconds =
+          (stepEnd - cursor).inMicroseconds / Duration.microsecondsPerSecond;
+      position = _moveByWind(position, wind, seconds);
+      cursor = stepEnd;
+    }
+    return position;
+  }
+
+  static GeoPoint _moveByWind(
+    GeoPoint point,
+    WindForecastVector wind,
+    double seconds,
+  ) {
+    const earthRadiusMeters = 6371000.0;
+    final latitudeRadians = point.latitude * math.pi / 180;
+    final latitude =
+        point.latitude +
+        wind.northMetersPerSecond * seconds / earthRadiusMeters * 180 / math.pi;
+    final longitudeScale = math.cos(latitudeRadians).abs().clamp(0.01, 1.0);
+    final longitude =
+        point.longitude +
+        wind.eastMetersPerSecond *
+            seconds /
+            (earthRadiusMeters * longitudeScale) *
+            180 /
+            math.pi;
+    return GeoPoint(latitude: latitude, longitude: longitude);
   }
 
   /// The balloon's height and climb rate at its current point in the flight.
@@ -625,6 +801,26 @@ class RideSimulationController extends ChangeNotifier {
   double _speedFor(_SimulatedAgent agent) {
     if (!_rideStarted) return 0;
     if (_state == RideSimulationState.completed) return 0;
+    final flight = _balloonFlight;
+    if (agent.role == RideRole.lead && flight != null) {
+      final position = _balloonPosition ?? flight.launch;
+      final altitude =
+          flight.launchElevationMetres + _heightAt(flight, _simulatedElapsed);
+      final forecast = windForecastController?.field?.at(position, altitude);
+      if (forecast != null) return forecast.speedMetersPerSecond;
+      final (before, after, _) = _flightWindow(flight);
+      final seconds =
+          (after.elapsed - before.elapsed).inMicroseconds /
+          Duration.microsecondsPerSecond;
+      return seconds <= 0
+          ? 0
+          : GeoCalculations.distanceMeters(before.position, after.position) /
+                seconds;
+    }
+    if (agent.role != RideRole.lead &&
+        agent.progressMeters >= routeDistanceMeters) {
+      return 0;
+    }
     if (agent.id == backRiderId && _backRiderDelayed) {
       return _baseSpeedMetersPerSecond * 0.45;
     }
@@ -666,16 +862,23 @@ class RideSimulationController extends ChangeNotifier {
   }
 
   void _positionFleetForPerspective() {
+    if (riderCount == 2) return;
     final local = _agents.first;
     if (_selectedLocalRole != RideRole.rider) return;
-    final maya = _agent('ride-lab-maya');
-    maya.progressMeters = math.min(
+    final balloon = riderCount == 2
+        ? _agent(companionRiderId)
+        : _agent('ride-lab-maya');
+    balloon.progressMeters = math.min(
       routeDistanceMeters,
-      math.max(maya.progressMeters, local.progressMeters + _followerGapMeters),
+      math.max(
+        balloon.progressMeters,
+        local.progressMeters + _followerGapMeters,
+      ),
     );
   }
 
   void _keepFollowerBehindLeader() {
+    if (riderCount == 2) return;
     if (_selectedLocalRole != RideRole.rider) return;
     final local = _agents.first;
     final lead = _leadAgent();
@@ -707,7 +910,14 @@ class RideSimulationController extends ChangeNotifier {
     }
     _agents.first.role = _selectedLocalRole;
     if (_selectedLocalRole != RideRole.lead) {
-      _agent('ride-lab-maya').role = RideRole.lead;
+      _agent(riderCount == 2 ? companionRiderId : 'ride-lab-maya').role =
+          RideRole.lead;
+    }
+    if (riderCount == 2) {
+      final companion = _agent(companionRiderId);
+      companion.displayName = _selectedLocalRole == RideRole.lead
+          ? 'Land Rover'
+          : 'Balloon';
     }
   }
 
@@ -719,8 +929,8 @@ class RideSimulationController extends ChangeNotifier {
   );
 
   String get _localPerspectiveName => switch (_selectedLocalRole) {
-    RideRole.lead => _session.displayName,
-    RideRole.rider => 'You · Follower',
+    RideRole.lead => riderCount == 2 ? 'Balloon' : _session.displayName,
+    RideRole.rider => riderCount == 2 ? 'You · Land Rover' : 'You · Follower',
   };
 
   DateTime _nextRecordedAt() {
@@ -770,7 +980,7 @@ class _SimulatedAgent {
   });
 
   final String id;
-  final String displayName;
+  String displayName;
   RideRole role;
   double progressMeters;
   final double speedFactor;

--- a/apps/mobile/lib/domain/ride_session.dart
+++ b/apps/mobile/lib/domain/ride_session.dart
@@ -7,9 +7,9 @@ import 'ride_role.dart';
 import 'rider_color.dart';
 
 class RideSession {
-  static const minimumSimulationRiderCount = 4;
+  static const minimumSimulationRiderCount = 2;
   static const maximumSimulationRiderCount = 30;
-  static const defaultSimulationRiderCount = 5;
+  static const defaultSimulationRiderCount = 2;
 
   const RideSession({
     required this.rideId,

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -51,6 +51,7 @@ import '../../services/navigation_export.dart';
 import '../../services/navigation_camera.dart';
 import '../../services/navigation_heading.dart';
 import '../../services/offline_tile_cache.dart';
+import '../../services/open_meteo_wind.dart';
 import '../../services/received_quick_message.dart';
 import '../../services/rider_trail_recorder.dart';
 import '../../services/road_routing.dart';
@@ -216,6 +217,7 @@ class RideMapFeature extends StatefulWidget {
     this.overlayMarkers,
     this.riderTrails,
     this.landingZone,
+    this.landingZoneUpdates,
     this.groupRiderCount,
     this.onOpenRoster,
     this.enforcementAlert,
@@ -271,6 +273,7 @@ class RideMapFeature extends StatefulWidget {
     this.perspective = RideMapPerspective.chase,
     this.aeronauticalChartConfiguration =
         const AeronauticalChartConfiguration(),
+    this.windForecastController,
   });
 
   factory RideMapFeature.fromEnvironment({
@@ -280,6 +283,7 @@ class RideMapFeature extends StatefulWidget {
     ValueListenable<List<MapOverlayMarker>>? overlayMarkers,
     ValueListenable<List<MapOverlayTrace>>? riderTrails,
     MapLandingZone? landingZone,
+    ValueListenable<MapLandingZone?>? landingZoneUpdates,
     int? groupRiderCount,
     VoidCallback? onOpenRoster,
     ValueListenable<EnforcementAlert?>? enforcementAlert,
@@ -332,6 +336,7 @@ class RideMapFeature extends StatefulWidget {
     Color localBadgeColor = const Color(0xFF2F80ED),
     RideMapPerspective perspective = RideMapPerspective.chase,
     AeronauticalChartConfiguration? aeronauticalChartConfiguration,
+    WindForecastController? windForecastController,
   }) => RideMapFeature(
     key: key,
     currentPosition: currentPosition,
@@ -339,6 +344,7 @@ class RideMapFeature extends StatefulWidget {
     overlayMarkers: overlayMarkers,
     riderTrails: riderTrails,
     landingZone: landingZone,
+    landingZoneUpdates: landingZoneUpdates,
     groupRiderCount: groupRiderCount,
     onOpenRoster: onOpenRoster,
     enforcementAlert: enforcementAlert,
@@ -394,6 +400,7 @@ class RideMapFeature extends StatefulWidget {
     aeronauticalChartConfiguration:
         aeronauticalChartConfiguration ??
         AeronauticalChartConfiguration.fromEnvironment(),
+    windForecastController: windForecastController,
   );
 
   final ValueListenable<GeoPoint?>? currentPosition;
@@ -401,6 +408,7 @@ class RideMapFeature extends StatefulWidget {
   final ValueListenable<List<MapOverlayMarker>>? overlayMarkers;
   final ValueListenable<List<MapOverlayTrace>>? riderTrails;
   final MapLandingZone? landingZone;
+  final ValueListenable<MapLandingZone?>? landingZoneUpdates;
 
   /// Which way the gap to the TEC is going (#181). Null where no trend is
   /// tracked, in which case the gap card shows the distance alone.
@@ -492,6 +500,7 @@ class RideMapFeature extends StatefulWidget {
   final Color localBadgeColor;
   final RideMapPerspective perspective;
   final AeronauticalChartConfiguration aeronauticalChartConfiguration;
+  final WindForecastController? windForecastController;
 
   @override
   State<RideMapFeature> createState() => _RideMapFeatureState();
@@ -603,6 +612,7 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         overlayMarkers: widget.overlayMarkers,
         riderTrails: widget.riderTrails,
         landingZone: widget.landingZone,
+        landingZoneUpdates: widget.landingZoneUpdates,
         groupRiderCount: widget.groupRiderCount,
         onOpenRoster: widget.onOpenRoster,
         enforcementAlert: widget.enforcementAlert,
@@ -651,6 +661,7 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         localBadgeColor: widget.localBadgeColor,
         perspective: widget.perspective,
         aeronauticalChartConfiguration: widget.aeronauticalChartConfiguration,
+        windForecastController: widget.windForecastController,
       );
     },
   );
@@ -689,6 +700,7 @@ class RideMapScreen extends StatefulWidget {
     this.overlayMarkers,
     this.riderTrails,
     this.landingZone,
+    this.landingZoneUpdates,
     this.groupRiderCount,
     this.onOpenRoster,
     this.enforcementAlert,
@@ -749,6 +761,7 @@ class RideMapScreen extends StatefulWidget {
     this.perspective = RideMapPerspective.chase,
     this.aeronauticalChartConfiguration =
         const AeronauticalChartConfiguration(),
+    this.windForecastController,
   });
 
   final RouteStore routeStore;
@@ -773,6 +786,7 @@ class RideMapScreen extends StatefulWidget {
   final ValueListenable<List<MapOverlayMarker>>? overlayMarkers;
   final ValueListenable<List<MapOverlayTrace>>? riderTrails;
   final MapLandingZone? landingZone;
+  final ValueListenable<MapLandingZone?>? landingZoneUpdates;
 
   /// Which way the gap to the TEC is going (#181). Null where no trend is
   /// tracked, in which case the gap card shows the distance alone.
@@ -869,6 +883,7 @@ class RideMapScreen extends StatefulWidget {
   final Color localBadgeColor;
   final RideMapPerspective perspective;
   final AeronauticalChartConfiguration aeronauticalChartConfiguration;
+  final WindForecastController? windForecastController;
 
   @override
   State<RideMapScreen> createState() => _RideMapScreenState();
@@ -885,6 +900,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
   static const _overlaySource = 'balloon-crumbs-overlays';
   static const _landingZoneSource = 'balloon-crumbs-landing-zone';
   static const _landingZoneImage = 'balloon-crumbs-landing-zone-flag';
+  static const _windForecastSource = 'balloon-crumbs-wind-forecast';
+  static const _windForecastImage = 'balloon-crumbs-wind-arrow';
   static const _aeronauticalChartSource = 'balloon-crumbs-aeronautical-chart';
   static const _aeronauticalChartLayer =
       'balloon-crumbs-aeronautical-chart-layer';
@@ -899,6 +916,17 @@ class _RideMapScreenState extends State<RideMapScreen> {
   bool get _showAeronauticalChart =>
       _isBalloonView &&
       widget.aeronauticalChartConfiguration.isCurrentAt(DateTime.now());
+
+  bool get _showWindForecast {
+    final controller = widget.windForecastController;
+    return _isBalloonView &&
+        controller != null &&
+        controller.enabled &&
+        controller.field != null;
+  }
+
+  MapLandingZone? get _landingZone =>
+      widget.landingZoneUpdates?.value ?? widget.landingZone;
 
   bool get _shouldAutoFollow =>
       _isBalloonView ? _effectivePosition != null : _isMoving;
@@ -1204,6 +1232,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
     widget.navigationPosition?.addListener(_onPositionChanged);
     widget.overlayMarkers?.addListener(_onOverlayDataChanged);
     widget.riderTrails?.addListener(_onOverlayDataChanged);
+    widget.landingZoneUpdates?.addListener(_onLandingZoneChanged);
+    widget.windForecastController?.addListener(_onWindForecastChanged);
     _connectorProgressGeometry = _connectorProgressTracker.update(
       _connectorRoute,
       _effectivePosition,
@@ -1240,6 +1270,16 @@ class _RideMapScreenState extends State<RideMapScreen> {
     if (oldWidget.riderTrails != widget.riderTrails) {
       oldWidget.riderTrails?.removeListener(_onOverlayDataChanged);
       widget.riderTrails?.addListener(_onOverlayDataChanged);
+    }
+    if (oldWidget.landingZoneUpdates != widget.landingZoneUpdates) {
+      oldWidget.landingZoneUpdates?.removeListener(_onLandingZoneChanged);
+      widget.landingZoneUpdates?.addListener(_onLandingZoneChanged);
+      _onLandingZoneChanged();
+    }
+    if (oldWidget.windForecastController != widget.windForecastController) {
+      oldWidget.windForecastController?.removeListener(_onWindForecastChanged);
+      widget.windForecastController?.addListener(_onWindForecastChanged);
+      _onWindForecastChanged();
     }
     if (oldWidget.speedLimitDisplay != widget.speedLimitDisplay) {
       if (_ownsSpeedLimitDisplay) _speedLimitDisplay.dispose();
@@ -1285,6 +1325,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
     widget.navigationPosition?.removeListener(_onPositionChanged);
     widget.overlayMarkers?.removeListener(_onOverlayDataChanged);
     widget.riderTrails?.removeListener(_onOverlayDataChanged);
+    widget.landingZoneUpdates?.removeListener(_onLandingZoneChanged);
+    widget.windForecastController?.removeListener(_onWindForecastChanged);
     _mapLibreController?.onFeatureTapped.remove(_onMapLibreFeatureTapped);
     _mapLibreController?.removeListener(_scheduleCameraFramingRefresh);
     _mapController.dispose();
@@ -1570,33 +1612,33 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   Positioned(
                     key: const Key('balloon-altitude-position'),
                     left: overlayLeft + 12,
-                    top: overlayTop + 12,
+                    // The clock is the first item in the balloon viewport. Keep
+                    // telemetry below it so the time never appears to belong to
+                    // the altitude card or gets covered by that wider surface.
+                    top: overlayTop + (widget.rideStarted ? 48 : 12),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         ValueListenableBuilder<MapNavigationPosition?>(
                           valueListenable: widget.navigationPosition!,
-                          builder: (context, fix, _) =>
-                              _BalloonAltitudeCard(fix: fix),
+                          builder: (context, fix, _) => _BalloonAltitudeCard(
+                            fix: fix,
+                            onShowMapInformation: _showBalloonMapInformation,
+                          ),
                         ),
                         const SizedBox(height: 8),
                         const _BalloonAltitudeLegend(),
                       ],
                     ),
                   ),
-                if (_isBalloonView)
+                if (_isBalloonView && widget.windForecastController != null)
                   Positioned(
-                    key: const Key('aeronautical-chart-status-position'),
+                    key: const Key('wind-forecast-control-position'),
+                    left: overlayLeft + 12,
                     right: overlayRight + 12,
-                    top: overlayTop + (landscape ? 12 : 118),
-                    child: _AeronauticalChartBadge(
-                      configuration: widget.aeronauticalChartConfiguration,
-                      now: DateTime.now(),
-                      onTap: () => _showMessage(
-                        widget.aeronauticalChartConfiguration.explanationAt(
-                          DateTime.now(),
-                        ),
-                      ),
+                    bottom: overlayBottom + 84,
+                    child: _WindForecastControl(
+                      controller: widget.windForecastController!,
                     ),
                   ),
                 Positioned.fill(
@@ -2332,7 +2374,10 @@ class _RideMapScreenState extends State<RideMapScreen> {
             Positioned(
               left: safeLeft,
               right: safeRight,
-              top: safeTop + 154,
+              // Balloon crews need the clock at the top of the viewport, above
+              // aircraft telemetry. The road view retains its established
+              // portrait placement clear of the route header and mini-map.
+              top: safeTop + (_isBalloonView ? 12 : 154),
               child: IgnorePointer(
                 child: Center(child: RideClock(darkMap: _basemap.dark)),
               ),
@@ -2473,7 +2518,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       ...(_isBalloonView
           ? _balloonGroundTrackPoints
           : route?.allPoints.toList(growable: false) ?? const <GeoPoint>[]),
-      ...?widget.landingZone?.boundary,
+      ...?_landingZone?.boundary,
     ];
     final points = framingPoints.map(_latLng).toList(growable: false);
     // With no route the rider's own position is the framing (#124); the UK-wide
@@ -2525,7 +2570,12 @@ class _RideMapScreenState extends State<RideMapScreen> {
             // road map made the two views look effectively identical.
             tileBuilder: (context, tile, _) => tile,
           ),
-        if (widget.landingZone case final zone?)
+        if (_showWindForecast)
+          MarkerLayer(
+            key: const Key('wind-forecast-layer'),
+            markers: _windForecastMarkers(),
+          ),
+        if (_landingZone case final zone?)
           CircleLayer(
             key: const Key('landing-zone-area-layer'),
             circles: [
@@ -2649,7 +2699,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   .toList(growable: false),
             ),
           ),
-        if (widget.landingZone case final zone?)
+        if (_landingZone case final zone?)
           MarkerLayer(
             key: const Key('landing-zone-marker-layer'),
             markers: [
@@ -2712,7 +2762,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       ...(_isBalloonView
           ? _balloonGroundTrackPoints
           : _route?.allPoints.toList(growable: false) ?? const []),
-      ...?widget.landingZone?.boundary,
+      ...?_landingZone?.boundary,
     ];
     // As above: no route still frames the rider rather than the whole country.
     final routePoints = planned.isNotEmpty ? planned : [?_effectivePosition];
@@ -3381,6 +3431,32 @@ class _RideMapScreenState extends State<RideMapScreen> {
     unawaited(_publishGroupPipSnapshot());
   }
 
+  void _onWindForecastChanged() {
+    if (!mounted) return;
+    setState(() {});
+    final controller = _mapLibreController;
+    if (_mapLibreStyleReady && controller != null) {
+      unawaited(
+        controller.setGeoJsonSource(
+          _windForecastSource,
+          _windForecastGeoJson(),
+        ),
+      );
+    }
+  }
+
+  void _onLandingZoneChanged() {
+    if (!mounted) return;
+    setState(() {});
+    final controller = _mapLibreController;
+    if (_mapLibreStyleReady && controller != null) {
+      unawaited(
+        controller.setGeoJsonSource(_landingZoneSource, _landingZoneGeoJson()),
+      );
+    }
+    _scheduleCameraFramingRefresh();
+  }
+
   void _onFlutterMapEvent(MapEvent event) {
     if (event.source == MapEventSource.nonRotatedSizeChange) return;
     if ((event.camera.rotation - _mapBearing.value).abs() >= 0.25) {
@@ -3911,6 +3987,58 @@ class _RideMapScreenState extends State<RideMapScreen> {
   /// MapLibre images are baked from - and answers a tap the way the native
   /// renderer does, so the two behave the same rather than one of them needing a
   /// long press to reveal a tooltip (#141).
+  List<WindForecastSample> _visibleWindForecastVectors() {
+    final controller = widget.windForecastController;
+    final field = controller?.field;
+    if (!_showWindForecast || controller == null || field == null) {
+      return const [];
+    }
+    return field.vectorsAt(controller.selectedAltitudeMetersMsl.toDouble());
+  }
+
+  List<Marker> _windForecastMarkers() => [
+    for (final sample in _visibleWindForecastVectors())
+      Marker(
+        point: LatLng(sample.position.latitude, sample.position.longitude),
+        width: 52,
+        height: 48,
+        child: Semantics(
+          label:
+              'Forecast wind from ${sample.vector.fromDegrees.round()} degrees '
+              'at ${sample.vector.speedKmh.round()} kilometres per hour',
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Transform.rotate(
+                angle: sample.vector.towardDegrees * math.pi / 180,
+                child: const Icon(
+                  Icons.navigation_rounded,
+                  color: Color(0xFF64D8FF),
+                  size: 25,
+                  shadows: [Shadow(color: Color(0xFF07131C), blurRadius: 5)],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 3, vertical: 1),
+                decoration: BoxDecoration(
+                  color: const Color(0xD907131C),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  '${sample.vector.speedKmh.round()}',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 9,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+  ];
+
   Widget _overlayMarkerChild(MapOverlayMarker overlay) {
     final hazard = overlay.hazardSymbol;
     if (hazard != null) {
@@ -3919,6 +4047,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         child: HazardMapSymbolBadge(symbol: hazard),
       );
     }
+
     final style = overlay.motorcycleStyle;
     return style == null
         ? _IconBadge(icon: overlay.icon, badgeColor: overlay.color, size: 34)
@@ -3974,6 +4103,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
     await controller.addImage(
       _landingZoneImage,
       await rasterizeIconGlyphPng(Icons.flag_rounded),
+      true,
+    );
+    await controller.addImage(
+      _windForecastImage,
+      await rasterizeIconGlyphPng(Icons.navigation_rounded),
       true,
     );
     _markerImagesRegistered = true;
@@ -4035,6 +4169,35 @@ class _RideMapScreenState extends State<RideMapScreen> {
           const ml.RasterLayerProperties(rasterOpacity: 1),
         );
       }
+      await controller.addGeoJsonSource(
+        _windForecastSource,
+        _windForecastGeoJson(),
+      );
+      await controller.addSymbolLayer(
+        _windForecastSource,
+        'balloon-crumbs-wind-forecast-arrows',
+        const ml.SymbolLayerProperties(
+          iconImage: _windForecastImage,
+          iconColor: '#64D8FF',
+          iconHaloColor: '#07131C',
+          iconHaloWidth: 2,
+          iconSize: 0.17,
+          iconRotate: ['get', 'toward'],
+          iconRotationAlignment: 'map',
+          iconPitchAlignment: 'map',
+          iconAllowOverlap: true,
+          iconIgnorePlacement: true,
+          textField: ['get', 'speedLabel'],
+          textColor: '#FFFFFF',
+          textHaloColor: '#07131C',
+          textHaloWidth: 2,
+          textSize: 10,
+          textOffset: [0, 1.7],
+          textAllowOverlap: true,
+          textIgnorePlacement: true,
+        ),
+        enableInteraction: false,
+      );
       await controller.addGeoJsonSource(
         _landingZoneSource,
         _landingZoneGeoJson(),
@@ -4309,6 +4472,10 @@ class _RideMapScreenState extends State<RideMapScreen> {
         _landingZoneGeoJson(),
       );
       await controller.setGeoJsonSource(
+        _windForecastSource,
+        _windForecastGeoJson(),
+      );
+      await controller.setGeoJsonSource(
         _trailDirectionArrowSource,
         _trailDirectionArrowGeoJson(),
       );
@@ -4574,7 +4741,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
   };
 
   Map<String, dynamic> _landingZoneGeoJson() {
-    final zone = widget.landingZone;
+    final zone = _landingZone;
     if (zone == null) {
       return const {'type': 'FeatureCollection', 'features': <Object>[]};
     }
@@ -4607,6 +4774,29 @@ class _RideMapScreenState extends State<RideMapScreen> {
       ],
     };
   }
+
+  Map<String, dynamic> _windForecastGeoJson() => {
+    'type': 'FeatureCollection',
+    'features': [
+      for (final sample in _visibleWindForecastVectors())
+        {
+          'type': 'Feature',
+          'properties': {
+            'toward': sample.vector.towardDegrees,
+            'from': sample.vector.fromDegrees,
+            'speedKmh': sample.vector.speedKmh,
+            'speedLabel': '${sample.vector.speedKmh.round()}',
+          },
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [
+              sample.position.longitude,
+              sample.position.latitude,
+            ],
+          },
+        },
+    ],
+  };
 
   Map<String, dynamic> _waypointGeoJson() => MapGeoJson.points(
     (_isBalloonView ? null : _route)?.waypoints
@@ -5242,7 +5432,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       ...(_isBalloonView
           ? _balloonGroundTrackPoints
           : _route?.allPoints.toList(growable: false) ?? const []),
-      ...?widget.landingZone?.boundary,
+      ...?_landingZone?.boundary,
     ];
     final routePoints = planned.isNotEmpty ? planned : [?_effectivePosition];
     if (_basemap.usesMapLibre) {
@@ -5554,6 +5744,19 @@ class _RideMapScreenState extends State<RideMapScreen> {
         ),
       ) ??
       false;
+
+  Future<void> _showBalloonMapInformation() async {
+    final now = DateTime.now();
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      useSafeArea: true,
+      builder: (context) => _BalloonMapInformationSheet(
+        configuration: widget.aeronauticalChartConfiguration,
+        now: now,
+      ),
+    );
+  }
 
   void _showMessage(String message) {
     if (!mounted) return;
@@ -8128,82 +8331,385 @@ class _EnforcementEmphasis extends StatelessWidget {
   }
 }
 
-class _AeronauticalChartBadge extends StatelessWidget {
-  const _AeronauticalChartBadge({
+class _WindForecastControl extends StatelessWidget {
+  const _WindForecastControl({required this.controller});
+
+  final WindForecastController controller;
+
+  @override
+  Widget build(BuildContext context) => AnimatedBuilder(
+    animation: controller,
+    builder: (context, _) {
+      final field = controller.field;
+      final selectedIndex = openMeteoWindAltitudeLevels.indexOf(
+        controller.selectedAltitudeMetersMsl,
+      );
+      final validAt = field?.validAt.toLocal();
+      final localizations = MaterialLocalizations.of(context);
+      final validTime = validAt == null
+          ? null
+          : '${localizations.formatShortDate(validAt)} '
+                '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(validAt))}';
+      final status = field == null
+          ? controller.loading
+                ? 'Loading latest forecast…'
+                : 'Forecast unavailable'
+          : field.isLiveForecast
+          ? '${field.sourceLabel} · valid $validTime'
+          : '${field.sourceLabel} · reference $validTime';
+      return Card(
+        key: const Key('wind-forecast-control'),
+        margin: EdgeInsets.zero,
+        color: const Color(0xE6252E39),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 12, 9),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Switch.adaptive(
+                    key: const Key('wind-forecast-toggle'),
+                    value: controller.enabled,
+                    onChanged: controller.setEnabled,
+                  ),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'FORECAST WIND · '
+                          '${controller.selectedAltitudeMetersMsl} M MSL',
+                          style: const TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w800,
+                            letterSpacing: 0.35,
+                          ),
+                        ),
+                        Text(
+                          status,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Color(0xFFB7C4D1),
+                            fontSize: 10,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (controller.loading && field != null)
+                    const Padding(
+                      padding: EdgeInsets.only(left: 8),
+                      child: SizedBox.square(
+                        dimension: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                ],
+              ),
+              if (controller.enabled) ...[
+                Row(
+                  children: [
+                    const Text('20', style: TextStyle(fontSize: 9)),
+                    Expanded(
+                      child: Slider(
+                        key: const Key('wind-altitude-slider'),
+                        min: 0,
+                        max: (openMeteoWindAltitudeLevels.length - 1)
+                            .toDouble(),
+                        divisions: openMeteoWindAltitudeLevels.length - 1,
+                        value: selectedIndex.clamp(0, 100).toDouble(),
+                        label: '${controller.selectedAltitudeMetersMsl} m MSL',
+                        onChanged: (value) => controller.setSelectedAltitude(
+                          openMeteoWindAltitudeLevels[value.round()].toDouble(),
+                        ),
+                      ),
+                    ),
+                    const Text('2000 m', style: TextStyle(fontSize: 9)),
+                  ],
+                ),
+                const Row(
+                  children: [
+                    Icon(Icons.navigation_rounded, size: 13),
+                    SizedBox(width: 5),
+                    Expanded(
+                      child: Text(
+                        'Arrow points downwind · number is km/h · forecast '
+                        'model only, not an aviation briefing',
+                        style: TextStyle(color: Color(0xFFB7C4D1), fontSize: 9),
+                      ),
+                    ),
+                  ],
+                ),
+                if (field?.origin == WindForecastOrigin.openMeteoUkmo)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: InkWell(
+                      key: const Key('open-meteo-attribution-link'),
+                      onTap: () => unawaited(
+                        launchUrl(
+                          OpenMeteoWindProvider.attributionUri,
+                          mode: LaunchMode.externalApplication,
+                        ),
+                      ),
+                      child: const Padding(
+                        padding: EdgeInsets.only(top: 5),
+                        child: Text(
+                          OpenMeteoWindProvider.attribution,
+                          style: TextStyle(
+                            color: Color(0xFF8DCBFF),
+                            fontSize: 9,
+                            decoration: TextDecoration.underline,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class _BalloonMapInformationSheet extends StatelessWidget {
+  const _BalloonMapInformationSheet({
     required this.configuration,
     required this.now,
-    required this.onTap,
   });
 
   final AeronauticalChartConfiguration configuration;
   final DateTime now;
-  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final current = configuration.isCurrentAt(now);
-    return Semantics(
-      button: true,
-      label: configuration.explanationAt(now),
-      child: Material(
-        key: const Key('aeronautical-chart-status'),
-        color: current ? const Color(0xE6252E39) : const Color(0xE63B3030),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(12),
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 170),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        current ? Icons.layers_outlined : Icons.layers_clear,
-                        size: 16,
-                        color: current
-                            ? const Color(0xFF6ED89A)
-                            : const Color(0xFFFFC857),
-                      ),
-                      const SizedBox(width: 6),
-                      Flexible(
-                        child: Text(
-                          configuration.statusLabelAt(now),
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 10,
-                            fontWeight: FontWeight.w800,
-                            letterSpacing: 0.4,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  if (current) ...[
-                    const SizedBox(height: 2),
-                    Text(
-                      configuration.attribution,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: Color(0xFFC6D0DA),
-                        fontSize: 9,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 4, 24, 28),
+        child: Column(
+          key: const Key('balloon-map-information-sheet'),
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Map information',
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
-          ),
+            const SizedBox(height: 20),
+            Row(
+              key: const Key('aeronautical-chart-information'),
+              children: [
+                Icon(
+                  current ? Icons.layers_outlined : Icons.layers_clear,
+                  color: current
+                      ? const Color(0xFF6ED89A)
+                      : const Color(0xFFFFC857),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    configuration.statusLabelAt(now),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(configuration.explanationAt(now)),
+            if (configuration.attribution.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              Text(
+                configuration.attribution,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: const Color(0xFFB7C4D1)),
+              ),
+            ],
+            const Divider(height: 36),
+            const _AeronauticalChartKey(),
+            const Divider(height: 36),
+            Row(
+              children: [
+                const Icon(Icons.height),
+                const SizedBox(width: 10),
+                Text(
+                  'Altitude and track',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            const Text(
+              'Balloon altitude and the coloured ground track are shown in '
+              'metres. GNSS altitude is not terrain clearance. Grey track '
+              'segments have no usable altitude.',
+            ),
+          ],
         ),
       ),
     );
   }
+}
+
+class _AeronauticalChartKey extends StatelessWidget {
+  const _AeronauticalChartKey();
+
+  @override
+  Widget build(BuildContext context) => Column(
+    key: const Key('aeronautical-chart-key'),
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Row(
+        children: [
+          const Icon(Icons.map_outlined),
+          const SizedBox(width: 10),
+          Text(
+            'Aeronautical chart key',
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+          ),
+        ],
+      ),
+      const SizedBox(height: 10),
+      const Text(
+        'Common markings in OpenAIP’s default chart. Colours group airspace '
+        'types; a colour alone does not say whether an area is active or safe '
+        'to enter.',
+      ),
+      const SizedBox(height: 14),
+      const _AeronauticalLegendRow(
+        borderColor: Color(0xFF9A0E0E),
+        fillColor: Color(0x339A0E0E),
+        title: 'Red / red hatching',
+        description:
+            'Prohibited, restricted, danger, and some temporary-use areas. '
+            'Check the named area and its current status.',
+      ),
+      const _AeronauticalLegendRow(
+        borderColor: Color(0xFF339E2F),
+        fillColor: Color(0x33339E2F),
+        title: 'Green',
+        description:
+            'Controlled airspace classes A–D. Clearance and operating rules '
+            'may apply.',
+      ),
+      const _AeronauticalLegendRow(
+        borderColor: Color(0xFF154D9A),
+        fillColor: Color(0x55DA6F86),
+        title: 'Blue / pink',
+        description:
+            'Control, traffic, and mandatory zones such as CTR, TMA, TMZ, and '
+            'RMZ. Blue also marks some Class E–G boundaries.',
+      ),
+      const _AeronauticalLegendRow(
+        borderColor: Color(0xFF9335C9),
+        fillColor: Color(0x33FF9200),
+        title: 'Orange / purple',
+        description:
+            'Military training, alert, warning, protected, or overflight '
+            'areas. Read the area label for its exact meaning.',
+      ),
+      const _AeronauticalLegendRow(
+        borderColor: Color(0xFF008BAF),
+        fillColor: Color(0x55FFD700),
+        title: 'Yellow / cyan',
+        description:
+            'Gliding, VFR, aerial sporting, or recreational activity areas.',
+      ),
+      const _AeronauticalLegendRow(
+        borderColor: Color(0xFF707070),
+        fillColor: Color(0x33575757),
+        title: 'Grey',
+        description: 'Airways and their boundaries.',
+      ),
+      const SizedBox(height: 4),
+      Text(
+        'LINES AND LABELS',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: const Color(0xFFCED6DF),
+          fontWeight: FontWeight.w800,
+          letterSpacing: 0.5,
+        ),
+      ),
+      const SizedBox(height: 6),
+      const Text(
+        'Dashed or hatched boundaries distinguish zone types; they do not '
+        'prove that a zone is active. Labels show the upper limit above the '
+        'lower limit. GND means the surface, MSL means above mean sea level, '
+        'and FL is a pressure-based flight level.',
+      ),
+      const SizedBox(height: 10),
+      const Text(
+        'If in doubt, treat the boundary as significant and confirm it with '
+        'the official AIP, current NOTAMs, and the flight’s responsible pilot.',
+        style: TextStyle(fontWeight: FontWeight.w700),
+      ),
+    ],
+  );
+}
+
+class _AeronauticalLegendRow extends StatelessWidget {
+  const _AeronauticalLegendRow({
+    required this.borderColor,
+    required this.fillColor,
+    required this.title,
+    required this.description,
+  });
+
+  final Color borderColor;
+  final Color fillColor;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(bottom: 12),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Semantics(
+          label: '$title chart marking',
+          child: Container(
+            width: 38,
+            height: 20,
+            margin: const EdgeInsets.only(top: 2),
+            decoration: BoxDecoration(
+              color: fillColor,
+              border: Border.all(color: borderColor, width: 2),
+              borderRadius: BorderRadius.circular(3),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: const TextStyle(fontWeight: FontWeight.w700)),
+              const SizedBox(height: 2),
+              Text(
+                description,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: const Color(0xFFCED6DF),
+                  height: 1.3,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
 }
 
 class _BalloonAltitudeLegend extends StatelessWidget {
@@ -8273,9 +8779,13 @@ class _BalloonAltitudeLegend extends StatelessWidget {
 }
 
 class _BalloonAltitudeCard extends StatelessWidget {
-  const _BalloonAltitudeCard({required this.fix});
+  const _BalloonAltitudeCard({
+    required this.fix,
+    required this.onShowMapInformation,
+  });
 
   final MapNavigationPosition? fix;
+  final VoidCallback onShowMapInformation;
 
   @override
   Widget build(BuildContext context) {
@@ -8317,16 +8827,29 @@ class _BalloonAltitudeCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Text(
-                  'BALLOON ALTITUDE',
-                  style: TextStyle(
-                    color: Color(0xFF9EABB9),
-                    fontSize: 11,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 0.8,
-                  ),
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        'BALLOON ALTITUDE',
+                        style: TextStyle(
+                          color: Color(0xFF9EABB9),
+                          fontSize: 11,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0.8,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      key: const Key('balloon-map-info-button'),
+                      tooltip: 'Map information',
+                      visualDensity: VisualDensity.compact,
+                      padding: EdgeInsets.zero,
+                      onPressed: onShowMapInformation,
+                      icon: const Icon(Icons.info_outline, size: 20),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 2),
                 Row(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.baseline,

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -66,6 +66,7 @@ import '../../services/fixed_speed_camera_provider.dart';
 import '../../services/gpx_import_source.dart';
 import '../../services/measurement_formatter.dart';
 import '../../services/native_push_token_source.dart';
+import '../../services/open_meteo_wind.dart';
 import '../../services/position_report_policy.dart';
 import '../../services/received_quick_message.dart';
 import '../../services/navigation_guidance.dart';
@@ -1077,6 +1078,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   CarPlayBridge? _carPlayBridge;
   String? _carPlayMapStyleJson;
   late final http.Client _carPlayRoutingClient;
+  late final http.Client _windForecastClient;
+  late final RoadRoutingService _simulationRoutingService;
   late final DestinationRoutePlanner _carPlayDestinationPlanner;
   ForegroundLocationController? _locationController;
   NearbyRelayController? _relayController;
@@ -1093,6 +1096,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   /// The bundled Fiesta flight, held so the simulation controller can play the
   /// balloon back against the clock rather than dragging it along the road.
   BalloonFlight? _balloonFlight;
+  WindForecastController? _windForecastController;
+  final ValueNotifier<MapLandingZone?> _simulationLandingZone = ValueNotifier(
+    null,
+  );
+  bool _simulationRerouteInFlight = false;
+  Duration? _lastSimulationRerouteElapsed;
+  awareness_geo.GeoPoint? _lastSimulationRerouteLanding;
+  int _simulationRerouteSequence = 0;
   RouteStore? _rideRouteStore;
   StreamSubscription<RideEvent>? _receivedEventSubscription;
   StreamSubscription<RideEvent>? _internetReceivedEventSubscription;
@@ -1173,21 +1184,23 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     )..start();
     final carPlayRouting = RoutingConfiguration.fromEnvironment();
     _carPlayRoutingClient = http.Client();
+    _windForecastClient = http.Client();
+    _simulationRoutingService = PreferenceAwareRoadRoutingService(
+      osrm: OsrmRoadRoutingService(
+        client: _carPlayRoutingClient,
+        baseUrl: carPlayRouting.routingBaseUrl,
+      ),
+      valhalla: ValhallaRoadRoutingService(
+        client: _carPlayRoutingClient,
+        routeUrl: carPlayRouting.valhallaRoutingUrl,
+      ),
+    );
     _carPlayDestinationPlanner = DestinationRoutePlanner(
       searchService: NominatimDestinationSearchService(
         client: _carPlayRoutingClient,
         baseUrl: carPlayRouting.geocodingBaseUrl,
       ),
-      routingService: PreferenceAwareRoadRoutingService(
-        osrm: OsrmRoadRoutingService(
-          client: _carPlayRoutingClient,
-          baseUrl: carPlayRouting.routingBaseUrl,
-        ),
-        valhalla: ValhallaRoadRoutingService(
-          client: _carPlayRoutingClient,
-          routeUrl: carPlayRouting.valhallaRoutingUrl,
-        ),
-      ),
+      routingService: _simulationRoutingService,
     );
     widget.rideController.addListener(_onRideControllerChanged);
     widget.sharedRoutes.addListener(_onSharedRoutesChanged);
@@ -1288,14 +1301,25 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         route = await loader.loadChaseRoute();
         _balloonFlight = await loader.load();
         _simulationRouteStore = InMemoryRouteStore(route);
+        final flight = _balloonFlight!;
+        _windForecastController = WindForecastController(
+          OpenMeteoWindProvider(client: _windForecastClient),
+          initialField: _bundledWindForecast(flight),
+        );
+        if (widget.enableNativeServices) {
+          unawaited(_windForecastController!.refresh(flight.launch));
+        }
         _warnings.add(
-          'Ride Lab is isolated: device GPS, internet relay and nearby radios '
-          'are disabled.',
+          'Ride Lab keeps device GPS, internet relay and nearby radios '
+          'disabled. Its forecast wind may use Open-Meteo.',
         );
       } on Object catch (error) {
         _warnings.add('The simulation route could not be loaded: $error');
       }
     } else if (widget.enableNativeServices) {
+      _windForecastController = WindForecastController(
+        OpenMeteoWindProvider(client: _windForecastClient),
+      );
       try {
         final session = widget.rideController.session;
         if (session != null) {
@@ -1955,7 +1979,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       session: session,
       route: simulationRoute,
       balloonFlight: _balloonFlight,
-      riderCount: session.simulationRiderCount,
+      windForecastController: _windForecastController,
+      // Old saved Ride Lab sessions can still carry the former five-rider
+      // setting. The demo is now deliberately one balloon and one chase car.
+      riderCount: RideSession.defaultSimulationRiderCount,
       rideStarted: widget.rideController.rideStarted,
     );
     _simulationController = controller;
@@ -1976,6 +2003,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   void _onSimulationVisualChanged() {
     if (!mounted || !_isSimulation) return;
+    _updateSimulationLandingZone();
+    unawaited(_rerouteSimulationChaseIfNeeded());
     final now = DateTime.now();
     final updateNavigationPosition =
         _lastSimulationNavigationUpdateAt == null ||
@@ -1991,12 +2020,127 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (updateOverlayMarkers) _lastSimulationOverlayUpdateAt = now;
     _updateMapOverlays(
       // The map status card is derived from the same authenticated synthetic
-      // fixes as the overlays. Without this, a restarted leader view could
-      // keep saying that Charlie's location was unavailable.
+      // fixes as the overlays. Without this, a restarted balloon view could
+      // keep saying that the chase vehicle's location was unavailable.
       updateDerivedState: updateOverlayMarkers,
       updateOverlayMarkers: updateOverlayMarkers,
       updateNavigationPosition: updateNavigationPosition,
     );
+  }
+
+  void _updateSimulationLandingZone() {
+    final simulation = _simulationController;
+    final predicted = simulation?.predictedLandingZone;
+    if (simulation == null || predicted == null) return;
+    final field = _windForecastController?.field;
+    final label = field?.isLiveForecast == true
+        ? 'Forecast landing area · UKMO via Open-Meteo'
+        : 'Forecast landing area · bundled wind fallback';
+    final next = MapLandingZone(
+      center: route_domain.GeoPoint(
+        latitude: predicted.latitude,
+        longitude: predicted.longitude,
+      ),
+      label: label,
+      radiusMeters: 300,
+    );
+    final previous = _simulationLandingZone.value;
+    if (previous != null &&
+        GeoCalculations.distanceMeters(
+              awareness_geo.GeoPoint(
+                latitude: previous.center.latitude,
+                longitude: previous.center.longitude,
+              ),
+              predicted,
+            ) <
+            10 &&
+        previous.label == next.label) {
+      return;
+    }
+    _simulationLandingZone.value = next;
+  }
+
+  Future<void> _rerouteSimulationChaseIfNeeded() async {
+    final simulation = _simulationController;
+    final landing = simulation?.predictedLandingZone;
+    final chase = simulation?.chaseVehicle;
+    if (!widget.enableNativeServices ||
+        simulation == null ||
+        landing == null ||
+        chase == null ||
+        _simulationRerouteInFlight ||
+        !widget.rideController.rideStarted ||
+        widget.rideController.ridePaused ||
+        widget.rideController.rideEnded) {
+      return;
+    }
+    final lastElapsed = _lastSimulationRerouteElapsed;
+    final elapsedEnough =
+        lastElapsed == null ||
+        simulation.simulatedElapsed - lastElapsed >= const Duration(minutes: 5);
+    final lastLanding = _lastSimulationRerouteLanding;
+    final landingMoved =
+        lastLanding == null ||
+        GeoCalculations.distanceMeters(lastLanding, landing) >= 300;
+    if (!elapsedEnough && !landingMoved) return;
+
+    _simulationRerouteInFlight = true;
+    // Record an attempt as well as a success. A temporary routing outage must
+    // not turn the simulator's 100 ms update into a network request loop.
+    _lastSimulationRerouteElapsed = simulation.simulatedElapsed;
+    _lastSimulationRerouteLanding = landing;
+    try {
+      final result = await _simulationRoutingService.routeThrough([
+        route_domain.GeoPoint(
+          latitude: chase.position.latitude,
+          longitude: chase.position.longitude,
+        ),
+        route_domain.GeoPoint(
+          latitude: landing.latitude,
+          longitude: landing.longitude,
+        ),
+      ], originBearingDegrees: chase.headingDegrees);
+      if (!mounted || _simulationController != simulation) return;
+      final route = route_domain.ImportedRoute(
+        id: 'live-chase-route-${_simulationRerouteSequence++}',
+        name: 'Live chase route to forecast landing area',
+        description:
+            'Recalculated from the Land Rover position to a road-accessible '
+            'point serving the forecast landing area.',
+        importedAt: DateTime.now(),
+        sourceFileName: 'live-open-meteo-chase-route',
+        paths: [
+          route_domain.RoutePath(
+            kind: route_domain.RoutePathKind.route,
+            points: result.points,
+          ),
+        ],
+        waypoints: const [],
+        maneuvers: result.maneuvers,
+      );
+      await _simulationRouteStore?.saveActiveRoute(route);
+      if (!mounted || _simulationController != simulation) return;
+      _activeRoute = route;
+      simulation.replaceChaseRoute(
+        result.points
+            .map(
+              (point) => awareness_geo.GeoPoint(
+                latitude: point.latitude,
+                longitude: point.longitude,
+              ),
+            )
+            .toList(growable: false),
+      );
+      setState(() {});
+    } on Object catch (error) {
+      final added = _warnings.add(
+        'Live chase rerouting is unavailable; the last road route is still '
+        'in use. $error',
+      );
+      if (added && mounted) setState(() {});
+    } finally {
+      _simulationRerouteInFlight = false;
+    }
   }
 
   void _onAwarenessChanged() {
@@ -2832,6 +2976,28 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         .toList(growable: false);
   }
 
+  static WindForecastField _bundledWindForecast(BalloonFlight flight) {
+    final vectors = [
+      for (final layer in flight.windLayers)
+        WindForecastVector(
+          altitudeMetersMsl: flight.launchElevationMetres + layer.heightMetres,
+          fromDegrees: layer.fromDegrees,
+          speedKmh: layer.speedKmh,
+        ),
+    ];
+    final sourceTime = DateTime.utc(2026, 8, 8, 6);
+    return WindForecastField(
+      columns: [
+        for (final point in windForecastGrid(flight.launch))
+          WindForecastColumn(position: point, vectors: vectors),
+      ],
+      validAt: sourceTime,
+      fetchedAt: sourceTime,
+      origin: WindForecastOrigin.bundledFallback,
+      sourceLabel: 'Bundled Open-Meteo rehearsal wind',
+    );
+  }
+
   Future<void> _onReceivedEvent(
     RideEvent event,
     RideTransportEvidence transport,
@@ -3067,6 +3233,18 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     // sample to the durable ride journal is briefly delayed or fails. Only
     // the journal feeds trails, summaries and GPX recording.
     _updateMapOverlays(updateDerivedState: false, updateOverlayMarkers: false);
+    final point = _mapPosition.value;
+    final wind = _windForecastController;
+    if (point != null && wind != null) {
+      unawaited(
+        wind.refresh(
+          awareness_geo.GeoPoint(
+            latitude: point.latitude,
+            longitude: point.longitude,
+          ),
+        ),
+      );
+    }
     if (warningChanged) setState(() {});
   }
 
@@ -3350,7 +3528,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     return RideMapFeature.fromEnvironment(
       key: ValueKey(
         'ride-map:${_appliedAuthoritativeRouteRevision ?? 'local'}:'
-        '${_activeRoute?.id ?? 'none'}:'
+        '${isBalloonView ? 'air' : _activeRoute?.id ?? 'none'}:'
         '${isBalloonView ? 'balloon' : 'chase'}',
       ),
       currentPosition: _mapPosition,
@@ -3358,15 +3536,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       navigationPosition: _mapNavigationPosition,
       overlayMarkers: _mapOverlays,
       riderTrails: _riderTrails,
-      landingZone: _isSimulation && _balloonFlight != null
-          ? MapLandingZone(
-              center: route_domain.GeoPoint(
-                latitude: _balloonFlight!.landing.latitude,
-                longitude: _balloonFlight!.landing.longitude,
-              ),
-              label: 'Simulated landing zone · wind-model endpoint',
-            )
-          : null,
+      landingZone: _isSimulation ? _simulationLandingZone.value : null,
+      landingZoneUpdates: _isSimulation ? _simulationLandingZone : null,
+      windForecastController: _windForecastController,
       groupRiderCount: widget.rideController.liveParticipants.length,
       onOpenRoster: _openRoster,
       // Deliberately not `onOpenRideMenu`. The control that reaches the other
@@ -3449,6 +3621,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           widget.mapStyleMode.dayStyle == DayMapStyle.restrained,
       localMotorcycleStyle: isBalloonView
           ? CraftIconStyle.balloon
+          : _isSimulation
+          ? CraftIconStyle.fourByFour
           : session?.motorcycleStyle ?? craftIconStyleDefault,
       localRiderSymbol:
           widget.rideController.session?.riderSymbol ?? riderSymbolDefault,
@@ -4848,6 +5022,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     widget.sharedRoutes.removeListener(_onSharedRoutesChanged);
     _simulationController?.removeListener(_onSimulationVisualChanged);
     _simulationController?.dispose();
+    _windForecastController?.dispose();
+    _simulationLandingZone.dispose();
     _preStartPresenceController?.removeListener(_onPreStartPresenceChanged);
     unawaited(_spokenGuidance?.stop());
     _awarenessController?.removeListener(_onAwarenessChanged);
@@ -4879,6 +5055,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     _rideCompletionSuggestion.dispose();
     unawaited(_carPlayBridge?.dispose());
     _carPlayRoutingClient.close();
+    _windForecastClient.close();
     super.dispose();
   }
 }

--- a/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
+++ b/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import '../../controllers/ride_simulation_controller.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/ride_role.dart';
-import '../../domain/ride_session.dart';
 import '../../services/measurement_formatter.dart';
 import '../map/craft_icon.dart';
 
@@ -57,7 +56,6 @@ class RideSimulationScreen extends StatelessWidget {
             final controls = _SimulationControls(
               controller: controller,
               onRoleChanged: onRoleChanged,
-              onRiderCountChanged: onRiderCountChanged,
             );
             final fleet = _FleetCard(
               controller: controller,
@@ -91,12 +89,10 @@ class _SimulationControls extends StatelessWidget {
   const _SimulationControls({
     required this.controller,
     required this.onRoleChanged,
-    required this.onRiderCountChanged,
   });
 
   final RideSimulationController controller;
   final Future<void> Function(RideRole role) onRoleChanged;
-  final Future<void> Function(int riderCount) onRiderCountChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -132,9 +128,9 @@ class _SimulationControls extends StatelessWidget {
             ),
             const SizedBox(height: 10),
             Text(
-              '${controller.riderCount} virtual craft use the real navigation '
-              'and off-course logic. Device GPS, internet relay and nearby '
-              'radios are off.',
+              'One balloon and one Land Rover use the production map and '
+              'navigation pipeline. The balloon keeps its scripted altitude '
+              'profile while forecast wind drives its horizontal track.',
               style: const TextStyle(color: Color(0xFFADB7C4), height: 1.35),
             ),
             const SizedBox(height: 14),
@@ -178,44 +174,9 @@ class _SimulationControls extends StatelessWidget {
             LinearProgressIndicator(value: controller.progress),
             const SizedBox(height: 8),
             Text(
-              '${(controller.progress * 100).round()}% route · '
+              '${(controller.progress * 100).round()}% flight · '
               '${_duration(controller.simulatedElapsed)} simulated',
               style: const TextStyle(color: Color(0xFF8F9BAA)),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                const Expanded(
-                  child: Text(
-                    'Virtual riders',
-                    style: TextStyle(fontWeight: FontWeight.w700),
-                  ),
-                ),
-                DropdownButton<int>(
-                  key: const Key('simulation-rider-count'),
-                  value: controller.riderCount,
-                  items: [
-                    for (
-                      var count = RideSession.minimumSimulationRiderCount;
-                      count <= RideSession.maximumSimulationRiderCount;
-                      count += 1
-                    )
-                      DropdownMenuItem(
-                        value: count,
-                        child: Text('$count riders'),
-                      ),
-                  ],
-                  onChanged: (count) {
-                    if (count != null && count != controller.riderCount) {
-                      unawaited(onRiderCountChanged(count));
-                    }
-                  },
-                ),
-              ],
-            ),
-            const Text(
-              'Changing the fleet starts a clean simulation.',
-              style: TextStyle(color: Color(0xFF8F9BAA), fontSize: 12),
             ),
             const SizedBox(height: 16),
             Row(
@@ -264,34 +225,12 @@ class _SimulationControls extends StatelessWidget {
               ],
             ),
             const Divider(height: 28),
-            SwitchListTile.adaptive(
-              key: const Key('simulation-off-route'),
-              contentPadding: EdgeInsets.zero,
-              title: const Text('Send Alex off route'),
-              subtitle: const Text('Builds the magenta trail and leader alert'),
-              value: controller.alexOffRoute,
-              onChanged: controller.setAlexOffRoute,
-            ),
-            SwitchListTile.adaptive(
-              key: const Key('simulation-tec-delay'),
-              contentPadding: EdgeInsets.zero,
-              title: const Text('Delay the back rider'),
-              subtitle: const Text('Increases the lead-to-TEC gap'),
-              value: controller.backRiderDelayed,
-              onChanged: controller.setBackRiderDelayed,
-            ),
-            const SizedBox(height: 6),
-            OutlinedButton.icon(
-              key: const Key('simulation-hazard'),
-              onPressed: () => unawaited(controller.reportRoadworks()),
-              icon: const Icon(Icons.warning_amber_rounded),
-              label: const Text('Drop roadworks 450 m ahead'),
-            ),
-            const SizedBox(height: 8),
             const Text(
-              'Open the Map tab to watch the production UI respond.',
-              textAlign: TextAlign.center,
-              style: TextStyle(color: Color(0xFF7F8A98), fontSize: 12),
+              'On the Map tab, the forecast landing area moves with the '
+              'balloon and the Land Rover recalculates its road route from its '
+              'actual position. Use the wind control there to change the '
+              'displayed altitude or hide the layer.',
+              style: TextStyle(color: Color(0xFF8F9BAA), height: 1.35),
             ),
           ],
         ),
@@ -320,7 +259,10 @@ class _FleetCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text('VIRTUAL FLEET', style: Theme.of(context).textTheme.titleMedium),
+          Text(
+            'LIVE DEMO CRAFT',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
           const SizedBox(height: 12),
           for (final rider in controller.riders) ...[
             Row(

--- a/apps/mobile/lib/services/fiesta_flight_loader.dart
+++ b/apps/mobile/lib/services/fiesta_flight_loader.dart
@@ -62,12 +62,14 @@ class BalloonFlight {
     required this.samples,
     required this.windLayers,
     required this.source,
+    this.launchElevationMetres = 0,
   });
 
   final String name;
   final GeoPoint launch;
   final List<BalloonFlightSample> samples;
   final List<BalloonWindLayer> windLayers;
+  final double launchElevationMetres;
 
   /// Provenance, carried so a surface can say where the numbers came from.
   final String source;
@@ -161,6 +163,8 @@ class BundledFiestaFlightLoader {
         longitude: (launch['longitude'] as num).toDouble(),
       ),
       source: decoded['source'] as String? ?? '',
+      launchElevationMetres:
+          (launch['elevationMetres'] as num?)?.toDouble() ?? 0,
       windLayers: [
         for (final layer
             in (decoded['windLayers'] as List? ?? []).whereType<Map>())

--- a/apps/mobile/lib/services/open_meteo_wind.dart
+++ b/apps/mobile/lib/services/open_meteo_wind.dart
@@ -1,0 +1,407 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../domain/geo_point.dart';
+import 'geo_calculations.dart';
+
+/// Height levels exposed by Open-Meteo's UKMO UKV forecast that are useful to
+/// a typical balloon flight. Values are metres above mean sea level (MSL).
+const openMeteoWindAltitudeLevels = <int>[
+  20,
+  50,
+  100,
+  150,
+  200,
+  300,
+  400,
+  500,
+  600,
+  800,
+  1000,
+  1250,
+  1500,
+  2000,
+];
+
+enum WindForecastOrigin { openMeteoUkmo, bundledFallback }
+
+class WindForecastVector {
+  const WindForecastVector({
+    required this.altitudeMetersMsl,
+    required this.fromDegrees,
+    required this.speedKmh,
+  });
+
+  final double altitudeMetersMsl;
+
+  /// Meteorological direction: where the wind comes from.
+  final double fromDegrees;
+  final double speedKmh;
+
+  double get towardDegrees => (fromDegrees + 180) % 360;
+  double get speedMetersPerSecond => speedKmh / 3.6;
+
+  double get eastMetersPerSecond {
+    final radians = towardDegrees * math.pi / 180;
+    return speedMetersPerSecond * math.sin(radians);
+  }
+
+  double get northMetersPerSecond {
+    final radians = towardDegrees * math.pi / 180;
+    return speedMetersPerSecond * math.cos(radians);
+  }
+
+  static WindForecastVector fromComponents({
+    required double altitudeMetersMsl,
+    required double eastMetersPerSecond,
+    required double northMetersPerSecond,
+  }) {
+    final speed = math.sqrt(
+      eastMetersPerSecond * eastMetersPerSecond +
+          northMetersPerSecond * northMetersPerSecond,
+    );
+    final toward =
+        (math.atan2(eastMetersPerSecond, northMetersPerSecond) * 180 / math.pi +
+            360) %
+        360;
+    return WindForecastVector(
+      altitudeMetersMsl: altitudeMetersMsl,
+      fromDegrees: (toward + 180) % 360,
+      speedKmh: speed * 3.6,
+    );
+  }
+}
+
+class WindForecastColumn {
+  const WindForecastColumn({required this.position, required this.vectors});
+
+  final GeoPoint position;
+  final List<WindForecastVector> vectors;
+
+  WindForecastVector? atAltitude(double altitudeMetersMsl) {
+    if (vectors.isEmpty) return null;
+    final ordered = [...vectors]
+      ..sort(
+        (first, second) =>
+            first.altitudeMetersMsl.compareTo(second.altitudeMetersMsl),
+      );
+    if (altitudeMetersMsl <= ordered.first.altitudeMetersMsl) {
+      return ordered.first;
+    }
+    if (altitudeMetersMsl >= ordered.last.altitudeMetersMsl) {
+      return ordered.last;
+    }
+    for (var index = 0; index < ordered.length - 1; index += 1) {
+      final below = ordered[index];
+      final above = ordered[index + 1];
+      if (altitudeMetersMsl > above.altitudeMetersMsl) continue;
+      final span = above.altitudeMetersMsl - below.altitudeMetersMsl;
+      final fraction = span <= 0
+          ? 0.0
+          : (altitudeMetersMsl - below.altitudeMetersMsl) / span;
+      // Interpolate the vector, not the bearing. A 350°/10° pair averages to
+      // north, while averaging the bearing numbers would point south.
+      return WindForecastVector.fromComponents(
+        altitudeMetersMsl: altitudeMetersMsl,
+        eastMetersPerSecond:
+            below.eastMetersPerSecond +
+            (above.eastMetersPerSecond - below.eastMetersPerSecond) * fraction,
+        northMetersPerSecond:
+            below.northMetersPerSecond +
+            (above.northMetersPerSecond - below.northMetersPerSecond) *
+                fraction,
+      );
+    }
+    return ordered.last;
+  }
+}
+
+class WindForecastSample {
+  const WindForecastSample({required this.position, required this.vector});
+
+  final GeoPoint position;
+  final WindForecastVector vector;
+}
+
+class WindForecastField {
+  const WindForecastField({
+    required this.columns,
+    required this.validAt,
+    required this.fetchedAt,
+    required this.origin,
+    required this.sourceLabel,
+  });
+
+  final List<WindForecastColumn> columns;
+  final DateTime validAt;
+  final DateTime fetchedAt;
+  final WindForecastOrigin origin;
+  final String sourceLabel;
+
+  bool get isLiveForecast => origin == WindForecastOrigin.openMeteoUkmo;
+
+  WindForecastVector? at(GeoPoint position, double altitudeMetersMsl) {
+    if (columns.isEmpty) return null;
+    final nearest = columns.reduce(
+      (first, second) =>
+          GeoCalculations.distanceMeters(position, first.position) <=
+              GeoCalculations.distanceMeters(position, second.position)
+          ? first
+          : second,
+    );
+    return nearest.atAltitude(altitudeMetersMsl);
+  }
+
+  List<WindForecastSample> vectorsAt(double altitudeMetersMsl) =>
+      List.unmodifiable([
+        for (final column in columns)
+          if (column.atAltitude(altitudeMetersMsl) case final vector?)
+            WindForecastSample(position: column.position, vector: vector),
+      ]);
+}
+
+abstract interface class WindForecastProvider {
+  Future<WindForecastField> fetch({
+    required GeoPoint center,
+    required DateTime at,
+  });
+}
+
+/// Latest UK Met Office UKV wind forecast, delivered by Open-Meteo.
+///
+/// This is forecast model output, not an airborne observation and not an
+/// aviation weather briefing. The request intentionally asks for a small 3×3
+/// grid and a short time window; slider changes reuse the vertical profile and
+/// never create another network request.
+class OpenMeteoWindProvider implements WindForecastProvider {
+  OpenMeteoWindProvider({
+    required this.client,
+    Uri? endpoint,
+    this.timeout = const Duration(seconds: 10),
+    this.maximumResponseBytes = 2 * 1024 * 1024,
+  }) : endpoint = endpoint ?? Uri.https('api.open-meteo.com', '/v1/forecast');
+
+  static const sourceLabel = 'UKMO UKV forecast via Open-Meteo';
+  static const attribution = 'Weather data by Open-Meteo.com';
+  static final attributionUri = Uri.parse('https://open-meteo.com/');
+
+  final http.Client client;
+  final Uri endpoint;
+  final Duration timeout;
+  final int maximumResponseBytes;
+
+  @override
+  Future<WindForecastField> fetch({
+    required GeoPoint center,
+    required DateTime at,
+  }) async {
+    if (endpoint.scheme != 'https' || endpoint.host.isEmpty) {
+      throw const FormatException('Open-Meteo wind endpoint must use HTTPS.');
+    }
+    final requestedPoints = windForecastGrid(center);
+    final variables = <String>[
+      for (final altitude in openMeteoWindAltitudeLevels) ...[
+        'wind_speed_${altitude}m',
+        'wind_direction_${altitude}m',
+      ],
+    ];
+    final uri = endpoint.replace(
+      queryParameters: {
+        'latitude': requestedPoints
+            .map((point) => point.latitude.toStringAsFixed(6))
+            .join(','),
+        'longitude': requestedPoints
+            .map((point) => point.longitude.toStringAsFixed(6))
+            .join(','),
+        'models': 'ukmo_seamless',
+        'hourly': variables.join(','),
+        'wind_speed_unit': 'kmh',
+        'timezone': 'GMT',
+        'past_hours': '1',
+        'forecast_hours': '3',
+      },
+    );
+    final response = await client
+        .get(uri, headers: const {'Accept': 'application/json'})
+        .timeout(timeout);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw FormatException(
+        'Open-Meteo wind request failed (${response.statusCode}).',
+      );
+    }
+    if (response.bodyBytes.length > maximumResponseBytes) {
+      throw const FormatException('Open-Meteo wind response is too large.');
+    }
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    final entries = decoded is List ? decoded : [decoded];
+    final columns = <WindForecastColumn>[];
+    DateTime? commonValidAt;
+    for (final entry in entries) {
+      if (entry is! Map) continue;
+      final latitude = (entry['latitude'] as num?)?.toDouble();
+      final longitude = (entry['longitude'] as num?)?.toDouble();
+      final hourly = entry['hourly'];
+      if (latitude == null || longitude == null || hourly is! Map) continue;
+      final times = hourly['time'];
+      if (times is! List || times.isEmpty) continue;
+      final parsedTimes = <DateTime>[];
+      for (final value in times) {
+        final parsed = DateTime.tryParse('${value}Z')?.toUtc();
+        if (parsed != null) parsedTimes.add(parsed);
+      }
+      if (parsedTimes.length != times.length) continue;
+      final target = at.toUtc();
+      var timeIndex = 0;
+      for (var index = 1; index < parsedTimes.length; index += 1) {
+        if ((parsedTimes[index].difference(target)).abs() <
+            (parsedTimes[timeIndex].difference(target)).abs()) {
+          timeIndex = index;
+        }
+      }
+      final validAt = parsedTimes[timeIndex];
+      commonValidAt ??= validAt;
+      final vectors = <WindForecastVector>[];
+      for (final altitude in openMeteoWindAltitudeLevels) {
+        final speeds = hourly['wind_speed_${altitude}m'];
+        final directions = hourly['wind_direction_${altitude}m'];
+        if (speeds is! List || directions is! List) continue;
+        if (timeIndex >= speeds.length || timeIndex >= directions.length) {
+          continue;
+        }
+        final speed = (speeds[timeIndex] as num?)?.toDouble();
+        final direction = (directions[timeIndex] as num?)?.toDouble();
+        if (speed == null || direction == null) continue;
+        if (!speed.isFinite || !direction.isFinite || speed < 0) continue;
+        vectors.add(
+          WindForecastVector(
+            altitudeMetersMsl: altitude.toDouble(),
+            fromDegrees: direction % 360,
+            speedKmh: speed,
+          ),
+        );
+      }
+      if (vectors.isNotEmpty) {
+        columns.add(
+          WindForecastColumn(
+            position: GeoPoint(latitude: latitude, longitude: longitude),
+            vectors: List.unmodifiable(vectors),
+          ),
+        );
+      }
+    }
+    if (columns.isEmpty || commonValidAt == null) {
+      throw const FormatException('Open-Meteo returned no usable wind data.');
+    }
+    return WindForecastField(
+      columns: List.unmodifiable(columns),
+      validAt: commonValidAt,
+      fetchedAt: DateTime.now().toUtc(),
+      origin: WindForecastOrigin.openMeteoUkmo,
+      sourceLabel: sourceLabel,
+    );
+  }
+}
+
+/// Nine sample points covering roughly 9 × 9 km around [center].
+List<GeoPoint> windForecastGrid(GeoPoint center) => List.unmodifiable([
+  for (final latitudeOffset in const [-0.04, 0.0, 0.04])
+    for (final longitudeOffset in const [-0.06, 0.0, 0.06])
+      GeoPoint(
+        latitude: (center.latitude + latitudeOffset).clamp(-90, 90),
+        longitude: (center.longitude + longitudeOffset).clamp(-180, 180),
+      ),
+]);
+
+class WindForecastController extends ChangeNotifier {
+  WindForecastController(
+    this._provider, {
+    DateTime Function()? clock,
+    WindForecastField? initialField,
+    bool enabled = true,
+    int selectedAltitudeMetersMsl = 500,
+  }) : _clock = clock ?? DateTime.now,
+       _field = initialField,
+       _selectedAltitudeMetersMsl = _nearestLevel(
+         selectedAltitudeMetersMsl.toDouble(),
+       ) {
+    _enabled = enabled;
+  }
+
+  final WindForecastProvider _provider;
+  final DateTime Function() _clock;
+  WindForecastField? _field;
+  bool _enabled = true;
+  int _selectedAltitudeMetersMsl;
+  bool _loading = false;
+  String? _error;
+  GeoPoint? _lastCenter;
+  DateTime? _lastAttemptAt;
+  int _generation = 0;
+
+  WindForecastField? get field => _field;
+  bool get enabled => _enabled;
+  bool get loading => _loading;
+  String? get error => _error;
+  int get selectedAltitudeMetersMsl => _selectedAltitudeMetersMsl;
+
+  void setEnabled(bool value) {
+    if (_enabled == value) return;
+    _enabled = value;
+    notifyListeners();
+  }
+
+  void setSelectedAltitude(double value) {
+    final next = _nearestLevel(value);
+    if (next == _selectedAltitudeMetersMsl) return;
+    _selectedAltitudeMetersMsl = next;
+    notifyListeners();
+  }
+
+  Future<void> refresh(GeoPoint center, {bool force = false}) async {
+    final now = _clock().toUtc();
+    final lastAttempt = _lastAttemptAt;
+    if (!force &&
+        (_loading ||
+            (lastAttempt != null &&
+                now.difference(lastAttempt).abs() <
+                    const Duration(minutes: 10)))) {
+      return;
+    }
+    final lastCenter = _lastCenter;
+    final field = _field;
+    final fresh =
+        field != null &&
+        now.difference(field.fetchedAt).abs() < const Duration(minutes: 30);
+    final nearby =
+        lastCenter != null &&
+        GeoCalculations.distanceMeters(lastCenter, center) < 5000;
+    if (!force && fresh && nearby && field.isLiveForecast) return;
+    final generation = ++_generation;
+    _lastAttemptAt = now;
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      final result = await _provider.fetch(center: center, at: _clock());
+      if (generation != _generation) return;
+      _field = result;
+      _lastCenter = center;
+    } on Object catch (error) {
+      if (generation != _generation) return;
+      _error = '$error';
+    } finally {
+      if (generation == _generation) {
+        _loading = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  static int _nearestLevel(double value) => openMeteoWindAltitudeLevels.reduce(
+    (first, second) =>
+        (first - value).abs() <= (second - value).abs() ? first : second,
+  );
+}

--- a/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
+++ b/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
@@ -6,6 +6,7 @@ import 'package:balloon_crumbs/domain/ride_role.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
 import 'package:balloon_crumbs/services/fiesta_flight_loader.dart';
 import 'package:balloon_crumbs/services/geo_calculations.dart';
+import 'package:balloon_crumbs/services/open_meteo_wind.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// The balloon flies its own air track; the chase drives a road.
@@ -58,7 +59,10 @@ void main() {
     );
   }
 
-  Future<RideSimulationController> build({bool rideStarted = true}) async {
+  Future<RideSimulationController> build({
+    bool rideStarted = true,
+    WindForecastController? windForecastController,
+  }) async {
     final store = InMemoryEventStore();
     final session = RideSession(
       rideId: 'fiesta',
@@ -82,6 +86,7 @@ void main() {
       session: session,
       route: chaseRoute,
       balloonFlight: flight(),
+      windForecastController: windForecastController,
       tickInterval: const Duration(days: 1),
       rideStarted: rideStarted,
     );
@@ -149,6 +154,54 @@ void main() {
     expect(altitude(), closeTo(0, 0.1));
   });
 
+  test(
+    'forecast wind drives direction while altitude stays scripted',
+    () async {
+      final wind = WindForecastController(
+        const _UnusedWindProvider(),
+        initialField: WindForecastField(
+          columns: const [
+            WindForecastColumn(
+              position: launch,
+              vectors: [
+                WindForecastVector(
+                  altitudeMetersMsl: 20,
+                  fromDegrees: 0,
+                  speedKmh: 36,
+                ),
+                WindForecastVector(
+                  altitudeMetersMsl: 500,
+                  fromDegrees: 0,
+                  speedKmh: 36,
+                ),
+              ],
+            ),
+          ],
+          validAt: DateTime.utc(2026, 8, 21, 10),
+          fetchedAt: DateTime.utc(2026, 8, 21, 10),
+          origin: WindForecastOrigin.bundledFallback,
+          sourceLabel: 'Test wind',
+        ),
+      );
+      addTearDown(wind.dispose);
+      final simulation = await build(windForecastController: wind);
+      addTearDown(simulation.dispose);
+
+      await simulation.advance(const Duration(minutes: 10));
+
+      final balloon = simulation.riders.singleWhere(
+        (rider) => rider.role == RideRole.lead,
+      );
+      expect(balloon.position.latitude, lessThan(launch.latitude - 0.04));
+      expect(balloon.position.longitude, closeTo(launch.longitude, 0.001));
+      expect(balloon.altitudeMeters, closeTo(69.2, 0.2));
+      expect(
+        simulation.predictedLandingZone?.latitude,
+        lessThan(balloon.position.latitude),
+      );
+    },
+  );
+
   test('a chase trail keeps more than the old 180-point window', () async {
     final simulation = await build();
     addTearDown(simulation.dispose);
@@ -188,7 +241,22 @@ void main() {
     // a missed rendezvous. Nothing should stop them or flag it.
     final simulation = await build();
     addTearDown(simulation.dispose);
-    await simulation.advance(const Duration(minutes: 52));
+    await simulation.advance(const Duration(minutes: 47));
+    final chaseBeforeReroute = simulation.riders
+        .where((rider) => rider.role != RideRole.lead)
+        .map((rider) => rider.position)
+        .toList();
+
+    // A landing-zone update creates a fresh road route from the Land Rover's
+    // actual position. It must not rewind the balloon or stop the retrieve.
+    simulation.replaceChaseRoute([
+      chaseBeforeReroute.single,
+      GeoPoint(
+        latitude: chaseBeforeReroute.single.latitude - 0.1,
+        longitude: chaseBeforeReroute.single.longitude - 0.1,
+      ),
+    ]);
+    await simulation.advance(const Duration(minutes: 5));
     final chaseAtLanding = simulation.riders
         .where((rider) => rider.role != RideRole.lead)
         .map((rider) => rider.position)
@@ -214,4 +282,14 @@ void main() {
       reason: 'at least one chase vehicle should still be moving',
     );
   });
+}
+
+class _UnusedWindProvider implements WindForecastProvider {
+  const _UnusedWindProvider();
+
+  @override
+  Future<WindForecastField> fetch({
+    required GeoPoint center,
+    required DateTime at,
+  }) => throw UnimplementedError();
 }

--- a/apps/mobile/test/controllers/ride_simulation_controller_test.dart
+++ b/apps/mobile/test/controllers/ride_simulation_controller_test.dart
@@ -5,16 +5,22 @@ import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart';
 import 'package:balloon_crumbs/domain/ride_role.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/features/map/craft_icon.dart';
 import 'package:balloon_crumbs/services/ride_completion_detector.dart';
 
 void main() {
   late InMemoryEventStore store;
   late SituationalAwarenessController awareness;
   late RideSimulationController simulation;
+  late RideSession session;
+  const route = [
+    GeoPoint(latitude: 51, longitude: -1),
+    GeoPoint(latitude: 51, longitude: -0.9),
+  ];
 
   setUp(() async {
     store = InMemoryEventStore();
-    final session = RideSession(
+    session = RideSession(
       rideId: 'sim-ride',
       rideCode: 'SIM123',
       inviteSecret: 'simulation-secret-that-is-long-enough',
@@ -25,10 +31,6 @@ void main() {
       joinedAt: DateTime.utc(2026, 7, 17),
       isSimulation: true,
     );
-    const route = [
-      GeoPoint(latitude: 51, longitude: -1),
-      GeoPoint(latitude: 51, longitude: -0.9),
-    ];
     awareness = SituationalAwarenessController(store, session, route: route);
     await awareness.initialize();
     simulation = RideSimulationController(
@@ -45,20 +47,30 @@ void main() {
     awareness.dispose();
   });
 
+  Future<RideSimulationController> buildLegacyFleet() async {
+    final controller = RideSimulationController(
+      awareness,
+      session: session,
+      route: route,
+      riderCount: 5,
+      tickInterval: const Duration(days: 1),
+    );
+    await controller.initialize();
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
   test(
-    'emits an authenticated five-bike fleet and advances virtual time',
+    'emits one balloon and one Land Rover and advances virtual time',
     () async {
-      expect(awareness.riderLocations, hasLength(5));
-      expect(awareness.authenticatedLocationEvidence, hasLength(5));
-      expect(
-        awareness.riderLocations
-            .singleWhere(
-              (location) =>
-                  location.riderId == RideSimulationController.backRiderId,
-            )
-            .role,
-        RideRole.rider,
+      expect(awareness.riderLocations, hasLength(2));
+      expect(awareness.authenticatedLocationEvidence, hasLength(2));
+      final chase = simulation.riders.singleWhere(
+        (rider) => rider.id == RideSimulationController.companionRiderId,
       );
+      expect(chase.displayName, 'Land Rover');
+      expect(chase.role, RideRole.rider);
+      expect(chase.motorcycleStyle, CraftIconStyle.fourByFour);
 
       final initialProgress = simulation.progress;
       await simulation.advance(const Duration(seconds: 2));
@@ -201,18 +213,7 @@ void main() {
     final initialLeader = simulation.riders.singleWhere(
       (rider) => rider.role == RideRole.lead,
     );
-    final backRider = simulation.riders.singleWhere(
-      (rider) => rider.id == RideSimulationController.backRiderId,
-    );
-    expect(initialLeader.travelTrail.length, greaterThan(1));
-    expect(
-      initialLeader.travelTrail.first.latitude,
-      closeTo(backRider.position.latitude, 1e-7),
-    );
-    expect(
-      initialLeader.travelTrail.first.longitude,
-      closeTo(backRider.position.longitude, 1e-7),
-    );
+    expect(initialLeader.travelTrail, hasLength(1));
 
     await simulation.advance(const Duration(seconds: 1));
 
@@ -222,51 +223,45 @@ void main() {
     expect(movingLeader.travelTrail.length, greaterThan(1));
   });
 
-  test('switches between leader, follower and TEC perspectives', () {
+  test('switches between balloon and Land Rover perspectives', () {
     simulation.setLocalRole(RideRole.rider);
     expect(simulation.localRole, RideRole.rider);
     final follower = simulation.riders.singleWhere((rider) => rider.isLocal);
     final leader = simulation.riders.singleWhere(
-      (rider) => rider.displayName == 'Maya',
+      (rider) => rider.displayName == 'Balloon',
     );
-    expect(follower.displayName, 'You · Follower');
-    expect(follower.progress, lessThan(leader.progress));
+    expect(follower.displayName, 'You · Land Rover');
+    expect(follower.motorcycleStyle, CraftIconStyle.fourByFour);
     expect(leader.role, RideRole.lead);
-
-    simulation.setLocalRole(RideRole.rider);
-    expect(simulation.localRole, RideRole.rider);
-    expect(
-      simulation.riders
-          .singleWhere(
-            (rider) => rider.id == RideSimulationController.backRiderId,
-          )
-          .role,
-      RideRole.rider,
-    );
   });
 
-  test('follower perspective remains behind the simulated leader', () async {
+  test('the two demo craft keep moving after changing perspective', () async {
     simulation.setLocalRole(RideRole.rider);
     simulation.setTimeScale(1);
+    final before = {
+      for (final rider in simulation.riders) rider.id: rider.position,
+    };
 
     await simulation.advance(const Duration(seconds: 30));
 
     final follower = simulation.riders.singleWhere((rider) => rider.isLocal);
     final leader = simulation.riders.singleWhere(
-      (rider) => rider.displayName == 'Maya',
+      (rider) => rider.displayName == 'Balloon',
     );
     expect(follower.role, RideRole.rider);
     expect(leader.role, RideRole.lead);
-    expect(follower.progress, lessThan(leader.progress));
+    expect(follower.position, isNot(before[follower.id]));
+    expect(leader.position, isNot(before[leader.id]));
   });
 
   test(
     'off-route visual trail is local to the current simulation run',
     () async {
-      simulation.setAlexOffRoute(true);
-      await simulation.advance(const Duration(seconds: 1));
+      final legacy = await buildLegacyFleet();
+      legacy.setAlexOffRoute(true);
+      await legacy.advance(const Duration(seconds: 1));
 
-      final alex = simulation.riders.singleWhere(
+      final alex = legacy.riders.singleWhere(
         (rider) => rider.id == RideSimulationController.offRouteRiderId,
       );
       expect(alex.offRouteTrail, hasLength(greaterThanOrEqualTo(2)));
@@ -277,9 +272,9 @@ void main() {
         isTrue,
       );
 
-      simulation.setAlexOffRoute(false);
+      legacy.setAlexOffRoute(false);
       expect(
-        simulation.riders
+        legacy.riders
             .singleWhere(
               (rider) => rider.id == RideSimulationController.offRouteRiderId,
             )
@@ -290,20 +285,21 @@ void main() {
   );
 
   test('can delay TEC and inject a synthetic roadworks hazard', () async {
-    final normalTecSpeed = simulation.riders
+    final legacy = await buildLegacyFleet();
+    final normalTecSpeed = legacy.riders
         .singleWhere(
           (rider) => rider.id == RideSimulationController.backRiderId,
         )
         .speedMetersPerSecond;
-    simulation.setBackRiderDelayed(true);
-    final delayedTecSpeed = simulation.riders
+    legacy.setBackRiderDelayed(true);
+    final delayedTecSpeed = legacy.riders
         .singleWhere(
           (rider) => rider.id == RideSimulationController.backRiderId,
         )
         .speedMetersPerSecond;
     expect(delayedTecSpeed, lessThan(normalTecSpeed));
 
-    await simulation.reportRoadworks();
+    await legacy.reportRoadworks();
     expect(awareness.activeHazards.single.details, contains('Ride Lab'));
     expect(
       (awareness.activeHazards.single.position.longitude -

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -4,11 +4,13 @@ import 'package:balloon_crumbs/domain/altitude.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/domain/route_store.dart';
 import 'package:balloon_crumbs/domain/distance_unit.dart';
+import 'package:balloon_crumbs/domain/geo_point.dart' as live;
 import 'package:balloon_crumbs/features/map/craft_icon.dart';
 import 'package:balloon_crumbs/features/map/ride_map.dart';
 import 'package:balloon_crumbs/services/basemap_configuration.dart';
 import 'package:balloon_crumbs/services/gpx_import_source.dart';
 import 'package:balloon_crumbs/services/offline_tile_cache.dart';
+import 'package:balloon_crumbs/services/open_meteo_wind.dart';
 import 'package:balloon_crumbs/services/route_importer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -55,6 +57,33 @@ void main() {
       ]);
       addTearDown(navigation.dispose);
       addTearDown(trails.dispose);
+      final wind = WindForecastController(
+        const _NoWindProvider(),
+        initialField: WindForecastField(
+          columns: const [
+            WindForecastColumn(
+              position: live.GeoPoint(latitude: 51.43, longitude: -2.70),
+              vectors: [
+                WindForecastVector(
+                  altitudeMetersMsl: 20,
+                  fromDegrees: 250,
+                  speedKmh: 12,
+                ),
+                WindForecastVector(
+                  altitudeMetersMsl: 1000,
+                  fromDegrees: 300,
+                  speedKmh: 30,
+                ),
+              ],
+            ),
+          ],
+          validAt: DateTime.utc(2026, 8, 21, 10),
+          fetchedAt: DateTime.utc(2026, 8, 21, 9, 55),
+          origin: WindForecastOrigin.bundledFallback,
+          sourceLabel: 'Bundled demo wind',
+        ),
+      );
+      addTearDown(wind.dispose);
       final cache = OfflineTileCache(
         rootDirectory: directory,
         configuration: const BasemapConfiguration(),
@@ -71,6 +100,7 @@ void main() {
             offlineTileCache: cache,
             navigationPosition: navigation,
             riderTrails: trails,
+            windForecastController: wind,
             landingZone: const MapLandingZone(
               center: GeoPoint(latitude: 51.4128, longitude: -2.7584),
               label: 'Simulated landing zone',
@@ -85,16 +115,26 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('balloon-altitude-card')), findsOneWidget);
+      expect(find.byKey(const Key('ride-clock')), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.byKey(const Key('ride-clock'))).dy,
+        lessThan(
+          tester.getTopLeft(find.byKey(const Key('balloon-altitude-card'))).dy,
+        ),
+        reason: 'the clock belongs above balloon telemetry',
+      );
       expect(find.text('226 m'), findsOneWidget);
       expect(find.textContaining('↑ 1.2 m/s'), findsOneWidget);
       expect(find.textContaining('GNSS'), findsOneWidget);
       expect(find.textContaining('relative to launch'), findsOneWidget);
       expect(find.text('Not terrain clearance'), findsOneWidget);
+      expect(find.byKey(const Key('aeronautical-chart-status')), findsNothing);
       expect(
-        find.byKey(const Key('aeronautical-chart-status')),
-        findsOneWidget,
+        find.byKey(const Key('aeronautical-chart-status-position')),
+        findsNothing,
       );
-      expect(find.text('AIRSPACE UNAVAILABLE'), findsOneWidget);
+      expect(find.text('AIRSPACE UNAVAILABLE'), findsNothing);
+      expect(find.byKey(const Key('balloon-map-info-button')), findsOneWidget);
       expect(find.byKey(const Key('balloon-altitude-legend')), findsOneWidget);
       expect(find.text('TRACK ALTITUDE · METRES'), findsOneWidget);
       expect(find.byKey(const Key('landing-zone-area-layer')), findsOneWidget);
@@ -102,6 +142,22 @@ void main() {
         find.byKey(const Key('landing-zone-marker-layer')),
         findsOneWidget,
       );
+      expect(find.byKey(const Key('wind-forecast-control')), findsOneWidget);
+      expect(find.byKey(const Key('wind-altitude-slider')), findsOneWidget);
+      expect(find.byKey(const Key('wind-forecast-layer')), findsOneWidget);
+      expect(find.textContaining('500 M MSL'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('wind-forecast-toggle')));
+      await tester.pump();
+      expect(wind.enabled, isFalse);
+      expect(find.byKey(const Key('wind-altitude-slider')), findsNothing);
+      expect(find.byKey(const Key('wind-forecast-layer')), findsNothing);
+
+      wind.setEnabled(true);
+      wind.setSelectedAltitude(1000);
+      await tester.pump();
+      expect(find.textContaining('1000 M MSL'), findsOneWidget);
+      expect(find.byKey(const Key('wind-forecast-layer')), findsOneWidget);
 
       final trackLayer = tester.widget<PolylineLayer>(
         find.byType(PolylineLayer),
@@ -131,6 +187,27 @@ void main() {
         isFalse,
         reason: 'the balloon viewport must not draw the chase road route',
       );
+
+      await tester.tap(find.byKey(const Key('balloon-map-info-button')));
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const Key('balloon-map-information-sheet')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('aeronautical-chart-information')),
+        findsOneWidget,
+      );
+      expect(find.text('AIRSPACE UNAVAILABLE'), findsOneWidget);
+      expect(
+        find.textContaining('official AIP and NOTAM briefing'),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('aeronautical-chart-key')), findsOneWidget);
+      expect(find.text('Red / red hatching'), findsOneWidget);
+      expect(find.text('Blue / pink'), findsOneWidget);
+      expect(find.textContaining('GND means the surface'), findsOneWidget);
+      expect(find.textContaining('shown in metres'), findsOneWidget);
 
       for (final key in const [
         'posted-speed-limit-position',
@@ -186,4 +263,14 @@ class _NoFileSource implements GpxImportSource {
 
   @override
   Future<PickedGpxFile?> pickGpxFile() async => null;
+}
+
+class _NoWindProvider implements WindForecastProvider {
+  const _NoWindProvider();
+
+  @override
+  Future<WindForecastField> fetch({
+    required live.GeoPoint center,
+    required DateTime at,
+  }) => throw UnimplementedError();
 }

--- a/apps/mobile/test/features/ride_simulation_screen_test.dart
+++ b/apps/mobile/test/features/ride_simulation_screen_test.dart
@@ -68,7 +68,9 @@ void main() {
     expect(playButton.onPressed, isNull);
   });
 
-  testWidgets('Ride Lab exposes fleet scenarios in landscape', (tester) async {
+  testWidgets('Ride Lab presents the live two-craft demo in landscape', (
+    tester,
+  ) async {
     tester.view.physicalSize = const Size(844, 390);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
@@ -121,20 +123,13 @@ void main() {
     );
 
     expect(find.text('Ride Lab'), findsOneWidget);
-    expect(find.text('VIRTUAL FLEET'), findsOneWidget);
-    expect(find.text('Demo Lead'), findsOneWidget);
-    expect(find.text('Charlie'), findsOneWidget);
-    expect(find.byKey(const Key('simulation-off-route')), findsOneWidget);
+    expect(find.text('LIVE DEMO CRAFT'), findsOneWidget);
+    expect(find.text('Balloon'), findsWidgets);
+    expect(find.text('Land Rover'), findsOneWidget);
+    expect(find.byKey(const Key('simulation-off-route')), findsNothing);
     expect(find.byKey(const Key('simulation-role')), findsOneWidget);
     expect(find.text('Chase'), findsOneWidget);
-    expect(find.text('Balloon'), findsOneWidget);
-    expect(find.byKey(const Key('simulation-rider-count')), findsOneWidget);
-
-    await tester.ensureVisible(find.byKey(const Key('simulation-off-route')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('simulation-off-route')));
-    await tester.pump();
-    expect(simulation.alexOffRoute, isTrue);
+    expect(find.byKey(const Key('simulation-rider-count')), findsNothing);
 
     await tester.ensureVisible(find.text('Chase'));
     await tester.tap(find.text('Chase'));

--- a/apps/mobile/test/services/open_meteo_wind_test.dart
+++ b/apps/mobile/test/services/open_meteo_wind_test.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/services/open_meteo_wind.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  test('loads a UKMO wind column grid from Open-Meteo', () async {
+    Uri? requestedUri;
+    final client = MockClient((request) async {
+      requestedUri = request.url;
+      final entries = [
+        for (var index = 0; index < 9; index += 1)
+          {
+            'latitude': 51.4 + index * 0.001,
+            'longitude': -2.7 + index * 0.001,
+            'hourly': {
+              'time': [
+                '2026-08-21T09:00',
+                '2026-08-21T10:00',
+                '2026-08-21T11:00',
+              ],
+              'wind_speed_20m': [12, 18, 24],
+              'wind_direction_20m': [260, 270, 280],
+              'wind_speed_500m': [24, 36, 48],
+              'wind_direction_500m': [170, 180, 190],
+            },
+          },
+      ];
+      return http.Response(jsonEncode(entries), 200);
+    });
+    addTearDown(client.close);
+
+    final field = await OpenMeteoWindProvider(client: client).fetch(
+      center: const GeoPoint(latitude: 51.44, longitude: -2.65),
+      at: DateTime.utc(2026, 8, 21, 10, 10),
+    );
+
+    expect(requestedUri?.scheme, 'https');
+    expect(requestedUri?.queryParameters['models'], 'ukmo_seamless');
+    expect(
+      requestedUri?.queryParameters['hourly'],
+      allOf(contains('wind_speed_20m'), contains('wind_direction_2000m')),
+    );
+    expect(field.columns, hasLength(9));
+    expect(field.validAt, DateTime.utc(2026, 8, 21, 10));
+    expect(field.origin, WindForecastOrigin.openMeteoUkmo);
+    final vector = field.at(
+      const GeoPoint(latitude: 51.404, longitude: -2.696),
+      500,
+    );
+    expect(vector?.speedKmh, 36);
+    expect(vector?.fromDegrees, 180);
+  });
+
+  test('interpolates wind components across north without bearing wrap', () {
+    const column = WindForecastColumn(
+      position: GeoPoint(latitude: 51, longitude: -2),
+      vectors: [
+        WindForecastVector(
+          altitudeMetersMsl: 100,
+          fromDegrees: 350,
+          speedKmh: 20,
+        ),
+        WindForecastVector(
+          altitudeMetersMsl: 200,
+          fromDegrees: 10,
+          speedKmh: 20,
+        ),
+      ],
+    );
+
+    final middle = column.atAltitude(150)!;
+    expect(middle.fromDegrees, anyOf(closeTo(0, 0.01), closeTo(360, 0.01)));
+    expect(middle.speedKmh, closeTo(19.7, 0.1));
+  });
+
+  test('controller toggles display and reuses one vertical forecast', () async {
+    final provider = _RecordingProvider();
+    final controller = WindForecastController(
+      provider,
+      clock: () => DateTime.utc(2026, 8, 21, 10),
+    );
+    addTearDown(controller.dispose);
+
+    await controller.refresh(const GeoPoint(latitude: 51.44, longitude: -2.65));
+    controller.setSelectedAltitude(1240);
+    controller.setEnabled(false);
+    await controller.refresh(
+      const GeoPoint(latitude: 51.441, longitude: -2.651),
+    );
+
+    expect(provider.fetchCount, 1);
+    expect(controller.selectedAltitudeMetersMsl, 1250);
+    expect(controller.enabled, isFalse);
+    expect(controller.field, isNotNull);
+  });
+}
+
+class _RecordingProvider implements WindForecastProvider {
+  int fetchCount = 0;
+
+  @override
+  Future<WindForecastField> fetch({
+    required GeoPoint center,
+    required DateTime at,
+  }) async {
+    fetchCount += 1;
+    return WindForecastField(
+      columns: [
+        WindForecastColumn(
+          position: center,
+          vectors: const [
+            WindForecastVector(
+              altitudeMetersMsl: 20,
+              fromDegrees: 270,
+              speedKmh: 15,
+            ),
+          ],
+        ),
+      ],
+      validAt: at,
+      fetchedAt: at,
+      origin: WindForecastOrigin.openMeteoUkmo,
+      sourceLabel: OpenMeteoWindProvider.sourceLabel,
+    );
+  }
+}

--- a/docs/tester-release-notes.md
+++ b/docs/tester-release-notes.md
@@ -5,6 +5,23 @@ version, Play version code, commit, destination track, and recent changes. Copy
 the tester-facing entry here after each release so an installed build can be
 matched to its changes.
 
+## 1.0.1 (Play build 26 / TestFlight build 27) — 21 August 2026
+
+- Adds UKMO forecast wind from Open-Meteo to the balloon map, with downwind
+  arrows, speed, source and valid time.
+- Adds an altitude slider from 20 m to 2,000 m MSL and a switch that hides the
+  wind overlay without changing the simulated flight.
+- Replaces the old demo fleet with one balloon and one Land Rover.
+- Keeps the balloon's scripted climb and descent while forecast wind controls
+  its ground direction.
+- Updates the forecast landing area as the balloon moves and reroutes the Land
+  Rover from its current position when that area changes.
+- Moves the map clock above altitude telemetry and moves OpenAIP status into the
+  information sheet, alongside a plain-language aeronautical chart key.
+
+Open-Meteo wind and OpenAIP airspace are advisory forecast/context layers, not
+an aviation weather briefing, clearance, or primary navigation source.
+
 ## 1.0.1 (Play build 25) — 20 August 2026
 
 - Colours each balloon ground-track leg by measured altitude and shows a metric

--- a/docs/weather-wind-source.md
+++ b/docs/weather-wind-source.md
@@ -1,0 +1,29 @@
+# Weather and wind source
+
+Open-Meteo is the selected advisory wind provider for tester builds. Balloon
+Crumbs requests the UK Met Office UKV forecast through Open-Meteo's keyless
+forecast API and displays a small grid of wind direction and speed values at
+selectable heights from 20 m to 2,000 m above mean sea level.
+
+No API credential is stored or shipped. Slider changes reuse the complete
+vertical profile returned by the last request; they do not make another
+request. Forecast data is kept in memory only. The simulator retains its dated,
+bundled wind profile as an offline fallback.
+
+The map attributes the live data to Open-Meteo and identifies UKMO as the model
+source. Open-Meteo's UKMO documentation states that UK Met Office data is
+licensed under CC BY-SA 4.0:
+
+- <https://open-meteo.com/en/docs/ukmo-api>
+- <https://open-meteo.com/en/license>
+
+## Limitations
+
+This is numerical forecast-model output, not a live measurement from the
+balloon and not an aviation weather briefing. The displayed valid time, height
+datum, units, source, and forecast-only warning must remain visible. Turning the
+map layer off hides the arrows but does not change the simulator's wind physics.
+
+The public keyless endpoint is appropriate for the current internal-test use.
+Usage, attribution, caching, and commercial terms must be reviewed again before
+a public or paid release.


### PR DESCRIPTION
## Summary
- add attributed UKMO wind forecasts through Open-Meteo with altitude selection and visibility control
- replace the Ride Lab fleet with one balloon and one Land Rover
- drive balloon drift and landing prediction from forecast wind while preserving scripted altitude
- reroute the chase vehicle from its live location when the forecast landing area changes
- include the OpenAIP information/key and clock placement fixes in the tester release

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test --reporter compact` (1,706 passed; 24 skipped)

## Release
- Android Play internal build 26
- iOS TestFlight build 27