### PR TITLE
feat: add wind destination planning

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -9,9 +9,14 @@ pretend a balloon follows a road route:
   levels used by the mobile app;
 - the forecast track integrates the balloon through its own climb, cruise and
   descent profile;
+- the basemap and planner controls can switch between light and dark themes,
+  with an explicit tile-load indicator and retry action;
 - OpenAIP's combined aeronautical chart is visible with a plain-language key;
-- a forecast landing area and a separately editable pilot-intended landing area
-  are shown; and
+- the purple landing envelope is the convex boundary of endpoints produced by
+  the tested two-stage altitude strategies;
+- an optional destination search ranks those strategies by forecast miss
+  distance and clearly reports when none gets within the planning tolerance;
+- the forecast landing area and separately editable destination are shown; and
 - the resulting forecast track can be stored through `/api/v1/plans` and loaded
   in the app with the returned short code.
 
@@ -38,4 +43,7 @@ node --check apps/planner/app.js
 
 These are forecasts, not aviation briefings or primary navigation. The planner
 does not present a track as controllable, and it does not hide missing forecast
-data behind a synthetic fallback.
+data behind a synthetic fallback. The landing envelope is not a safe-landing
+assessment and does not mean that every point inside it is reachable. The
+destination search does not account for airspace, terrain, legal limits, burner
+fuel, or the balloon's actual climb and descent performance.

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -4,8 +4,10 @@ import {
   circlePolygon,
   forecastDistanceMetres,
   forecastFlightTrack,
+  forecastLandingEnvelope,
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
+  planWindRouteToDestination,
   vectorAtAltitude,
 } from "./planner-core.mjs";
 
@@ -15,6 +17,42 @@ const APP_LINK_ORIGIN = "https://balloon-crumbs.tailendcharlie.app";
 const FORECAST_AREA_RADIUS_METRES = 750;
 const INTENDED_AREA_RADIUS_METRES = 400;
 const DEFAULT_CENTER = [-2.5, 54.4];
