### PR TITLE
feat: optimise balloon flight trajectory

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -4,18 +4,21 @@ Static application code for a balloon pilot's forecast flight plan. It keeps
 the short plan-code flow inherited from Tail End Charlie, but it does not
 pretend a balloon follows a road route:
 
-- the pilot selects a launch point, departure time, duration and altitude;
+- the pilot selects a launch point, departure time, launch elevation and optional
+  destination;
 - UKMO UKV wind from Open-Meteo is sampled on the same 3×3 grid and MSL height
-  levels used by the mobile app;
-- the forecast track integrates the balloon through its own climb, cruise and
-  descent profile;
+  levels used by the mobile app, with hourly interpolation during the flight;
+- the destination optimiser searches 10–180 minute durations and four changing
+  altitude controls up to the highest 2,000 m MSL forecast layer;
+- duration, altitude profile and resulting peak altitude are outputs of the
+  optimiser rather than pilot-supplied route inputs;
 - the basemap and planner controls can switch between light and dark themes,
   with an explicit tile-load indicator and retry action;
 - OpenAIP's combined aeronautical chart is visible with a plain-language key;
 - the purple landing envelope is the convex boundary of endpoints produced by
-  the tested two-stage altitude strategies;
-- an optional destination search ranks those strategies by forecast miss
-  distance and clearly reports when none gets within the planning tolerance;
+  the coarse duration and altitude search;
+- the destination search refines its best candidates to a 100 m acceptance
+  distance and clearly reports when none can get that close;
 - the forecast landing area and separately editable destination are shown; and
 - the resulting forecast track can be stored through `/api/v1/plans` and loaded
   in the app with the returned short code.

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -3,7 +3,6 @@ import {
   buildFlightPlanGpx,
   circlePolygon,
   forecastDistanceMetres,
-  forecastFlightTrack,
   forecastLandingEnvelope,
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
@@ -62,7 +61,6 @@ const elements = Object.fromEntries(
     "copy-code",
     "clear-destination",
     "departure-time",
-    "duration-minutes",
     "forecast-distance",
     "forecast-summary",
     "forecast-validity",
@@ -75,7 +73,6 @@ const elements = Object.fromEntries(
     "map-prompt",
     "map-status",
     "map-status-text",
-    "maximum-altitude",
     "open-in-app",
     "plan-code",
     "plan-expiry",
@@ -473,42 +470,40 @@ function updateSources() {
 }
 
 function fitForecast() {
-  if (!state.track?.length) return;
   const bounds = new maplibregl.LngLatBounds();
-  for (const point of state.track) bounds.extend([point.longitude, point.latitude]);
+  if (state.launch) bounds.extend([state.launch.longitude, state.launch.latitude]);
+  for (const point of state.track ?? []) bounds.extend([point.longitude, point.latitude]);
   if (state.intendedLanding) {
     bounds.extend([state.intendedLanding.longitude, state.intendedLanding.latitude]);
   }
   for (const point of state.landingEnvelope) {
     bounds.extend([point.longitude, point.latitude]);
   }
-  state.map.fitBounds(bounds, { padding: 90, maxZoom: 11, duration: 700 });
+  if (!bounds.isEmpty()) state.map.fitBounds(bounds, { padding: 90, maxZoom: 11, duration: 700 });
 }
 
-function validFlightSettings() {
-  const durationMinutes = Number(elements.duration_minutes.value);
+function validLaunchSettings() {
   const launchElevationMetresMsl = Number(elements.launch_elevation.value);
-  const maximumAltitudeMetresMsl = Number(elements.maximum_altitude.value);
-  if (!Number.isFinite(durationMinutes) || durationMinutes < 10 || durationMinutes > 180) {
-    throw new Error("Flight duration must be between 10 and 180 minutes.");
-  }
-  if (!Number.isFinite(launchElevationMetresMsl) || launchElevationMetresMsl < -50) {
+  if (
+    !Number.isFinite(launchElevationMetresMsl) ||
+    launchElevationMetresMsl < -50 ||
+    launchElevationMetresMsl > 1000
+  ) {
     throw new Error("Choose a valid launch elevation in metres MSL.");
   }
-  if (
-    !Number.isFinite(maximumAltitudeMetresMsl) ||
-    maximumAltitudeMetresMsl < launchElevationMetresMsl ||
-    maximumAltitudeMetresMsl > 2500
-  ) {
-    throw new Error("Maximum altitude must be above launch and no more than 2,500 m MSL.");
-  }
-  return { durationMinutes, launchElevationMetresMsl, maximumAltitudeMetresMsl };
+  return { launchElevationMetresMsl };
+}
+
+function formatMissDistance(distanceMetres) {
+  return distanceMetres < 1000
+    ? `${Math.round(distanceMetres)} m`
+    : `${(distanceMetres / 1000).toFixed(1)} km`;
 }
 
 function recomputeTrack({ fit = false } = {}) {
   if (!state.field || !state.launch) return;
   try {
-    const settings = { field: state.field, launch: state.launch, ...validFlightSettings() };
+    const settings = { field: state.field, launch: state.launch, ...validLaunchSettings() };
     if (state.manualLanding && state.intendedLanding) {
       state.routePlan = planWindRouteToDestination({
         ...settings,
@@ -517,58 +512,62 @@ function recomputeTrack({ fit = false } = {}) {
       state.track = state.routePlan.track;
       state.landingEnvelope = state.routePlan.boundary;
       state.landingCandidateCount = state.routePlan.candidateCount;
-      const missKilometres = (state.routePlan.missDistanceMetres / 1000).toFixed(1);
-      const toleranceKilometres = (
-        state.routePlan.acceptedMissDistanceMetres / 1000
-      ).toFixed(1);
-      const firstAltitude = Math.round(state.routePlan.firstCruiseAltitudeMetresMsl);
-      const secondAltitude = Math.round(state.routePlan.secondCruiseAltitudeMetresMsl);
+      const missDistance = formatMissDistance(state.routePlan.missDistanceMetres);
+      const duration = Number.isInteger(state.routePlan.durationMinutes)
+        ? state.routePlan.durationMinutes.toFixed(0)
+        : state.routePlan.durationMinutes.toFixed(1);
+      const profile = state.routePlan.controlAltitudesMetresMsl
+        .map((altitude) => `${Math.round(altitude)} m`)
+        .join(" → ");
       elements.route_strategy.hidden = false;
       elements.route_strategy.textContent =
-        firstAltitude === secondAltitude
-          ? `Closest tested height plan: hold near ${firstAltitude} m MSL, then descend.`
-          : `Closest tested height plan: ${firstAltitude} m, then ${secondAltitude} m MSL, then descend.`;
+        `Optimised forecast: ${duration} min · peak ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · ` +
+        `heights at 20/40/60/80%: ${profile}, then land at launch elevation.`;
       setStatus(
         elements.route_status,
         state.routePlan.reachesDestination
-          ? `The closest forecast endpoint is ${missKilometres} km from the destination, inside the ${toleranceKilometres} km planning tolerance.`
-          : `The winds do not support this destination in the tested height plans. The closest forecast endpoint still misses by ${missKilometres} km; the shown track is best-effort only.`,
+          ? `The optimised forecast endpoint is ${missDistance} from the destination, within the 100 m acceptance distance.`
+          : `The forecast winds do not support this destination inside the search limits. The closest endpoint still misses by ${missDistance}; the shown track is best-effort only.`,
         state.routePlan.reachesDestination ? "good" : "error",
       );
+      state.forecastLanding = state.track.at(-1);
+      setMarker("forecast", state.forecastLanding, "Forecast landing");
+      setMarker("intended", state.intendedLanding, "Destination");
     } else {
       state.routePlan = null;
-      state.track = forecastFlightTrack(settings);
+      state.track = null;
+      state.forecastLanding = null;
       const envelope = forecastLandingEnvelope(settings);
       state.landingEnvelope = envelope.boundary;
       state.landingCandidateCount = envelope.candidates.length;
       elements.route_strategy.hidden = true;
+      setMarker("forecast", null);
+      setMarker("intended", null);
       setStatus(
         elements.route_status,
-        "Set a destination to test two-stage altitude plans against the forecast wind layers.",
+        "Set a destination to optimise flight duration and four in-flight altitude controls.",
       );
     }
-    state.forecastLanding = state.track.at(-1);
-    if (!state.manualLanding || !state.intendedLanding) state.intendedLanding = state.forecastLanding;
-    setMarker("forecast", state.forecastLanding, "Forecast landing");
-    setMarker("intended", state.intendedLanding, "Destination");
     updateSources();
     updateWindMarkers();
     elements.set_landing.disabled = false;
     elements.clear_destination.disabled = !state.manualLanding;
-    elements.generate_code.disabled = false;
-    elements.forecast_summary.hidden = false;
-    elements.forecast_distance.textContent = `${(forecastDistanceMetres(state.track) / 1000).toFixed(1)} km forecast drift`;
-    elements.forecast_validity.textContent = `Wind valid ${formatUtc(state.field.validAt)}`;
+    elements.generate_code.disabled = !state.track;
+    elements.forecast_summary.hidden = !state.track;
+    if (state.track) {
+      elements.forecast_distance.textContent = `${(forecastDistanceMetres(state.track) / 1000).toFixed(1)} km forecast drift`;
+      elements.forecast_validity.textContent = `${state.routePlan.durationMinutes.toFixed(1)} min · hourly wind from departure`;
+    }
     setStatus(
       elements.landing_status,
       state.manualLanding
-        ? "Destination retained. The forecast landing and height strategy update separately."
-        : `The purple envelope bounds endpoints from ${state.landingCandidateCount} two-stage height plans. It is not a safe-landing assessment.`,
+        ? `Destination retained. ${state.routePlan.evaluatedCandidateCount} duration and height refinements were evaluated.`
+        : `The purple envelope bounds ${state.landingCandidateCount} coarse duration and height forecasts. It is not a safe-landing assessment.`,
       "good",
     );
     setStatus(
       elements.wind_status,
-      `UKMO wind valid ${formatUtc(state.field.validAt)} · forecast model, not an observation.`,
+      `Hourly UKMO wind forecast starts ${formatUtc(state.field.validAt)} · model data, not an observation.`,
       "good",
     );
     if (fit) fitForecast();
@@ -594,7 +593,7 @@ async function refreshForecast() {
   let departure;
   try {
     departure = selectedDeparture();
-    validFlightSettings();
+    validLaunchSettings();
   } catch (error) {
     setStatus(elements.wind_status, error.message, "error");
     return;
@@ -671,7 +670,7 @@ function chooseLaunch(point) {
   void refreshForecast();
 }
 
-function chooseLanding(point) {
+async function chooseLanding(point) {
   state.intendedLanding = { latitude: point.lat, longitude: point.lng };
   state.manualLanding = true;
   setMarker("intended", state.intendedLanding, "Destination");
@@ -681,9 +680,12 @@ function chooseLanding(point) {
   elements.clear_destination.disabled = false;
   setStatus(
     elements.landing_status,
-    `Destination set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. Testing forecast height plans…`,
+    `Destination set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. Optimising duration and altitude profile…`,
     "good",
   );
+  await new Promise((resolve) => {
+    window.requestAnimationFrame(() => window.setTimeout(resolve, 0));
+  });
   recomputeTrack({ fit: true });
 }
 
@@ -788,9 +790,7 @@ function bindControls() {
     }
   });
   elements.departure_time.addEventListener("change", () => void refreshForecast());
-  for (const input of [elements.duration_minutes, elements.launch_elevation, elements.maximum_altitude]) {
-    input.addEventListener("change", () => recomputeTrack({ fit: false }));
-  }
+  elements.launch_elevation.addEventListener("change", () => recomputeTrack({ fit: false }));
   elements.generate_code.addEventListener("click", () => void generatePlanCode());
   elements.copy_code.addEventListener("click", () => void copyPlanCode());
 }
@@ -839,7 +839,7 @@ async function start() {
       updateSources();
       state.map.on("click", (event) => {
         if (state.mode === "launch") chooseLaunch(event.lngLat);
-        else if (state.mode === "landing") chooseLanding(event.lngLat);
+        else if (state.mode === "landing") void chooseLanding(event.lngLat);
       });
     });
   } catch (error) {

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -51,37 +51,22 @@
           <div class="section-heading">
             <span>2</span>
             <div>
-              <h2 id="flight-title">Flight shape</h2>
-              <p>The balloon climbs, cruises, then descends through forecast layers.</p>
+              <h2 id="flight-title">Forecast setup</h2>
+              <p>Set only what the optimiser cannot choose: departure and ground elevation.</p>
             </div>
           </div>
           <label class="field">
             <span>Departure (local time)</span>
             <input type="datetime-local" id="departure-time" />
           </label>
-          <div class="field-grid">
-            <label class="field">
-              <span>Duration</span>
-              <span class="input-with-unit">
-                <input type="number" id="duration-minutes" min="10" max="180" step="5" value="60" />
-                <i>min</i>
-              </span>
-            </label>
-            <label class="field">
-              <span>Launch elevation</span>
-              <span class="input-with-unit">
-                <input type="number" id="launch-elevation" min="-50" max="1000" step="10" value="100" />
-                <i>m MSL</i>
-              </span>
-            </label>
-          </div>
           <label class="field">
-            <span>Planned maximum altitude</span>
+            <span>Launch elevation</span>
             <span class="input-with-unit">
-              <input type="number" id="maximum-altitude" min="100" max="2500" step="50" value="1000" />
+              <input type="number" id="launch-elevation" min="-50" max="1000" step="10" value="100" />
               <i>m MSL</i>
             </span>
           </label>
+          <p class="search-limits small">The destination search chooses a 10–180 minute duration and four altitude controls between launch elevation and 2,000 m MSL. Its resulting peak altitude is an output, not an input.</p>
         </section>
 
         <section class="panel-section" aria-labelledby="wind-title">
@@ -110,7 +95,7 @@
             <span>4</span>
             <div>
               <h2 id="landing-title">Destination and landing envelope</h2>
-              <p>Test whether forecast winds at different heights can approach a chosen destination.</p>
+              <p>Optimise duration and a changing altitude profile toward a chosen destination.</p>
             </div>
           </div>
           <div class="button-row">
@@ -120,7 +105,7 @@
           <p class="status" id="landing-status">Waiting for a wind forecast.</p>
           <p class="status" id="route-status" role="status">Set a launch point to calculate the landing envelope.</p>
           <p class="route-strategy" id="route-strategy" hidden></p>
-          <p class="small muted">The purple boundary is a convex envelope of tested forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. The height solver does not assess airspace, terrain, legal limits, fuel or actual climb/descent performance.</p>
+          <p class="small muted">The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
         </section>
 
         <section class="panel-section" aria-labelledby="airspace-title">

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -4,6 +4,13 @@ export const WIND_LEVELS_METRES_MSL = Object.freeze([
 
 const EARTH_RADIUS_METRES = 6_371_000;
 const DEFAULT_STEP_SECONDS = 60;
+export const ROUTE_SEARCH_LIMITS = Object.freeze({
+  minimumDurationMinutes: 10,
+  maximumDurationMinutes: 180,
+  altitudeCeilingMetresMsl: 2000,
+  acceptedMissDistanceMetres: 100,
+});
+export const ROUTE_CONTROL_FRACTIONS = Object.freeze([0, 0.2, 0.4, 0.6, 0.8, 1]);
 
 function finiteNumber(value, label) {
   const number = Number(value);
@@ -70,8 +77,7 @@ export function parseOpenMeteoForecast(payload, requestedAt) {
   const target = requestedAt instanceof Date ? requestedAt : new Date(requestedAt);
   if (Number.isNaN(target.getTime())) throw new TypeError("Forecast time is invalid.");
   const entries = Array.isArray(payload) ? payload : [payload];
-  const columns = [];
-  let validAt = null;
+  const slicesByTime = new Map();
 
   for (const entry of entries) {
     if (!entry || typeof entry !== "object" || !entry.hourly) continue;
@@ -87,29 +93,41 @@ export function parseOpenMeteoForecast(payload, requestedAt) {
     const rawTimes = Array.isArray(entry.hourly.time) ? entry.hourly.time : [];
     const times = rawTimes.map(parseUtcHour);
     if (times.length === 0 || times.some((time) => time === null)) continue;
-    const timeIndex = nearestTimeIndex(times, target);
-    const vectors = [];
-    for (const altitudeMetresMsl of WIND_LEVELS_METRES_MSL) {
-      const speeds = entry.hourly[`wind_speed_${altitudeMetresMsl}m`];
-      const directions = entry.hourly[`wind_direction_${altitudeMetresMsl}m`];
-      const speedKmh = Number(Array.isArray(speeds) ? speeds[timeIndex] : NaN);
-      const fromDegrees = Number(Array.isArray(directions) ? directions[timeIndex] : NaN);
-      if (!Number.isFinite(speedKmh) || speedKmh < 0 || !Number.isFinite(fromDegrees)) continue;
-      vectors.push({
-        altitudeMetresMsl,
-        speedKmh,
-        fromDegrees: ((fromDegrees % 360) + 360) % 360,
-      });
+    for (let timeIndex = 0; timeIndex < times.length; timeIndex += 1) {
+      const vectors = [];
+      for (const altitudeMetresMsl of WIND_LEVELS_METRES_MSL) {
+        const speeds = entry.hourly[`wind_speed_${altitudeMetresMsl}m`];
+        const directions = entry.hourly[`wind_direction_${altitudeMetresMsl}m`];
+        const speedKmh = Number(Array.isArray(speeds) ? speeds[timeIndex] : NaN);
+        const fromDegrees = Number(Array.isArray(directions) ? directions[timeIndex] : NaN);
+        if (!Number.isFinite(speedKmh) || speedKmh < 0 || !Number.isFinite(fromDegrees)) continue;
+        vectors.push({
+          altitudeMetresMsl,
+          speedKmh,
+          fromDegrees: ((fromDegrees % 360) + 360) % 360,
+        });
+      }
+      if (vectors.length === 0) continue;
+      const epoch = times[timeIndex].getTime();
+      const slice = slicesByTime.get(epoch) ?? { validAt: times[timeIndex], columns: [] };
+      slice.columns.push({ position, vectors });
+      slicesByTime.set(epoch, slice);
     }
-    if (vectors.length === 0) continue;
-    validAt ??= times[timeIndex];
-    columns.push({ position, vectors });
   }
 
-  if (columns.length === 0 || validAt === null) {
+  const timeSlices = [...slicesByTime.values()]
+    .filter((slice) => slice.columns.length > 0)
+    .sort((first, second) => first.validAt - second.validAt);
+  if (timeSlices.length === 0) {
     throw new Error("Open-Meteo returned no usable wind profiles for this time and place.");
   }
-  return { columns, validAt, requestedAt: target };
+  const selected = timeSlices[nearestTimeIndex(timeSlices.map((slice) => slice.validAt), target)];
+  return {
+    columns: selected.columns,
+    validAt: selected.validAt,
+    requestedAt: target,
+    timeSlices,
+  };
 }
 
 function components(vector) {
@@ -173,15 +191,49 @@ export function distanceMetres(first, second) {
   return 2 * EARTH_RADIUS_METRES * Math.asin(Math.sqrt(haversine));
 }
 
-export function vectorAtPosition(field, position, altitudeMetresMsl) {
-  const columns = field?.columns ?? [];
+function vectorInColumns(columns, position, altitudeMetresMsl) {
   if (columns.length === 0) return null;
-  const nearest = columns.reduce((best, candidate) =>
-    distanceMetres(candidate.position, position) < distanceMetres(best.position, position)
-      ? candidate
-      : best,
-  );
+  let nearest = columns[0];
+  let nearestDistance = distanceMetres(nearest.position, position);
+  for (let index = 1; index < columns.length; index += 1) {
+    const candidateDistance = distanceMetres(columns[index].position, position);
+    if (candidateDistance >= nearestDistance) continue;
+    nearest = columns[index];
+    nearestDistance = candidateDistance;
+  }
   return vectorAtAltitude(nearest, altitudeMetresMsl);
+}
+
+export function vectorAtPosition(field, position, altitudeMetresMsl, elapsedSeconds = 0) {
+  const slices = field?.timeSlices ?? [];
+  if (slices.length === 0) {
+    return vectorInColumns(field?.columns ?? [], position, altitudeMetresMsl);
+  }
+  const requestedAt = field.requestedAt instanceof Date ? field.requestedAt : field.validAt;
+  const targetTime = requestedAt.getTime() + finiteNumber(elapsedSeconds, "elapsed seconds") * 1000;
+  let upperIndex = slices.findIndex((slice) => slice.validAt.getTime() >= targetTime);
+  if (upperIndex < 0) upperIndex = slices.length - 1;
+  const lowerIndex = Math.max(0, upperIndex - 1);
+  const lower = slices[lowerIndex];
+  const upper = slices[upperIndex];
+  const lowerVector = vectorInColumns(lower.columns, position, altitudeMetresMsl);
+  const upperVector = vectorInColumns(upper.columns, position, altitudeMetresMsl);
+  if (!lowerVector) return upperVector;
+  if (!upperVector || lowerIndex === upperIndex) return lowerVector;
+  const interval = upper.validAt.getTime() - lower.validAt.getTime();
+  const fraction =
+    interval <= 0
+      ? 0
+      : Math.max(0, Math.min(1, (targetTime - lower.validAt.getTime()) / interval));
+  const lowerComponents = components(lowerVector);
+  const upperComponents = components(upperVector);
+  return vectorFromComponents(
+    altitudeMetresMsl,
+    lowerComponents.eastMetresPerSecond +
+      (upperComponents.eastMetresPerSecond - lowerComponents.eastMetresPerSecond) * fraction,
+    lowerComponents.northMetresPerSecond +
+      (upperComponents.northMetresPerSecond - lowerComponents.northMetresPerSecond) * fraction,
+  );
 }
 
 export function altitudeForFlightFraction({
@@ -220,6 +272,29 @@ export function altitudeForStrategyFraction({
   return launch + (second - launch) * ((1 - progress) / 0.3);
 }
 
+export function altitudeForProfileFraction({
+  fraction,
+  launchElevationMetresMsl,
+  controlAltitudesMetresMsl,
+}) {
+  const progress = Math.max(0, Math.min(1, finiteNumber(fraction, "flight fraction")));
+  const launch = finiteNumber(launchElevationMetresMsl, "launch elevation");
+  if (!Array.isArray(controlAltitudesMetresMsl) || controlAltitudesMetresMsl.length !== 4) {
+    throw new RangeError("An altitude profile requires four in-flight control heights.");
+  }
+  const altitudes = [
+    launch,
+    ...controlAltitudesMetresMsl.map((altitude, index) =>
+      Math.max(launch, finiteNumber(altitude, `control altitude ${index + 1}`)),
+    ),
+    launch,
+  ];
+  if (progress >= 1) return launch;
+  const segment = Math.min(4, Math.floor(progress / 0.2));
+  const segmentProgress = (progress - ROUTE_CONTROL_FRACTIONS[segment]) / 0.2;
+  return altitudes[segment] + (altitudes[segment + 1] - altitudes[segment]) * segmentProgress;
+}
+
 export function moveWithWind(position, vector, seconds) {
   const origin = validPoint(position);
   const elapsed = finiteNumber(seconds, "elapsed seconds");
@@ -251,15 +326,17 @@ function forecastTrackWithAltitudeProfile({
     throw new RangeError("Flight duration or forecast step is outside the supported range.");
   }
   const points = [];
-  for (let elapsedSeconds = 0; elapsedSeconds <= durationSeconds; elapsedSeconds += step) {
+  let elapsedSeconds = 0;
+  while (true) {
     const fraction = elapsedSeconds / durationSeconds;
     const altitudeMetresMsl = altitudeAtFraction(fraction);
-    const vector = vectorAtPosition(field, position, altitudeMetresMsl);
+    const vector = vectorAtPosition(field, position, altitudeMetresMsl, elapsedSeconds);
     if (!vector) throw new Error("The wind field does not cover the forecast flight.");
     points.push({ ...position, altitudeMetresMsl, elapsedSeconds, wind: vector });
-    if (elapsedSeconds < durationSeconds) {
-      position = moveWithWind(position, vector, Math.min(step, durationSeconds - elapsedSeconds));
-    }
+    if (elapsedSeconds >= durationSeconds) break;
+    const nextElapsedSeconds = Math.min(durationSeconds, elapsedSeconds + step);
+    position = moveWithWind(position, vector, nextElapsedSeconds - elapsedSeconds);
+    elapsedSeconds = nextElapsedSeconds;
   }
   return Object.freeze(points);
 }
@@ -310,13 +387,73 @@ export function forecastAltitudeStrategyTrack({
   });
 }
 
-function strategyAltitudes(launchElevationMetresMsl, maximumAltitudeMetresMsl) {
+export function forecastAltitudeProfileTrack({
+  field,
+  launch,
+  launchElevationMetresMsl,
+  controlAltitudesMetresMsl,
+  durationMinutes,
+  stepSeconds = DEFAULT_STEP_SECONDS,
+}) {
+  return forecastTrackWithAltitudeProfile({
+    field,
+    launch,
+    durationMinutes,
+    stepSeconds,
+    altitudeAtFraction: (fraction) =>
+      altitudeForProfileFraction({
+        fraction,
+        launchElevationMetresMsl,
+        controlAltitudesMetresMsl,
+      }),
+  });
+}
+
+function strategyAltitudes(launchElevationMetresMsl, altitudeCeilingMetresMsl) {
   const launch = finiteNumber(launchElevationMetresMsl, "launch elevation");
-  const maximum = finiteNumber(maximumAltitudeMetresMsl, "maximum altitude");
-  if (maximum < launch) throw new RangeError("Maximum altitude must not be below launch.");
-  return [...new Set([launch, maximum, ...WIND_LEVELS_METRES_MSL])]
-    .filter((altitude) => altitude >= launch && altitude <= maximum)
+  const ceiling = finiteNumber(altitudeCeilingMetresMsl, "altitude ceiling");
+  if (ceiling < launch) throw new RangeError("Altitude ceiling must not be below launch.");
+  return [...new Set([launch, ceiling, ...WIND_LEVELS_METRES_MSL])]
+    .filter((altitude) => altitude >= launch && altitude <= ceiling)
     .sort((first, second) => first - second);
+}
+
+function routeDurations(minimumDurationMinutes, maximumDurationMinutes, stepMinutes = 10) {
+  const minimum = finiteNumber(minimumDurationMinutes, "minimum route duration");
+  const maximum = finiteNumber(maximumDurationMinutes, "maximum route duration");
+  const step = finiteNumber(stepMinutes, "route duration step");
+  if (minimum < 10 || maximum > 180 || minimum > maximum || step <= 0) {
+    throw new RangeError("Route duration search is outside the supported range.");
+  }
+  const durations = [];
+  for (let duration = minimum; duration <= maximum; duration += step) durations.push(duration);
+  if (durations.at(-1) !== maximum) durations.push(maximum);
+  return durations;
+}
+
+function profileIsFeasible({
+  controlAltitudesMetresMsl,
+  launchElevationMetresMsl,
+  altitudeCeilingMetresMsl,
+  durationMinutes,
+  maximumVerticalRateMetresPerSecond,
+}) {
+  const launch = finiteNumber(launchElevationMetresMsl, "launch elevation");
+  const ceiling = finiteNumber(altitudeCeilingMetresMsl, "altitude ceiling");
+  const segmentSeconds = (finiteNumber(durationMinutes, "flight duration") * 60) / 5;
+  const altitudes = [launch, ...controlAltitudesMetresMsl, launch];
+  if (
+    altitudes.some(
+      (altitude) => !Number.isFinite(altitude) || altitude < launch || altitude > ceiling,
+    )
+  ) {
+    return false;
+  }
+  return altitudes.slice(1).every(
+    (altitude, index) =>
+      Math.abs(altitude - altitudes[index]) / segmentSeconds <=
+      maximumVerticalRateMetresPerSecond,
+  );
 }
 
 function convexHull(points) {
@@ -348,82 +485,254 @@ function convexHull(points) {
   return [...lower.slice(0, -1), ...upper.slice(0, -1)];
 }
 
-export function forecastLandingEnvelope({
+function coarseLandingCandidates({
   field,
   launch,
   launchElevationMetresMsl,
-  maximumAltitudeMetresMsl,
-  durationMinutes,
+  destination,
+  minimumDurationMinutes,
+  maximumDurationMinutes,
+  altitudeCeilingMetresMsl,
+  maximumVerticalRateMetresPerSecond,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
-  const altitudes = strategyAltitudes(
-    launchElevationMetresMsl,
-    maximumAltitudeMetresMsl,
+  const target = destination ? validPoint(destination, "destination") : null;
+  const altitudes = strategyAltitudes(launchElevationMetresMsl, altitudeCeilingMetresMsl);
+  const durations = routeDurations(
+    minimumDurationMinutes,
+    maximumDurationMinutes,
   );
   const candidates = [];
-  for (const firstCruiseAltitudeMetresMsl of altitudes) {
-    for (const secondCruiseAltitudeMetresMsl of altitudes) {
-      const track = forecastAltitudeStrategyTrack({
-        field,
-        launch,
-        launchElevationMetresMsl,
-        firstCruiseAltitudeMetresMsl,
-        secondCruiseAltitudeMetresMsl,
-        durationMinutes,
-        stepSeconds,
-      });
-      candidates.push({
-        firstCruiseAltitudeMetresMsl,
-        secondCruiseAltitudeMetresMsl,
-        track,
-        landing: track.at(-1),
-      });
+  for (const durationMinutes of durations) {
+    for (const firstAltitude of altitudes) {
+      for (const secondAltitude of altitudes) {
+        const controlAltitudesMetresMsl = [
+          firstAltitude,
+          firstAltitude,
+          secondAltitude,
+          secondAltitude,
+        ];
+        if (
+          !profileIsFeasible({
+            controlAltitudesMetresMsl,
+            launchElevationMetresMsl,
+            altitudeCeilingMetresMsl,
+            durationMinutes,
+            maximumVerticalRateMetresPerSecond,
+          })
+        ) {
+          continue;
+        }
+        const track = forecastAltitudeProfileTrack({
+          field,
+          launch,
+          launchElevationMetresMsl,
+          controlAltitudesMetresMsl,
+          durationMinutes,
+          stepSeconds,
+        });
+        const landing = track.at(-1);
+        candidates.push({
+          durationMinutes,
+          controlAltitudesMetresMsl,
+          peakAltitudeMetresMsl: Math.max(launchElevationMetresMsl, ...controlAltitudesMetresMsl),
+          landing,
+          ...(target ? { missDistanceMetres: distanceMetres(landing, target) } : {}),
+        });
+      }
     }
   }
+  return candidates;
+}
+
+function routeSearchSettings(options) {
+  const minimumDurationMinutes =
+    options.minimumDurationMinutes ?? ROUTE_SEARCH_LIMITS.minimumDurationMinutes;
+  const maximumDurationMinutes =
+    options.maximumDurationMinutes ?? ROUTE_SEARCH_LIMITS.maximumDurationMinutes;
+  const altitudeCeilingMetresMsl =
+    options.altitudeCeilingMetresMsl ?? ROUTE_SEARCH_LIMITS.altitudeCeilingMetresMsl;
+  const maximumVerticalRateMetresPerSecond = options.maximumVerticalRateMetresPerSecond ?? 5;
+  routeDurations(minimumDurationMinutes, maximumDurationMinutes);
+  if (altitudeCeilingMetresMsl < options.launchElevationMetresMsl) {
+    throw new RangeError("Altitude ceiling must not be below launch.");
+  }
+  return {
+    minimumDurationMinutes,
+    maximumDurationMinutes,
+    altitudeCeilingMetresMsl,
+    maximumVerticalRateMetresPerSecond,
+  };
+}
+
+export function forecastLandingEnvelope(options) {
+  const settings = routeSearchSettings(options);
+  const candidates = coarseLandingCandidates({ ...options, ...settings });
   return Object.freeze({
     candidates: Object.freeze(candidates),
     boundary: Object.freeze(convexHull(candidates.map((candidate) => candidate.landing))),
+    ...settings,
   });
 }
 
-export function planWindRouteToDestination({
-  field,
-  launch,
-  destination,
-  launchElevationMetresMsl,
-  maximumAltitudeMetresMsl,
-  durationMinutes,
-  stepSeconds = DEFAULT_STEP_SECONDS,
-  toleranceMetres,
-}) {
-  const target = validPoint(destination, "destination");
-  const envelope = forecastLandingEnvelope({
+function routeCandidateKey(durationMinutes, controlAltitudesMetresMsl) {
+  return `${Math.round(durationMinutes * 60)}:${controlAltitudesMetresMsl
+    .map((altitude) => Math.round(altitude))
+    .join(",")}`;
+}
+
+function bestUniqueCandidates(candidates, limit) {
+  const unique = new Map();
+  for (const candidate of candidates) {
+    const key = routeCandidateKey(candidate.durationMinutes, candidate.controlAltitudesMetresMsl);
+    const existing = unique.get(key);
+    if (!existing || candidate.missDistanceMetres < existing.missDistanceMetres) {
+      unique.set(key, candidate);
+    }
+  }
+  return [...unique.values()]
+    .sort((first, second) => first.missDistanceMetres - second.missDistanceMetres)
+    .slice(0, limit);
+}
+
+export function planWindRouteToDestination(options) {
+  const {
     field,
     launch,
+    destination,
     launchElevationMetresMsl,
-    maximumAltitudeMetresMsl,
-    durationMinutes,
+    stepSeconds = DEFAULT_STEP_SECONDS,
+  } = options;
+  const target = validPoint(destination, "destination");
+  const settings = routeSearchSettings(options);
+  const coarseCandidates = coarseLandingCandidates({
+    ...options,
+    ...settings,
+    destination: target,
     stepSeconds,
   });
-  const ranked = envelope.candidates
-    .map((candidate) => ({
-      ...candidate,
-      missDistanceMetres: distanceMetres(candidate.landing, target),
-    }))
-    .sort((first, second) => first.missDistanceMetres - second.missDistanceMetres);
-  const best = ranked[0];
+  if (coarseCandidates.length === 0) {
+    throw new Error("No feasible altitude profiles were available inside the route-search limits.");
+  }
+  const altitudeLevels = strategyAltitudes(
+    launchElevationMetresMsl,
+    settings.altitudeCeilingMetresMsl,
+  );
+  const evaluationCache = new Map();
+  const evaluate = (durationMinutes, controlAltitudesMetresMsl) => {
+    const boundedDurationMinutes = Math.max(
+      settings.minimumDurationMinutes,
+      Math.min(settings.maximumDurationMinutes, Math.round(durationMinutes * 60) / 60),
+    );
+    const boundedAltitudes = controlAltitudesMetresMsl.map((altitude) =>
+      Math.max(
+        launchElevationMetresMsl,
+        Math.min(settings.altitudeCeilingMetresMsl, Math.round(altitude)),
+      ),
+    );
+    const key = routeCandidateKey(boundedDurationMinutes, boundedAltitudes);
+    if (evaluationCache.has(key)) return evaluationCache.get(key);
+    if (
+      !profileIsFeasible({
+        controlAltitudesMetresMsl: boundedAltitudes,
+        launchElevationMetresMsl,
+        altitudeCeilingMetresMsl: settings.altitudeCeilingMetresMsl,
+        durationMinutes: boundedDurationMinutes,
+        maximumVerticalRateMetresPerSecond: settings.maximumVerticalRateMetresPerSecond,
+      })
+    ) {
+      evaluationCache.set(key, null);
+      return null;
+    }
+    const track = forecastAltitudeProfileTrack({
+      field,
+      launch,
+      launchElevationMetresMsl,
+      controlAltitudesMetresMsl: boundedAltitudes,
+      durationMinutes: boundedDurationMinutes,
+      stepSeconds,
+    });
+    const landing = track.at(-1);
+    const candidate = {
+      durationMinutes: boundedDurationMinutes,
+      controlAltitudesMetresMsl: boundedAltitudes,
+      peakAltitudeMetresMsl: Math.max(launchElevationMetresMsl, ...boundedAltitudes),
+      track,
+      landing,
+      missDistanceMetres: distanceMetres(landing, target),
+    };
+    evaluationCache.set(key, candidate);
+    return candidate;
+  };
+
+  let beam = bestUniqueCandidates(coarseCandidates, 10)
+    .map((candidate) =>
+      evaluate(candidate.durationMinutes, candidate.controlAltitudesMetresMsl),
+    )
+    .filter(Boolean);
+  for (let pass = 0; pass < 2; pass += 1) {
+    for (let controlIndex = 0; controlIndex < 4; controlIndex += 1) {
+      const expanded = [...beam];
+      for (const seed of beam) {
+        for (const altitude of altitudeLevels) {
+          const controlAltitudes = [...seed.controlAltitudesMetresMsl];
+          controlAltitudes[controlIndex] = altitude;
+          const candidate = evaluate(seed.durationMinutes, controlAltitudes);
+          if (candidate) expanded.push(candidate);
+        }
+      }
+      beam = bestUniqueCandidates(expanded, 10);
+    }
+  }
+
+  const refinementScales = [
+    [300, 200],
+    [120, 100],
+    [60, 50],
+    [30, 20],
+    [10, 10],
+    [5, 5],
+    [1, 1],
+  ];
+  const refined = [];
+  for (const seed of beam.slice(0, 4)) {
+    let best = seed;
+    for (const [durationStepSeconds, altitudeStepMetres] of refinementScales) {
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        const neighbours = [best];
+        for (const direction of [-1, 1]) {
+          const durationCandidate = evaluate(
+            best.durationMinutes + (direction * durationStepSeconds) / 60,
+            best.controlAltitudesMetresMsl,
+          );
+          if (durationCandidate) neighbours.push(durationCandidate);
+          for (let controlIndex = 0; controlIndex < 4; controlIndex += 1) {
+            const controlAltitudes = [...best.controlAltitudesMetresMsl];
+            controlAltitudes[controlIndex] += direction * altitudeStepMetres;
+            const altitudeCandidate = evaluate(best.durationMinutes, controlAltitudes);
+            if (altitudeCandidate) neighbours.push(altitudeCandidate);
+          }
+        }
+        const nextBest = bestUniqueCandidates(neighbours, 1)[0];
+        if (nextBest.missDistanceMetres >= best.missDistanceMetres - 0.01) break;
+        best = nextBest;
+      }
+    }
+    refined.push(best);
+  }
+  const best = bestUniqueCandidates([...beam, ...refined], 1)[0];
   const directDistanceMetres = distanceMetres(launch, target);
-  const acceptedMissDistanceMetres = Number.isFinite(Number(toleranceMetres))
-    ? Math.max(100, Number(toleranceMetres))
-    : Math.max(1_000, Math.min(3_000, directDistanceMetres * 0.1));
+  const acceptedMissDistanceMetres = ROUTE_SEARCH_LIMITS.acceptedMissDistanceMetres;
   return Object.freeze({
     ...best,
     destination: target,
     directDistanceMetres,
     acceptedMissDistanceMetres,
     reachesDestination: best.missDistanceMetres <= acceptedMissDistanceMetres,
-    boundary: envelope.boundary,
-    candidateCount: envelope.candidates.length,
+    boundary: Object.freeze(convexHull(coarseCandidates.map((candidate) => candidate.landing))),
+    candidateCount: coarseCandidates.length,
+    evaluatedCandidateCount: [...evaluationCache.values()].filter(Boolean).length,
+    ...settings,
   });
 }
 

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -4,15 +4,19 @@ import test from "node:test";
 import {
   WIND_LEVELS_METRES_MSL,
   altitudeForFlightFraction,
+  altitudeForProfileFraction,
   altitudeForStrategyFraction,
   buildFlightPlanGpx,
   circlePolygon,
+  forecastAltitudeProfileTrack,
   forecastLandingEnvelope,
   forecastFlightTrack,
+  moveWithWind,
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
   planWindRouteToDestination,
   vectorAtAltitude,
+  vectorAtPosition,
   windForecastGrid,
 } from "./planner-core.mjs";
 
@@ -43,6 +47,20 @@ test("forecast parser chooses the hour nearest the pilot's departure", () => {
   const field = parseOpenMeteoForecast(source, new Date("2026-08-21T08:52:00Z"));
   assert.equal(field.validAt.toISOString(), "2026-08-21T09:00:00.000Z");
   assert.equal(vectorAtAltitude(field.columns[0], 500).speedKmh, 28);
+});
+
+test("wind vectors interpolate between hourly forecast slices during the flight", () => {
+  const source = payload();
+  source.hourly.wind_direction_500m = [270, 180];
+  const field = parseOpenMeteoForecast(source, new Date("2026-08-21T08:00:00Z"));
+  const vector = vectorAtPosition(
+    field,
+    { latitude: 51.5, longitude: -2.5 },
+    500,
+    30 * 60,
+  );
+  assert.ok(Math.abs(vector.fromDegrees - 225) < 0.1);
+  assert.ok(Math.abs(vector.speedKmh - 25.46) < 0.1);
 });
 
 test("vertical interpolation crosses north without wrapping south", () => {
@@ -80,6 +98,19 @@ test("destination strategy can use two different cruise wind layers and still la
   assert.equal(altitudeForStrategyFraction({ fraction: 1, ...settings }), 100);
 });
 
+test("multi-stage altitude profiles interpolate four controls and return to launch", () => {
+  const settings = {
+    launchElevationMetresMsl: 100,
+    controlAltitudesMetresMsl: [300, 700, 500, 900],
+  };
+  assert.equal(altitudeForProfileFraction({ fraction: 0, ...settings }), 100);
+  assert.equal(altitudeForProfileFraction({ fraction: 0.1, ...settings }), 200);
+  assert.equal(altitudeForProfileFraction({ fraction: 0.2, ...settings }), 300);
+  assert.equal(altitudeForProfileFraction({ fraction: 0.4, ...settings }), 700);
+  assert.equal(altitudeForProfileFraction({ fraction: 0.8, ...settings }), 900);
+  assert.equal(altitudeForProfileFraction({ fraction: 1, ...settings }), 100);
+});
+
 test("forecast track follows wind while maintaining its own altitude profile", () => {
   const field = parseOpenMeteoForecast(payload(), new Date("2026-08-21T08:00:00Z"));
   const track = forecastFlightTrack({
@@ -96,7 +127,36 @@ test("forecast track follows wind while maintaining its own altitude profile", (
   assert.ok(Math.abs(track.at(-1).altitudeMetresMsl - 100) < 1e-9);
 });
 
-test("wind routing chooses a closest altitude strategy and reports impossible targets", () => {
+test("wind routing chooses duration automatically and refines a reachable endpoint within 100 m", () => {
+  const launch = { latitude: 51.5, longitude: -2.5 };
+  const vector = { altitudeMetresMsl: 100, speedKmh: 36, fromDegrees: 270 };
+  const field = {
+    columns: [
+      {
+        position: launch,
+        vectors: [vector, { ...vector, altitudeMetresMsl: 1000 }],
+      },
+    ],
+  };
+  const destination = moveWithWind(launch, vector, 1000);
+  const result = planWindRouteToDestination({
+    field,
+    launch,
+    destination,
+    launchElevationMetresMsl: 100,
+    minimumDurationMinutes: 10,
+    maximumDurationMinutes: 30,
+    altitudeCeilingMetresMsl: 1000,
+  });
+  assert.equal(result.reachesDestination, true);
+  assert.equal(result.acceptedMissDistanceMetres, 100);
+  assert.ok(result.missDistanceMetres < 1);
+  assert.ok(Math.abs(result.durationMinutes - 1000 / 60) < 0.02);
+  assert.equal(result.controlAltitudesMetresMsl.length, 4);
+  assert.equal(result.track.at(-1).elapsedSeconds, 1000);
+});
+
+test("wind routing changes a multi-stage altitude profile and reports impossible targets", () => {
   const launch = { latitude: 51.5, longitude: -2.5 };
   const field = {
     columns: [
@@ -113,28 +173,37 @@ test("wind routing chooses a closest altitude strategy and reports impossible ta
     field,
     launch,
     launchElevationMetresMsl: 100,
-    maximumAltitudeMetresMsl: 1000,
-    durationMinutes: 60,
-    stepSeconds: 300,
+    minimumDurationMinutes: 40,
+    maximumDurationMinutes: 100,
+    altitudeCeilingMetresMsl: 1000,
   };
+  const knownTrack = forecastAltitudeProfileTrack({
+    field,
+    launch,
+    launchElevationMetresMsl: 100,
+    controlAltitudesMetresMsl: [100, 1000, 100, 1000],
+    durationMinutes: 73,
+  });
   const envelope = forecastLandingEnvelope(settings);
-  assert.ok(envelope.candidates.length > 20);
+  assert.ok(envelope.candidates.length > 100);
   assert.ok(envelope.boundary.length >= 3);
 
   const possible = planWindRouteToDestination({
     ...settings,
-    destination: { latitude: 51.64, longitude: -2.36 },
-    toleranceMetres: 8_000,
+    destination: knownTrack.at(-1),
   });
   assert.equal(possible.reachesDestination, true);
+  assert.ok(possible.missDistanceMetres < 100);
   assert.equal(possible.track.at(-1).altitudeMetresMsl, 100);
-  assert.ok(possible.firstCruiseAltitudeMetresMsl <= 1000);
-  assert.ok(possible.secondCruiseAltitudeMetresMsl <= 1000);
+  assert.equal(possible.controlAltitudesMetresMsl.length, 4);
+  assert.equal(
+    possible.peakAltitudeMetresMsl,
+    Math.max(100, ...possible.controlAltitudesMetresMsl),
+  );
 
   const impossible = planWindRouteToDestination({
     ...settings,
     destination: { latitude: 51.5, longitude: -3.0 },
-    toleranceMetres: 1_000,
   });
   assert.equal(impossible.reachesDestination, false);
   assert.ok(impossible.missDistanceMetres > 20_000);

--- a/apps/planner/styles.css
+++ b/apps/planner/styles.css
@@ -104,6 +104,7 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .status.error { color: #ffaaa0; }
 .status.good { color: #9be5bb; }
 .route-strategy { margin: 0.7rem 0 0; padding: 0.7rem 0.8rem; border: 1px solid #655a84; border-radius: 0.65rem; background: #1d1928; color: #d9cdf7; font-size: 0.8rem; line-height: 1.4; font-weight: 750; }
+.search-limits { margin: 0.75rem 0 0; padding: 0.65rem 0.75rem; border-left: 3px solid var(--purple); background: color-mix(in srgb, var(--purple) 9%, transparent); color: var(--muted); }
 .muted { color: var(--muted); }
 .small { font-size: 0.75rem; line-height: 1.45; }
 


### PR DESCRIPTION
## Summary
- remove fixed duration and maximum-altitude inputs from the pilot planner
- search 10–180 minute durations and four independent in-flight altitude controls
- interpolate hourly UKMO wind during the forecast and derive peak altitude as an output
- accept forecast endpoints within 100 m and report unreachable destinations as best effort
- update the landing envelope, route presentation, documentation, and deterministic tests

## Verification
- `node --check apps/planner/planner-core.mjs`
- `node --check apps/planner/app.js`
- `node --test apps/planner/planner-core.test.mjs apps/planner/pages-worker.test.mjs`
- `git diff --check`
- Chrome live UKMO smoke test: optimiser selected 120.7 minutes and a four-stage profile, landing 1 m from the map-selected destination

Closes #41