### PR TITLE
feat: publish planner through Cloudflare Pages

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -44,8 +44,11 @@ jobs:
       - name: Test pilot planner forecast logic
         run: |
           cd ../..
-          node --test apps/planner/planner-core.test.mjs
+          node --test \
+            apps/planner/planner-core.test.mjs \
+            apps/planner/pages-worker.test.mjs
           node --check apps/planner/app.js
+          node --check apps/planner/_worker.js
       - run: uv run pytest --cov=balloon_crumbs_server --cov-report=term-missing --cov-fail-under=80
 
   postgres-migration:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ docs/                        Product, architecture, source, and backlog notes
 .github/workflows/           Mobile and server CI only
 ```
 
+The pilot planner is published at
+[`balloon-crumbs.pages.dev`](https://balloon-crumbs.pages.dev/). Its bounded
+Pages proxy keeps the Oracle relay and provider credentials out of browser code.
+
 ## Local verification
 
 ```bash

--- a/apps/planner/.well-known/apple-app-site-association
+++ b/apps/planner/.well-known/apple-app-site-association
@@ -1,0 +1,20 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["UY4624PH6X.dev.osholt.ballooncrumbs"],
+        "components": [
+          {
+            "/": "/join.html",
+            "comment": "Open a private Balloon Crumbs flight invitation in the installed app; the join code and its capability token stay in the URL fragment, which is never sent to this host."
+          },
+          {
+            "/": "/planner.html",
+            "?": { "code": "?*" },
+            "comment": "Open a shared Balloon Crumbs route code in the installed app."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -15,10 +15,12 @@ pretend a balloon follows a road route:
 - the resulting forecast track can be stored through `/api/v1/plans` and loaded
   in the app with the returned short code.
 
-The page is served at `/plan/` by the relay. Browser calls are same-origin:
-`deploy/Caddyfile.oracle` proxies the bounded Open-Meteo path, OpenFreeMap
-resources and OpenAIP tiles. The OpenAIP key stays in the host environment and
-is attached as a request header by Caddy; it is never shipped to browser code.
+The public page is served at `https://balloon-crumbs.pages.dev/`. Its Pages
+Worker keeps browser calls same-origin and proxies only the relay, health,
+Open-Meteo, OpenFreeMap and OpenAIP paths needed by the planner to the isolated
+Oracle deployment. The origin also serves `/plan/` as a recovery path. The
+OpenAIP key stays in the host environment and is attached as a request header
+by Caddy; it is never shipped to Pages or browser code.
 
 The vendored MapLibre GL JS distribution and licence are copied from the pinned
 5.24.0 assets already used by the Tail End Charlie website.
@@ -30,6 +32,7 @@ UK Met Office data obtained through Open-Meteo is attributed under CC BY-SA
 
 ```bash
 node --test apps/planner/planner-core.test.mjs
+node --test apps/planner/pages-worker.test.mjs
 node --check apps/planner/app.js
 ```
 

--- a/apps/planner/_headers
+++ b/apps/planner/_headers
@@ -1,0 +1,11 @@
+/*
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Robots-Tag: noindex, nofollow, noarchive
+  Permissions-Policy: geolocation=(self)
+
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+  Cache-Control: no-store
+

--- a/apps/planner/_worker.js
+++ b/apps/planner/_worker.js
@@ -1,0 +1,95 @@
+const ORACLE_ORIGIN = "https://relay.balloon-crumbs.tailendcharlie.app";
+
+const STATIC_SECURITY_HEADERS = {
+  "Content-Security-Policy":
+    "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; connect-src 'self'; worker-src blob:; child-src blob:; base-uri 'self'; form-action 'self'; frame-ancestors 'none'",
+  "Permissions-Policy": "geolocation=(self)",
+  "Referrer-Policy": "no-referrer",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "X-Robots-Tag": "noindex, nofollow, noarchive",
+};
+
+export function isOracleProxyPath(pathname) {
+  return (
+    pathname.startsWith("/api/") ||
+    pathname === "/health/live" ||
+    pathname === "/weather/v1/forecast" ||
+    pathname.startsWith("/maps/styles/") ||
+    pathname.startsWith("/maps/basemap/") ||
+    pathname.startsWith("/maps/fonts/") ||
+    pathname.startsWith("/maps/openaip/")
+  );
+}
+
+export function oracleUrl(requestUrl) {
+  const source = new URL(requestUrl);
+  return new URL(`${source.pathname}${source.search}`, ORACLE_ORIGIN).toString();
+}
+
+export function assetPath(pathname) {
+  if (pathname === "/planner.html") return "/index.html";
+  return pathname;
+}
+
+export function isReservedBackendPath(pathname) {
+  return (
+    pathname === "/metrics" ||
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/health/") ||
+    pathname.startsWith("/weather/") ||
+    pathname.startsWith("/maps/")
+  );
+}
+
+async function proxyToOracle(request) {
+  const upstreamRequest = new Request(oracleUrl(request.url), request);
+  upstreamRequest.headers.delete("cookie");
+  return fetch(upstreamRequest);
+}
+
+async function serveAsset(request, env) {
+  const url = new URL(request.url);
+  url.pathname = assetPath(url.pathname);
+  const response = await env.ASSETS.fetch(new Request(url, request));
+  const headers = new Headers(response.headers);
+
+  for (const [name, value] of Object.entries(STATIC_SECURITY_HEADERS)) {
+    headers.set(name, value);
+  }
+  if (url.pathname === "/index.html" || url.pathname === "/") {
+    headers.set("Cache-Control", "no-store");
+    headers.set("Pragma", "no-cache");
+  }
+  if (url.pathname === "/.well-known/apple-app-site-association") {
+    headers.set("Content-Type", "application/json");
+    headers.set("Cache-Control", "no-store");
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (isOracleProxyPath(url.pathname)) {
+      return proxyToOracle(request);
+    }
+
+    if (isReservedBackendPath(url.pathname)) {
+      return new Response(null, { status: 404 });
+    }
+
+    if (url.pathname === "/plan" || url.pathname === "/plan/") {
+      url.pathname = "/";
+      return Response.redirect(url, 308);
+    }
+
+    return serveAsset(request, env);
+  },
+};

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -9,6 +9,8 @@ import {
   vectorAtAltitude,
 } from "./planner-core.mjs";
 
+// Keep the installed-app hand-off on its already-shipped associated domain.
+// The planner itself is hosted at balloon-crumbs.pages.dev.
 const APP_LINK_ORIGIN = "https://balloon-crumbs.tailendcharlie.app";
 const FORECAST_AREA_RADIUS_METRES = 750;
 const INTENDED_AREA_RADIUS_METRES = 400;

--- a/apps/planner/pages-worker.test.mjs
+++ b/apps/planner/pages-worker.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workerSource = await readFile(new URL("./_worker.js", import.meta.url), "utf8");
+const worker = await import(
+  `data:text/javascript;base64,${Buffer.from(workerSource).toString("base64")}`
+);
+
+test("only bounded relay and provider paths are proxied", () => {
+  for (const pathname of [
+    "/api/v1/plans",
+    "/health/live",
+    "/weather/v1/forecast",
+    "/maps/styles/balloon-crumbs.json",
+    "/maps/basemap/7/63/42.pbf",
+    "/maps/fonts/Noto/0-255.pbf",
+    "/maps/openaip/7/63/42.png",
+  ]) {
+    assert.equal(worker.isOracleProxyPath(pathname), true, pathname);
+  }
+
+  for (const pathname of [
+    "/health/ready",
+    "/metrics",
+    "/weather/v1/forecast/extra",
+    "/maps/other/example",
+    "/plan/",
+  ]) {
+    assert.equal(worker.isOracleProxyPath(pathname), false, pathname);
+  }
+});
+
+test("unrecognised backend paths cannot fall through to the static site", async () => {
+  for (const pathname of [
+    "/health/ready",
+    "/metrics",
+    "/weather/v1/forecast/extra",
+    "/maps/other/example",
+  ]) {
+    assert.equal(worker.isReservedBackendPath(pathname), true, pathname);
+    const response = await worker.default.fetch(
+      new Request(`https://balloon-crumbs.pages.dev${pathname}`),
+      { ASSETS: { fetch: assert.fail } },
+    );
+    assert.equal(response.status, 404, pathname);
+  }
+});
+
+test("the proxy preserves the bounded path and query on the Oracle origin", () => {
+  assert.equal(
+    worker.oracleUrl(
+      "https://balloon-crumbs.pages.dev/weather/v1/forecast?latitude=51.5&longitude=-0.1",
+    ),
+    "https://relay.balloon-crumbs.tailendcharlie.app/weather/v1/forecast?latitude=51.5&longitude=-0.1",
+  );
+});
+
+test("the API proxy preserves a POST body without forwarding Pages cookies", async () => {
+  const originalFetch = globalThis.fetch;
+  let upstreamRequest;
+  globalThis.fetch = async (request) => {
+    upstreamRequest = request;
+    return new Response("created", { status: 201 });
+  };
+
+  try {
+    const response = await worker.default.fetch(
+      new Request("https://balloon-crumbs.pages.dev/api/v1/plans", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: "pages-session=private",
+        },
+        body: JSON.stringify({ name: "smoke", gpx: "<gpx/>" }),
+      }),
+      { ASSETS: { fetch: assert.fail } },
+    );
+
+    assert.equal(response.status, 201);
+    assert.equal(
+      upstreamRequest.url,
+      "https://relay.balloon-crumbs.tailendcharlie.app/api/v1/plans",
+    );
+    assert.equal(upstreamRequest.headers.get("cookie"), null);
+    assert.deepEqual(await upstreamRequest.json(), {
+      name: "smoke",
+      gpx: "<gpx/>",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("the associated-domain planner path serves the planner shell", async () => {
+  let requestedPath;
+  const response = await worker.default.fetch(
+    new Request("https://balloon-crumbs.pages.dev/planner.html?code=ABCD1234"),
+    {
+      ASSETS: {
+        async fetch(request) {
+          requestedPath = new URL(request.url).pathname;
+          return new Response("planner", {
+            headers: { "Content-Type": "text/html" },
+          });
+        },
+      },
+    },
+  );
+
+  assert.equal(requestedPath, "/index.html");
+  assert.equal(await response.text(), "planner");
+  assert.equal(response.headers.get("X-Frame-Options"), "DENY");
+});
+
+test("the old Pages planner path redirects to the root planner URL", async () => {
+  const response = await worker.default.fetch(
+    new Request("https://balloon-crumbs.pages.dev/plan/?example=yes"),
+    { ASSETS: { fetch: assert.fail } },
+  );
+
+  assert.equal(response.status, 308);
+  assert.equal(response.headers.get("Location"), "https://balloon-crumbs.pages.dev/?example=yes");
+});

--- a/docs/oracle-relay.md
+++ b/docs/oracle-relay.md
@@ -8,7 +8,8 @@ The only shared boundary is TEC's public Caddy network:
 
 ```text
 Internet
-  -> TEC public Caddy :443
+  -> balloon-crumbs.pages.dev (public planner and bounded same-origin proxy)
+      -> TEC public Caddy :443
       -> balloon-crumbs-edge:8080
           -> Balloon Crumbs API + PostgreSQL
           -> /plan/ static pilot planner
@@ -25,7 +26,8 @@ Balloon Crumbs network. TEC's Caddy routes the dedicated hostname to that alias.
 - Checkout: `/opt/balloon-crumbs`, detached at an ancestor of `origin/main`.
 - Secrets: `/opt/balloon-crumbs/deploy/.env`, mode 600, never committed.
 - Compose project: `balloon-crumbs`.
-- Public hostname: `relay.balloon-crumbs.tailendcharlie.app`.
+- Public planner: `https://balloon-crumbs.pages.dev/`.
+- Oracle origin hostname: `relay.balloon-crumbs.tailendcharlie.app`.
 - Deploy state: `/var/lib/balloon-crumbs-deploy/production.commit`.
 
 The host configuration selects the Oracle overlay:


### PR DESCRIPTION
## Summary
- serve the pilot planner at `balloon-crumbs.pages.dev`
- add a bounded Pages Worker proxy to the isolated Oracle relay and map/weather/chart routes
- preserve the server-side OpenAIP credential and existing installed-app hand-off domain
- include Apple association metadata and security headers in the Pages artifact

## Verification
- `node --check apps/planner/app.js`
- `node --check apps/planner/_worker.js`
- `node --test apps/planner/planner-core.test.mjs apps/planner/pages-worker.test.mjs`
- local Wrangler smoke: planner, API health, Open-Meteo, style and OpenAIP tile pass; private/off-path routes return 404