+const MAP_PALETTES = Object.freeze({
+  dark: {
+    background: "#14111b",
+    landcover: "#17201c",
+    park: "#17201c",
+    residential: "#181420",
+    water: "#1b2436",
+    building: "#201b29",
+    boundary: "#3a3247",
+    path: "#241f2e",
+    minor: "#2a2434",
+    tertiary: "#352e42",
+    primary: "#40374f",
+    motorway: "#4d4260",
+    label: "#8d84a0",
+    place: "#c4b9c0",
+    halo: "#14111b",
+  },
+  light: {
+    background: "#f1eee7",
+    landcover: "#dce8d5",
+    park: "#d4e6cd",
+    residential: "#e9e3dc",
+    water: "#b9dced",
+    building: "#ddd4ca",
+    boundary: "#a89bab",
+    path: "#d2c9bf",
+    minor: "#c7bdb2",
+    tertiary: "#b6a99e",
+    primary: "#9d8d83",
+    motorway: "#8d7b87",
+    label: "#514958",
+    place: "#302b34",
+    halo: "#f1eee7",
+  },
+});
 
 const elements = Object.fromEntries(
   [
@@ -22,6 +60,7 @@ const elements = Object.fromEntries(
     "clock",
     "code-result",
     "copy-code",
+    "clear-destination",
     "departure-time",
     "duration-minutes",
     "forecast-distance",
@@ -34,13 +73,20 @@ const elements = Object.fromEntries(
     "landing-status",
     "map",
     "map-prompt",
+    "map-status",
+    "map-status-text",
     "maximum-altitude",
     "open-in-app",
     "plan-code",
     "plan-expiry",
     "plan-name",
+    "retry-map",
+    "route-status",
+    "route-strategy",
     "set-landing",
     "set-launch",
+    "theme-label",
+    "theme-toggle",
     "use-location",
     "wind-altitude",
     "wind-altitude-label",
@@ -58,10 +104,14 @@ const state = {
   forecastLanding: null,
   intendedLanding: null,
   manualLanding: false,
+  landingEnvelope: [],
+  landingCandidateCount: 0,
+  routePlan: null,
   markers: {},
   windMarkers: [],
   forecastRequest: null,
   forecastGeneration: 0,
+  mapTileFailures: 0,
 };
 
 function setStatus(element, message, kind = "") {
@@ -132,6 +182,74 @@ async function loadMapStyle() {
   return style;
 }
 
+function selectedMapTheme() {
+  return elements.theme_toggle.checked ? "dark" : "light";
+}
+
+function themePaintUpdates(themeName) {
+  const palette = MAP_PALETTES[themeName];
+  return [
+    ["background", "background-color", palette.background],
+    ["landcover-green", "fill-color", palette.landcover],
+    ["park", "fill-color", palette.park],
+    ["landuse-residential", "fill-color", palette.residential],
+    ["water", "fill-color", palette.water],
+    ["waterway", "line-color", palette.water],
+    ["building", "fill-color", palette.building],
+    ["boundary-admin", "line-color", palette.boundary],
+    ["road-path", "line-color", palette.path],
+    ["road-minor", "line-color", palette.minor],
+    ["road-tertiary", "line-color", palette.tertiary],
+    ["road-primary", "line-color", palette.primary],
+    ["road-motorway", "line-color", palette.motorway],
+    ["road-label", "text-color", palette.label],
+    ["road-label", "text-halo-color", palette.halo],
+    ["place-label", "text-color", palette.place],
+    ["place-label", "text-halo-color", palette.halo],
+  ];
+}
+
+function themeStyle(style, themeName) {
+  const layers = new Map((style.layers ?? []).map((layer) => [layer.id, layer]));
+  for (const [layerId, property, value] of themePaintUpdates(themeName)) {
+    const layer = layers.get(layerId);
+    if (layer) layer.paint = { ...(layer.paint ?? {}), [property]: value };
+  }
+  return style;
+}
+
+function applyMapTheme() {
+  const themeName = selectedMapTheme();
+  document.documentElement.dataset.theme = themeName;
+  elements.theme_label.textContent = themeName === "dark" ? "Dark map" : "Light map";
+  if (!state.map?.isStyleLoaded()) return;
+  for (const [layerId, property, value] of themePaintUpdates(themeName)) {
+    if (state.map.getLayer(layerId)) state.map.setPaintProperty(layerId, property, value);
+  }
+  if (state.map.getLayer("openaip-chart")) {
+    state.map.setPaintProperty(
+      "openaip-chart",
+      "raster-opacity",
+      themeName === "dark" ? 0.76 : 0.62,
+    );
+  }
+  if (state.map.getLayer("forecast-track-casing")) {
+    state.map.setPaintProperty(
+      "forecast-track-casing",
+      "line-color",
+      themeName === "dark" ? "#11151c" : "#ffffff",
+    );
+  }
+}
+
+function setMapStatus(message, kind = "", retry = false) {
+  elements.map_status.hidden = false;
+  elements.map_status.classList.toggle("error", kind === "error");
+  elements.map_status.classList.toggle("good", kind === "good");
+  elements.map_status_text.textContent = message;
+  elements.retry_map.hidden = !retry;
+}
+
 function lineCollection(track) {
   if (!track || track.length < 2) return { type: "FeatureCollection", features: [] };
   return {
@@ -167,6 +285,25 @@ function polygonFeature(center, radiusMetres) {
   };
 }
 
+function landingEnvelopeFeature(boundary) {
+  if (!Array.isArray(boundary) || boundary.length === 0) {
+    return { type: "FeatureCollection", features: [] };
+  }
+  const coordinates = boundary.map((point) => [point.longitude, point.latitude]);
+  let geometry;
+  if (coordinates.length >= 3) {
+    geometry = { type: "Polygon", coordinates: [[...coordinates, coordinates[0]]] };
+  } else if (coordinates.length === 2) {
+    geometry = { type: "LineString", coordinates };
+  } else {
+    geometry = { type: "Point", coordinates: coordinates[0] };
+  }
+  return {
+    type: "FeatureCollection",
+    features: [{ type: "Feature", properties: {}, geometry }],
+  };
+}
+
 function addPlannerLayers(map) {
   const firstSymbol = map.getStyle().layers.find((layer) => layer.type === "symbol")?.id;
   map.addSource("openaip-chart", {
@@ -182,17 +319,45 @@ function addPlannerLayers(map) {
       source: "openaip-chart",
       minzoom: 4,
       maxzoom: 14,
-      paint: { "raster-opacity": 0.76, "raster-fade-duration": 180 },
+      paint: {
+        "raster-opacity": selectedMapTheme() === "dark" ? 0.76 : 0.62,
+        "raster-fade-duration": 180,
+      },
     },
     firstSymbol,
   );
+
+  map.addSource("landing-envelope", {
+    type: "geojson",
+    data: landingEnvelopeFeature(null),
+  });
+  map.addLayer({
+    id: "landing-envelope-fill",
+    type: "fill",
+    source: "landing-envelope",
+    paint: { "fill-color": "#a78bfa", "fill-opacity": 0.14 },
+  });
+  map.addLayer({
+    id: "landing-envelope-outline",
+    type: "line",
+    source: "landing-envelope",
+    paint: {
+      "line-color": "#a78bfa",
+      "line-width": 2.5,
+      "line-dasharray": [3, 2],
+    },
+  });
 
   map.addSource("forecast-track", { type: "geojson", data: lineCollection(null) });
   map.addLayer({
     id: "forecast-track-casing",
     type: "line",
     source: "forecast-track",
-    paint: { "line-color": "#11151c", "line-width": 9, "line-opacity": 0.8 },
+    paint: {
+      "line-color": selectedMapTheme() === "dark" ? "#11151c" : "#ffffff",
+      "line-width": 9,
+      "line-opacity": 0.8,
+    },
     layout: { "line-cap": "round", "line-join": "round" },
   });
   map.addLayer({
@@ -297,6 +462,9 @@ function updateSources() {
   if (!state.map?.isStyleLoaded()) return;
   state.map.getSource("forecast-track")?.setData(lineCollection(state.track));
   state.map
+    .getSource("landing-envelope")
+    ?.setData(landingEnvelopeFeature(state.landingEnvelope));
+  state.map
     .getSource("forecast-area")
     ?.setData(polygonFeature(state.forecastLanding, FORECAST_AREA_RADIUS_METRES));
   state.map
@@ -310,6 +478,9 @@ function fitForecast() {
   for (const point of state.track) bounds.extend([point.longitude, point.latitude]);
   if (state.intendedLanding) {
     bounds.extend([state.intendedLanding.longitude, state.intendedLanding.latitude]);
+  }
+  for (const point of state.landingEnvelope) {
+    bounds.extend([point.longitude, point.latitude]);
   }
   state.map.fitBounds(bounds, { padding: 90, maxZoom: 11, duration: 700 });
 }
@@ -337,14 +508,53 @@ function validFlightSettings() {
 function recomputeTrack({ fit = false } = {}) {
   if (!state.field || !state.launch) return;
   try {
-    state.track = forecastFlightTrack({ field: state.field, launch: state.launch, ...validFlightSettings() });
+    const settings = { field: state.field, launch: state.launch, ...validFlightSettings() };
+    if (state.manualLanding && state.intendedLanding) {
+      state.routePlan = planWindRouteToDestination({
+        ...settings,
+        destination: state.intendedLanding,
+      });
+      state.track = state.routePlan.track;
+      state.landingEnvelope = state.routePlan.boundary;
+      state.landingCandidateCount = state.routePlan.candidateCount;
+      const missKilometres = (state.routePlan.missDistanceMetres / 1000).toFixed(1);
+      const toleranceKilometres = (
+        state.routePlan.acceptedMissDistanceMetres / 1000
+      ).toFixed(1);
+      const firstAltitude = Math.round(state.routePlan.firstCruiseAltitudeMetresMsl);
+      const secondAltitude = Math.round(state.routePlan.secondCruiseAltitudeMetresMsl);
+      elements.route_strategy.hidden = false;
+      elements.route_strategy.textContent =
+        firstAltitude === secondAltitude
+          ? `Closest tested height plan: hold near ${firstAltitude} m MSL, then descend.`
+          : `Closest tested height plan: ${firstAltitude} m, then ${secondAltitude} m MSL, then descend.`;
+      setStatus(
+        elements.route_status,
+        state.routePlan.reachesDestination
+          ? `The closest forecast endpoint is ${missKilometres} km from the destination, inside the ${toleranceKilometres} km planning tolerance.`
+          : `The winds do not support this destination in the tested height plans. The closest forecast endpoint still misses by ${missKilometres} km; the shown track is best-effort only.`,
+        state.routePlan.reachesDestination ? "good" : "error",
+      );
+    } else {
+      state.routePlan = null;
+      state.track = forecastFlightTrack(settings);
+      const envelope = forecastLandingEnvelope(settings);
+      state.landingEnvelope = envelope.boundary;
+      state.landingCandidateCount = envelope.candidates.length;
+      elements.route_strategy.hidden = true;
+      setStatus(
+        elements.route_status,
+        "Set a destination to test two-stage altitude plans against the forecast wind layers.",
+      );
+    }
     state.forecastLanding = state.track.at(-1);
     if (!state.manualLanding || !state.intendedLanding) state.intendedLanding = state.forecastLanding;
     setMarker("forecast", state.forecastLanding, "Forecast landing");
-    setMarker("intended", state.intendedLanding, "Pilot intended landing area");
+    setMarker("intended", state.intendedLanding, "Destination");
     updateSources();
     updateWindMarkers();
     elements.set_landing.disabled = false;
+    elements.clear_destination.disabled = !state.manualLanding;
     elements.generate_code.disabled = false;
     elements.forecast_summary.hidden = false;
     elements.forecast_distance.textContent = `${(forecastDistanceMetres(state.track) / 1000).toFixed(1)} km forecast drift`;
@@ -352,8 +562,8 @@ function recomputeTrack({ fit = false } = {}) {
     setStatus(
       elements.landing_status,
       state.manualLanding
-        ? "Pilot landing area retained. Forecast landing has updated separately."
-        : "Pilot landing area currently follows the forecast endpoint.",
+        ? "Destination retained. The forecast landing and height strategy update separately."
+        : `The purple envelope bounds endpoints from ${state.landingCandidateCount} two-stage height plans. It is not a safe-landing assessment.`,
       "good",
     );
     setStatus(
@@ -365,11 +575,17 @@ function recomputeTrack({ fit = false } = {}) {
   } catch (error) {
     state.track = null;
     state.forecastLanding = null;
+    state.landingEnvelope = [];
+    state.landingCandidateCount = 0;
+    state.routePlan = null;
     elements.generate_code.disabled = true;
     elements.set_landing.disabled = true;
+    elements.clear_destination.disabled = true;
     elements.forecast_summary.hidden = true;
+    elements.route_strategy.hidden = true;
     updateSources();
     setStatus(elements.wind_status, error.message, "error");
+    setStatus(elements.route_status, "No route calculation is available with these settings.", "error");
   }
 }
 
@@ -405,17 +621,23 @@ async function refreshForecast() {
     state.field = null;
     state.track = null;
     state.forecastLanding = null;
+    state.landingEnvelope = [];
+    state.landingCandidateCount = 0;
+    state.routePlan = null;
     clearWindMarkers();
     updateSources();
     elements.generate_code.disabled = true;
     elements.set_landing.disabled = true;
+    elements.clear_destination.disabled = true;
     elements.forecast_summary.hidden = true;
+    elements.route_strategy.hidden = true;
     setStatus(
       elements.wind_status,
       `No usable live wind forecast: ${error.message} Do not substitute a guessed track.`,
       "error",
     );
     setStatus(elements.landing_status, "Waiting for a usable wind forecast.");
+    setStatus(elements.route_status, "No route calculation is available without wind data.", "error");
   }
 }
 
@@ -423,7 +645,20 @@ function chooseLaunch(point) {
   state.launch = { latitude: point.lat, longitude: point.lng };
   state.manualLanding = false;
   state.intendedLanding = null;
+  state.track = null;
+  state.forecastLanding = null;
+  state.landingEnvelope = [];
+  state.landingCandidateCount = 0;
+  state.routePlan = null;
+  elements.clear_destination.disabled = true;
+  elements.set_landing.disabled = true;
+  elements.generate_code.disabled = true;
+  elements.forecast_summary.hidden = true;
+  elements.route_strategy.hidden = true;
   setMarker("launch", state.launch, "Launch");
+  setMarker("forecast", null);
+  setMarker("intended", null);
+  updateSources();
   setStatus(
     elements.launch_status,
     `${state.launch.latitude.toFixed(5)}, ${state.launch.longitude.toFixed(5)}`,
@@ -431,28 +666,42 @@ function chooseLaunch(point) {
   );
   state.mode = null;
   elements.map_prompt.hidden = true;
+  setStatus(elements.landing_status, "Waiting for the wind forecast.");
+  setStatus(elements.route_status, "Calculating the landing envelope from this launch point…");
   void refreshForecast();
 }
 
 function chooseLanding(point) {
   state.intendedLanding = { latitude: point.lat, longitude: point.lng };
   state.manualLanding = true;
-  setMarker("intended", state.intendedLanding, "Pilot intended landing area");
+  setMarker("intended", state.intendedLanding, "Destination");
   updateSources();
   state.mode = null;
   elements.map_prompt.hidden = true;
+  elements.clear_destination.disabled = false;
   setStatus(
     elements.landing_status,
-    `Pilot landing area set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. It can be updated again.`,
+    `Destination set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. Testing forecast height plans…`,
     "good",
   );
+  recomputeTrack({ fit: true });
+}
+
+function clearDestination() {
+  state.manualLanding = false;
+  state.intendedLanding = null;
+  state.routePlan = null;
+  elements.clear_destination.disabled = true;
+  recomputeTrack({ fit: true });
 }
 
 function beginMapChoice(mode) {
   state.mode = mode;
   elements.map_prompt.hidden = false;
   elements.map_prompt.textContent =
-    mode === "launch" ? "Click the map to set the launch point" : "Click the map to move the intended landing area";
+    mode === "launch"
+      ? "Click the map to set the launch point"
+      : "Click the map to set the intended destination";
 }
 
 function useDeviceLocation() {
@@ -523,7 +772,10 @@ async function copyPlanCode() {
 function bindControls() {
   elements.set_launch.addEventListener("click", () => beginMapChoice("launch"));
   elements.set_landing.addEventListener("click", () => beginMapChoice("landing"));
+  elements.clear_destination.addEventListener("click", clearDestination);
   elements.use_location.addEventListener("click", useDeviceLocation);
+  elements.theme_toggle.addEventListener("change", applyMapTheme);
+  elements.retry_map.addEventListener("click", () => window.location.reload());
   elements.wind_altitude.addEventListener("input", updateWindMarkers);
   elements.wind_toggle.addEventListener("change", updateWindMarkers);
   elements.airspace_toggle.addEventListener("change", () => {
@@ -544,13 +796,16 @@ function bindControls() {
 }
 
 async function start() {
+  elements.theme_toggle.checked = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  applyMapTheme();
   configureDepartureInput();
   updateClock();
   window.setInterval(updateClock, 1_000);
   bindControls();
   updateWindMarkers();
   try {
-    const style = await loadMapStyle();
+    setMapStatus("Loading basemap tiles…");
+    const style = themeStyle(await loadMapStyle(), selectedMapTheme());
     state.map = new maplibregl.Map({
       container: "map",
       style,
@@ -560,8 +815,27 @@ async function start() {
     });
     state.map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "bottom-right");
     state.map.addControl(new maplibregl.AttributionControl({ compact: true }), "bottom-right");
+    state.map.on("sourcedata", (event) => {
+      if (event.sourceId === "basemap" && event.isSourceLoaded) {
+        state.mapTileFailures = 0;
+        setMapStatus("Basemap tiles loaded", "good");
+      }
+    });
+    state.map.on("error", (event) => {
+      const sourceId = event.sourceId ?? event.source?.id;
+      if (sourceId !== "basemap" && sourceId !== "openaip-chart") return;
+      state.mapTileFailures += 1;
+      setMapStatus(
+        sourceId === "basemap"
+          ? "Some basemap tiles failed to load."
+          : "Some OpenAIP chart tiles failed to load.",
+        "error",
+        true,
+      );
+    });
     state.map.on("load", () => {
       addPlannerLayers(state.map);
+      applyMapTheme();
       updateSources();
       state.map.on("click", (event) => {
         if (state.mode === "launch") chooseLaunch(event.lngLat);
@@ -570,6 +844,7 @@ async function start() {
     });
   } catch (error) {
     elements.map.textContent = `Map unavailable: ${error.message}`;
+    setMapStatus("The basemap could not start.", "error", true);
     setStatus(elements.wind_status, "The map could not start, so no flight forecast was made.", "error");
   }
 }

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -14,7 +14,14 @@
         <p class="eyebrow">Balloon Crumbs</p>
         <h1>Pilot flight planner</h1>
       </div>
-      <p class="clock" id="clock" aria-label="Current UTC time"></p>
+      <div class="header-actions">
+        <label class="switch theme-switch" title="Switch the planner and basemap theme">
+          <input type="checkbox" id="theme-toggle" checked />
+          <span aria-hidden="true"></span>
+          <b id="theme-label">Dark map</b>
+        </label>
+        <p class="clock" id="clock" aria-label="Current UTC time"></p>
+      </div>
     </header>
 
     <div class="advisory" role="note">
@@ -102,12 +109,18 @@
           <div class="section-heading">
             <span>4</span>
             <div>
-              <h2 id="landing-title">Intended landing area</h2>
-              <p>The forecast endpoint is selected initially. The pilot can move it.</p>
+              <h2 id="landing-title">Destination and landing envelope</h2>
+              <p>Test whether forecast winds at different heights can approach a chosen destination.</p>
             </div>
           </div>
-          <button type="button" id="set-landing" disabled>Move landing area on map</button>
+          <div class="button-row">
+            <button type="button" id="set-landing" disabled>Set destination on map</button>
+            <button type="button" id="clear-destination" disabled>Clear destination</button>
+          </div>
           <p class="status" id="landing-status">Waiting for a wind forecast.</p>
+          <p class="status" id="route-status" role="status">Set a launch point to calculate the landing envelope.</p>
+          <p class="route-strategy" id="route-strategy" hidden></p>
+          <p class="small muted">The purple boundary is a convex envelope of tested forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. The height solver does not assess airspace, terrain, legal limits, fuel or actual climb/descent performance.</p>
         </section>
 
         <section class="panel-section" aria-labelledby="airspace-title">
@@ -161,6 +174,10 @@
       <section class="map-shell" aria-label="Forecast flight map">
         <div id="map" class="map"></div>
         <div class="map-prompt" id="map-prompt">Click the map to set the launch point</div>
+        <div class="map-status" id="map-status" role="status">
+          <span id="map-status-text">Loading basemap tiles…</span>
+          <button type="button" id="retry-map" hidden>Retry</button>
+        </div>
         <div class="forecast-summary" id="forecast-summary" hidden>
           <strong id="forecast-distance"></strong>
           <span id="forecast-validity"></span>
@@ -168,8 +185,9 @@
         <div class="map-legend" aria-label="Map legend">
           <span><i class="legend-dot launch"></i>Launch</span>
           <span><i class="legend-dot forecast"></i>Forecast landing</span>
-          <span><i class="legend-dot intended"></i>Pilot landing area</span>
+          <span><i class="legend-dot intended"></i>Destination</span>
           <span><i class="legend-line"></i>Altitude-coloured forecast track</span>
+          <span><i class="legend-envelope"></i>Forecast landing envelope</span>
         </div>
       </section>
     </main>

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -197,6 +197,29 @@ export function altitudeForFlightFraction({
   return launch + (maximum - launch) * ((1 - progress) / 0.3);
 }
 
+export function altitudeForStrategyFraction({
+  fraction,
+  launchElevationMetresMsl,
+  firstCruiseAltitudeMetresMsl,
+  secondCruiseAltitudeMetresMsl,
+}) {
+  const progress = Math.max(0, Math.min(1, finiteNumber(fraction, "flight fraction")));
+  const launch = finiteNumber(launchElevationMetresMsl, "launch elevation");
+  const first = Math.max(
+    launch,
+    finiteNumber(firstCruiseAltitudeMetresMsl, "first cruise altitude"),
+  );
+  const second = Math.max(
+    launch,
+    finiteNumber(secondCruiseAltitudeMetresMsl, "second cruise altitude"),
+  );
+  if (progress <= 0.2) return launch + (first - launch) * (progress / 0.2);
+  if (progress <= 0.45) return first;
+  if (progress <= 0.55) return first + (second - first) * ((progress - 0.45) / 0.1);
+  if (progress <= 0.7) return second;
+  return launch + (second - launch) * ((1 - progress) / 0.3);
+}
+
 export function moveWithWind(position, vector, seconds) {
   const origin = validPoint(position);
   const elapsed = finiteNumber(seconds, "elapsed seconds");
@@ -214,12 +237,11 @@ export function moveWithWind(position, vector, seconds) {
   };
 }
 
-export function forecastFlightTrack({
+function forecastTrackWithAltitudeProfile({
   field,
   launch,
-  launchElevationMetresMsl,
-  maximumAltitudeMetresMsl,
   durationMinutes,
+  altitudeAtFraction,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   let position = validPoint(launch, "launch point");
@@ -231,11 +253,7 @@ export function forecastFlightTrack({
   const points = [];
   for (let elapsedSeconds = 0; elapsedSeconds <= durationSeconds; elapsedSeconds += step) {
     const fraction = elapsedSeconds / durationSeconds;
-    const altitudeMetresMsl = altitudeForFlightFraction({
-      fraction,
-      launchElevationMetresMsl,
-      maximumAltitudeMetresMsl,
-    });
+    const altitudeMetresMsl = altitudeAtFraction(fraction);
     const vector = vectorAtPosition(field, position, altitudeMetresMsl);
     if (!vector) throw new Error("The wind field does not cover the forecast flight.");
     points.push({ ...position, altitudeMetresMsl, elapsedSeconds, wind: vector });
@@ -244,6 +262,169 @@ export function forecastFlightTrack({
     }
   }
   return Object.freeze(points);
+}
+
+export function forecastFlightTrack({
+  field,
+  launch,
+  launchElevationMetresMsl,
+  maximumAltitudeMetresMsl,
+  durationMinutes,
+  stepSeconds = DEFAULT_STEP_SECONDS,
+}) {
+  return forecastTrackWithAltitudeProfile({
+    field,
+    launch,
+    durationMinutes,
+    stepSeconds,
+    altitudeAtFraction: (fraction) =>
+      altitudeForFlightFraction({
+        fraction,
+        launchElevationMetresMsl,
+        maximumAltitudeMetresMsl,
+      }),
+  });
+}
+
+export function forecastAltitudeStrategyTrack({
+  field,
+  launch,
+  launchElevationMetresMsl,
+  firstCruiseAltitudeMetresMsl,
+  secondCruiseAltitudeMetresMsl,
+  durationMinutes,
+  stepSeconds = DEFAULT_STEP_SECONDS,
+}) {
+  return forecastTrackWithAltitudeProfile({
+    field,
+    launch,
+    durationMinutes,
+    stepSeconds,
+    altitudeAtFraction: (fraction) =>
+      altitudeForStrategyFraction({
+        fraction,
+        launchElevationMetresMsl,
+        firstCruiseAltitudeMetresMsl,
+        secondCruiseAltitudeMetresMsl,
+      }),
+  });
+}
+
+function strategyAltitudes(launchElevationMetresMsl, maximumAltitudeMetresMsl) {
+  const launch = finiteNumber(launchElevationMetresMsl, "launch elevation");
+  const maximum = finiteNumber(maximumAltitudeMetresMsl, "maximum altitude");
+  if (maximum < launch) throw new RangeError("Maximum altitude must not be below launch.");
+  return [...new Set([launch, maximum, ...WIND_LEVELS_METRES_MSL])]
+    .filter((altitude) => altitude >= launch && altitude <= maximum)
+    .sort((first, second) => first - second);
+}
+
+function convexHull(points) {
+  const unique = [
+    ...new Map(
+      points.map((point) => [
+        `${point.longitude.toFixed(8)},${point.latitude.toFixed(8)}`,
+        validPoint(point),
+      ]),
+    ).values(),
+  ].sort(
+    (first, second) =>
+      first.longitude - second.longitude || first.latitude - second.latitude,
+  );
+  if (unique.length <= 2) return unique;
+  const cross = (origin, first, second) =>
+    (first.longitude - origin.longitude) * (second.latitude - origin.latitude) -
+    (first.latitude - origin.latitude) * (second.longitude - origin.longitude);
+  const lower = [];
+  for (const point of unique) {
+    while (lower.length >= 2 && cross(lower.at(-2), lower.at(-1), point) <= 0) lower.pop();
+    lower.push(point);
+  }
+  const upper = [];
+  for (const point of [...unique].reverse()) {
+    while (upper.length >= 2 && cross(upper.at(-2), upper.at(-1), point) <= 0) upper.pop();
+    upper.push(point);
+  }
+  return [...lower.slice(0, -1), ...upper.slice(0, -1)];
+}
+
+export function forecastLandingEnvelope({
+  field,
+  launch,
+  launchElevationMetresMsl,
+  maximumAltitudeMetresMsl,
+  durationMinutes,
+  stepSeconds = DEFAULT_STEP_SECONDS,
+}) {
+  const altitudes = strategyAltitudes(
+    launchElevationMetresMsl,
+    maximumAltitudeMetresMsl,
+  );
+  const candidates = [];
+  for (const firstCruiseAltitudeMetresMsl of altitudes) {
+    for (const secondCruiseAltitudeMetresMsl of altitudes) {
+      const track = forecastAltitudeStrategyTrack({
+        field,
+        launch,
+        launchElevationMetresMsl,
+        firstCruiseAltitudeMetresMsl,
+        secondCruiseAltitudeMetresMsl,
+        durationMinutes,
+        stepSeconds,
+      });
+      candidates.push({
+        firstCruiseAltitudeMetresMsl,
+        secondCruiseAltitudeMetresMsl,
+        track,
+        landing: track.at(-1),
+      });
+    }
+  }
+  return Object.freeze({
+    candidates: Object.freeze(candidates),
+    boundary: Object.freeze(convexHull(candidates.map((candidate) => candidate.landing))),
+  });
+}
+
+export function planWindRouteToDestination({
+  field,
+  launch,
+  destination,
+  launchElevationMetresMsl,
+  maximumAltitudeMetresMsl,
+  durationMinutes,
+  stepSeconds = DEFAULT_STEP_SECONDS,
+  toleranceMetres,
+}) {
+  const target = validPoint(destination, "destination");
+  const envelope = forecastLandingEnvelope({
+    field,
+    launch,
+    launchElevationMetresMsl,
+    maximumAltitudeMetresMsl,
+    durationMinutes,
+    stepSeconds,
+  });
+  const ranked = envelope.candidates
+    .map((candidate) => ({
+      ...candidate,
+      missDistanceMetres: distanceMetres(candidate.landing, target),
+    }))
+    .sort((first, second) => first.missDistanceMetres - second.missDistanceMetres);
+  const best = ranked[0];
+  const directDistanceMetres = distanceMetres(launch, target);
+  const acceptedMissDistanceMetres = Number.isFinite(Number(toleranceMetres))
+    ? Math.max(100, Number(toleranceMetres))
+    : Math.max(1_000, Math.min(3_000, directDistanceMetres * 0.1));
+  return Object.freeze({
+    ...best,
+    destination: target,
+    directDistanceMetres,
+    acceptedMissDistanceMetres,
+    reachesDestination: best.missDistanceMetres <= acceptedMissDistanceMetres,
+    boundary: envelope.boundary,
+    candidateCount: envelope.candidates.length,
+  });
 }
 
 export function circlePolygon(center, radiusMetres, segments = 48) {

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -4,11 +4,14 @@ import test from "node:test";
 import {
   WIND_LEVELS_METRES_MSL,
   altitudeForFlightFraction,
+  altitudeForStrategyFraction,
   buildFlightPlanGpx,
   circlePolygon,
+  forecastLandingEnvelope,
   forecastFlightTrack,
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
+  planWindRouteToDestination,
   vectorAtAltitude,
   windForecastGrid,
 } from "./planner-core.mjs";
@@ -64,6 +67,19 @@ test("flight profile climbs, cruises and returns to launch elevation", () => {
   assert.ok(Math.abs(altitudeForFlightFraction({ fraction: 1, ...settings }) - 80) < 1e-9);
 });
 
+test("destination strategy can use two different cruise wind layers and still land", () => {
+  const settings = {
+    launchElevationMetresMsl: 100,
+    firstCruiseAltitudeMetresMsl: 300,
+    secondCruiseAltitudeMetresMsl: 900,
+  };
+  assert.equal(altitudeForStrategyFraction({ fraction: 0, ...settings }), 100);
+  assert.equal(altitudeForStrategyFraction({ fraction: 0.3, ...settings }), 300);
+  assert.equal(altitudeForStrategyFraction({ fraction: 0.5, ...settings }), 600);
+  assert.equal(altitudeForStrategyFraction({ fraction: 0.6, ...settings }), 900);
+  assert.equal(altitudeForStrategyFraction({ fraction: 1, ...settings }), 100);
+});
+
 test("forecast track follows wind while maintaining its own altitude profile", () => {
   const field = parseOpenMeteoForecast(payload(), new Date("2026-08-21T08:00:00Z"));
   const track = forecastFlightTrack({
@@ -78,6 +94,50 @@ test("forecast track follows wind while maintaining its own altitude profile", (
   assert.ok(Math.abs(track.at(-1).latitude - track[0].latitude) < 0.001);
   assert.equal(track[0].altitudeMetresMsl, 100);
   assert.ok(Math.abs(track.at(-1).altitudeMetresMsl - 100) < 1e-9);
+});
+
+test("wind routing chooses a closest altitude strategy and reports impossible targets", () => {
+  const launch = { latitude: 51.5, longitude: -2.5 };
+  const field = {
+    columns: [
+      {
+        position: launch,
+        vectors: [
+          { altitudeMetresMsl: 100, speedKmh: 36, fromDegrees: 270 },
+          { altitudeMetresMsl: 1000, speedKmh: 36, fromDegrees: 180 },
+        ],
+      },
+    ],
+  };
+  const settings = {
+    field,
+    launch,
+    launchElevationMetresMsl: 100,
+    maximumAltitudeMetresMsl: 1000,
+    durationMinutes: 60,
+    stepSeconds: 300,
+  };
+  const envelope = forecastLandingEnvelope(settings);
+  assert.ok(envelope.candidates.length > 20);
+  assert.ok(envelope.boundary.length >= 3);
+
+  const possible = planWindRouteToDestination({
+    ...settings,
+    destination: { latitude: 51.64, longitude: -2.36 },
+    toleranceMetres: 8_000,
+  });
+  assert.equal(possible.reachesDestination, true);
+  assert.equal(possible.track.at(-1).altitudeMetresMsl, 100);
+  assert.ok(possible.firstCruiseAltitudeMetresMsl <= 1000);
+  assert.ok(possible.secondCruiseAltitudeMetresMsl <= 1000);
+
+  const impossible = planWindRouteToDestination({
+    ...settings,
+    destination: { latitude: 51.5, longitude: -3.0 },
+    toleranceMetres: 1_000,
+  });
+  assert.equal(impossible.reachesDestination, false);
+  assert.ok(impossible.missDistanceMetres > 20_000);
 });
 
 test("generated GPX names the forecast and intended landing without claiming a route", () => {

--- a/apps/planner/styles.css
+++ b/apps/planner/styles.css
@@ -55,6 +55,8 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .site-header h1 { margin: 0.05rem 0 0; font-size: clamp(1.35rem, 3vw, 2rem); letter-spacing: -0.025em; }
 .eyebrow { margin: 0; color: var(--sky); text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.72rem; font-weight: 850; }
 .clock { margin: 0; font-variant-numeric: tabular-nums; font-size: 1rem; color: var(--muted); }
+.header-actions { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; justify-content: flex-end; }
+.theme-switch { min-width: 7.6rem; }
 
 .advisory {
   padding: 0.75rem clamp(1rem, 3vw, 2.5rem);
@@ -101,6 +103,7 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .status { min-height: 1.25rem; margin: 0.7rem 0 0; color: var(--muted); font-size: 0.82rem; line-height: 1.45; }
 .status.error { color: #ffaaa0; }
 .status.good { color: #9be5bb; }
+.route-strategy { margin: 0.7rem 0 0; padding: 0.7rem 0.8rem; border: 1px solid #655a84; border-radius: 0.65rem; background: #1d1928; color: #d9cdf7; font-size: 0.8rem; line-height: 1.4; font-weight: 750; }
 .muted { color: var(--muted); }
 .small { font-size: 0.75rem; line-height: 1.45; }
 
@@ -153,7 +156,7 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 
 .map-shell { position: relative; min-height: 42rem; background: #11141a; overflow: hidden; }
 .map { position: absolute; inset: 0; }
-.map-prompt, .forecast-summary, .map-legend {
+.map-prompt, .forecast-summary, .map-legend, .map-status {
   position: absolute;
   z-index: 2;
   background: rgb(17 21 28 / 0.93);
@@ -162,6 +165,10 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
   backdrop-filter: blur(8px);
 }
 .map-prompt { left: 50%; top: 1rem; transform: translateX(-50%); border-radius: 2rem; padding: 0.65rem 1rem; font-size: 0.82rem; font-weight: 750; }
+.map-status { left: 1rem; top: 1rem; border-radius: 0.7rem; padding: 0.48rem 0.65rem; display: flex; align-items: center; gap: 0.55rem; color: var(--muted); font-size: 0.72rem; }
+.map-status.good { color: #9be5bb; }
+.map-status.error { color: #ffaaa0; border-color: #8f4844; }
+.map-status button { padding: 0.28rem 0.5rem; font-size: 0.68rem; }
 .forecast-summary { top: 1rem; right: 1rem; border-radius: 0.75rem; padding: 0.7rem 0.85rem; display: grid; gap: 0.15rem; }
 .forecast-summary strong { color: var(--sky); }
 .forecast-summary span { color: var(--muted); font-size: 0.72rem; }
@@ -172,6 +179,7 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 .legend-dot.forecast { background: var(--sun); color: var(--sun); }
 .legend-dot.intended { background: var(--green); color: var(--green); }
 .legend-line { width: 1.4rem; height: 0.25rem; border-radius: 1rem; background: linear-gradient(90deg, #4ea5ff, #55e1d2, #ffd45e, #ff6f8c); }
+.legend-envelope { width: 1.4rem; height: 0.65rem; border: 2px dashed var(--purple); background: color-mix(in srgb, var(--purple) 18%, transparent); }
 
 .map-marker { width: 1.2rem; height: 1.2rem; border-radius: 50% 50% 50% 0; transform: rotate(-45deg); border: 2px solid #10141a; box-shadow: 0 2px 8px rgb(0 0 0 / 0.45); }
 .map-marker.launch { background: var(--sky); }
@@ -184,10 +192,60 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 
 .maplibregl-ctrl-group { background: #20252e; }
 .maplibregl-ctrl-group button { background: transparent; border: 0; border-radius: 0; }
+.maplibregl-ctrl-group button .maplibregl-ctrl-icon { filter: invert(1); }
 .maplibregl-ctrl-attrib { background: rgb(17 21 28 / 0.88) !important; color: #d8dce3; }
 .maplibregl-ctrl-attrib a { color: #a7e9f4; }
 
 footer { min-height: 2.7rem; padding: 0.75rem 1rem; display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap; color: #858e9d; font-size: 0.68rem; border-top: 1px solid #272c36; }
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --ink: #24212a;
+  --muted: #655f69;
+  --panel: #f7f4ef;
+  --panel-raised: #eee9e2;
+  --line: #c8c0b8;
+  --sky: #087f96;
+  --sun: #a66a00;
+  --green: #16784a;
+  --purple: #6650a4;
+  --shadow: 0 16px 45px rgb(41 34 31 / 0.18);
+  background: #e8e4de;
+}
+
+:root[data-theme="light"] body { background: #e8e4de; }
+:root[data-theme="light"] button { background: #e5dfd7; }
+:root[data-theme="light"] button:hover:not(:disabled) { background: #d9e9ec; }
+:root[data-theme="light"] .site-header { background: linear-gradient(135deg, #f7f4ef, #eef4f5 55%, #eee8f4); border-color: #d2cbc4; }
+:root[data-theme="light"] .advisory { background: #fff3d8; border-color: #d6b66d; color: #5c4616; }
+:root[data-theme="light"] .advisory strong { color: #3b2d0d; }
+:root[data-theme="light"] .planner-panel { border-color: #cbc4bc; }
+:root[data-theme="light"] .panel-section { border-color: #d7d0c8; }
+:root[data-theme="light"] .section-heading > span { background: #dce7e9; }
+:root[data-theme="light"] input[type="text"],
+:root[data-theme="light"] input[type="number"],
+:root[data-theme="light"] input[type="datetime-local"],
+:root[data-theme="light"] .input-with-unit { background: #ffffff; }
+:root[data-theme="light"] details { background: #ffffff; }
+:root[data-theme="light"] .generate-section { background: #eee9e2; }
+:root[data-theme="light"] .code-result { background: #f8fbfc; }
+:root[data-theme="light"] .route-strategy { background: #eee9f7; color: #493b72; border-color: #a89acb; }
+:root[data-theme="light"] .status.good,
+:root[data-theme="light"] .map-status.good { color: #14683f; }
+:root[data-theme="light"] .status.error,
+:root[data-theme="light"] .map-status.error { color: #a22929; }
+:root[data-theme="light"] .map-status.error { border-color: #b75b55; }
+:root[data-theme="light"] .map-shell { background: #e2e6e9; }
+:root[data-theme="light"] .map-prompt,
+:root[data-theme="light"] .forecast-summary,
+:root[data-theme="light"] .map-legend,
+:root[data-theme="light"] .map-status { background: rgb(255 255 255 / 0.92); color: #49434d; }
+:root[data-theme="light"] .map-legend { color: #3b3640; }
+:root[data-theme="light"] .maplibregl-ctrl-group { background: #ffffff; }
+:root[data-theme="light"] .maplibregl-ctrl-group button .maplibregl-ctrl-icon { filter: none; }
+:root[data-theme="light"] .maplibregl-ctrl-attrib { background: rgb(255 255 255 / 0.9) !important; color: #45404a; }
+:root[data-theme="light"] .maplibregl-ctrl-attrib a { color: #176b7a; }
+:root[data-theme="light"] footer { color: #635d67; border-color: #cbc4bc; }
 
 @media (max-width: 850px) {
   .planner-shell { grid-template-columns: 1fr; }
@@ -197,6 +255,7 @@ footer { min-height: 2.7rem; padding: 0.75rem 1rem; display: flex; justify-conte
 
 @media (max-width: 460px) {
   .site-header { align-items: flex-start; }
+  .header-actions { display: grid; justify-items: end; gap: 0.45rem; }
   .field-grid { grid-template-columns: 1fr; }
   .map-legend { right: 0.65rem; left: 0.65rem; bottom: 0.65rem; }
   .forecast-summary { top: 3.8rem; right: 0.65rem; }


### PR DESCRIPTION
## Summary
- add light/dark planner and basemap themes with visible tile status and retry
- calculate a convex landing envelope from tested two-stage altitude strategies
- rank those strategies against an optional destination and report supported vs best-effort results
- document the safety and reachability limitations

## Verification
- `node --check apps/planner/app.js`
- `node --check apps/planner/_worker.js`
- `node --test apps/planner/planner-core.test.mjs apps/planner/pages-worker.test.mjs`
- local Cloudflare Pages browser check in Chrome for both themes, tile status, envelope mode, destination miss, and clearing the destination

Closes #39