### PR TITLE
feat: improve planner wind and departure search

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -4,21 +4,23 @@ Static application code for a balloon pilot's forecast flight plan. It keeps
 the short plan-code flow inherited from Tail End Charlie, but it does not
 pretend a balloon follows a road route:
 
-- the pilot selects a launch point, departure time, launch elevation and optional
+- the pilot selects a launch point, flight date, launch elevation and optional
   destination;
 - UKMO UKV wind from Open-Meteo is sampled across a 5×5 grid spanning roughly
   120 km around the launch, at 14 MSL height levels, with hourly interpolation
   during the flight and spatially interpolated display arrows across the visible
   sampling area;
-- the destination optimiser searches 10–180 minute durations and four changing
-  altitude controls up to the highest 2,000 m MSL forecast layer;
-- duration, altitude profile and resulting peak altitude are outputs of the
-  optimiser rather than pilot-supplied route inputs;
+- the destination optimiser searches start times across the selected day,
+  10–180 minute durations and four changing altitude controls up to the highest
+  2,000 m MSL forecast layer;
+- start time, an approximate matching window for the selected profile, duration,
+  altitude profile and resulting peak altitude are optimiser outputs rather than
+  pilot-supplied route inputs;
 - the basemap and planner controls can switch between light and dark themes,
   with an explicit tile-load indicator and retry action;
 - OpenAIP's combined aeronautical chart is visible with a plain-language key;
 - the purple landing envelope is the convex boundary of endpoints produced by
-  the coarse duration and altitude search;
+  the coarse start-time, duration and altitude search;
 - the destination search refines its best candidates to a 100 m acceptance
   distance and clearly reports when none can get that close;
 - the forecast landing area and separately editable destination are shown; and

--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -6,8 +6,10 @@ pretend a balloon follows a road route:
 
 - the pilot selects a launch point, departure time, launch elevation and optional
   destination;
-- UKMO UKV wind from Open-Meteo is sampled on the same 3×3 grid and MSL height
-  levels used by the mobile app, with hourly interpolation during the flight;
+- UKMO UKV wind from Open-Meteo is sampled across a 5×5 grid spanning roughly
+  120 km around the launch, at 14 MSL height levels, with hourly interpolation
+  during the flight and spatially interpolated display arrows across the visible
+  sampling area;
 - the destination optimiser searches 10–180 minute durations and four changing
   altitude controls up to the highest 2,000 m MSL forecast layer;
 - duration, altitude profile and resulting peak altitude are outputs of the

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -119,15 +119,49 @@ function setStatus(element, message, kind = "") {
   element.classList.toggle("good", kind === "good");
 }
 
-function toLocalInputValue(date) {
+function toLocalDateInputValue(date) {
   const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
-  return local.toISOString().slice(0, 16);
+  return local.toISOString().slice(0, 10);
 }
 
-function selectedDeparture() {
-  const value = new Date(elements.departure_time.value);
-  if (Number.isNaN(value.getTime())) throw new Error("Choose a valid departure time.");
-  return value;
+function selectedSearchDay() {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(elements.departure_time.value);
+  if (!match) throw new Error("Choose a valid flight date.");
+  const dayStart = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  if (
+    dayStart.getFullYear() !== Number(match[1]) ||
+    dayStart.getMonth() !== Number(match[2]) - 1 ||
+    dayStart.getDate() !== Number(match[3])
+  ) {
+    throw new Error("Choose a valid flight date.");
+  }
+  return dayStart;
+}
+
+function selectedDepartureSearch() {
+  const dayStart = selectedSearchDay();
+  const nextDay = new Date(
+    dayStart.getFullYear(),
+    dayStart.getMonth(),
+    dayStart.getDate() + 1,
+  );
+  const today = new Date();
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const minimumDepartureOffsetMinutes =
+    dayStart.getTime() === todayStart.getTime()
+      ? Math.max(0, Math.ceil((today.getTime() - dayStart.getTime()) / 60_000))
+      : 0;
+  const maximumDepartureOffsetMinutes =
+    Math.floor((nextDay.getTime() - dayStart.getTime()) / 60_000) - 1;
+  if (minimumDepartureOffsetMinutes > maximumDepartureOffsetMinutes) {
+    throw new Error("There are no remaining start times today. Choose tomorrow instead.");
+  }
+  return {
+    dayStart,
+    minimumDepartureOffsetMinutes,
+    maximumDepartureOffsetMinutes,
+    departureSearchStepMinutes: 120,
+  };
 }
 
 function formatUtc(date) {
@@ -142,6 +176,35 @@ function formatUtc(date) {
   }).format(date) + " UTC";
 }
 
+function formatLocalDateTime(date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZoneName: "short",
+  }).format(date);
+}
+
+function formatLocalTime(date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZoneName: "short",
+  }).format(date);
+}
+
+function formatLocalDay(date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    weekday: "long",
+    day: "2-digit",
+    month: "long",
+  }).format(date);
+}
+
 function updateClock() {
   elements.clock.textContent = new Intl.DateTimeFormat("en-GB", {
     timeZone: "UTC",
@@ -154,11 +217,10 @@ function updateClock() {
 
 function configureDepartureInput() {
   const now = new Date();
-  const rounded = new Date(now.getTime() + 45 * 60_000);
-  rounded.setMinutes(0, 0, 0);
-  elements.departure_time.min = toLocalInputValue(new Date(now.getTime() - 30 * 60_000));
-  elements.departure_time.max = toLocalInputValue(new Date(now.getTime() + 47 * 60 * 60_000));
-  elements.departure_time.value = toLocalInputValue(rounded);
+  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  elements.departure_time.min = toLocalDateInputValue(now);
+  elements.departure_time.max = toLocalDateInputValue(tomorrow);
+  elements.departure_time.value = toLocalDateInputValue(now);
 }
 
 function normalizeStyleUrl(value) {
@@ -472,8 +534,22 @@ function updateWindMarkers() {
   const altitude = selectedWindLevel();
   elements.wind_altitude_label.textContent = `${altitude} m MSL`;
   if (!state.field || !elements.wind_toggle.checked) return;
+  let departureOffsetSeconds = 0;
+  try {
+    departureOffsetSeconds =
+      (state.routePlan?.departureOffsetMinutes ??
+        selectedDepartureSearch().minimumDepartureOffsetMinutes) * 60;
+  } catch {
+    // Keep the map clear until a valid search day is selected.
+    return;
+  }
   for (const position of windDisplayPositions()) {
-    const vector = interpolatedVectorAtPosition(state.field, position, altitude);
+    const vector = interpolatedVectorAtPosition(
+      state.field,
+      position,
+      altitude,
+      departureOffsetSeconds,
+    );
     if (!vector) continue;
     const element = document.createElement("div");
     element.className = "wind-marker";
@@ -541,7 +617,13 @@ function formatMissDistance(distanceMetres) {
 function recomputeTrack({ fit = false } = {}) {
   if (!state.field || !state.launch) return;
   try {
-    const settings = { field: state.field, launch: state.launch, ...validLaunchSettings() };
+    const departureSearch = selectedDepartureSearch();
+    const settings = {
+      field: state.field,
+      launch: state.launch,
+      ...validLaunchSettings(),
+      ...departureSearch,
+    };
     if (state.manualLanding && state.intendedLanding) {
       state.routePlan = planWindRouteToDestination({
         ...settings,
@@ -557,15 +639,22 @@ function recomputeTrack({ fit = false } = {}) {
       const profile = state.routePlan.controlAltitudesMetresMsl
         .map((altitude) => `${Math.round(altitude)} m`)
         .join(" → ");
+      const window = state.routePlan.departureWindow;
+      const windowText = window
+        ? window.startOffsetMinutes === window.endOffsetMinutes
+          ? ` Approximate matching start time with this profile: ${formatLocalTime(window.startAt)}.`
+          : ` Approximate matching start window with this profile: ${formatLocalTime(window.startAt)}–${formatLocalTime(window.endAt)}.`
+        : "";
       elements.route_strategy.hidden = false;
       elements.route_strategy.textContent =
-        `Optimised forecast: ${duration} min · peak ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · ` +
-        `heights at 20/40/60/80%: ${profile}, then land at launch elevation.`;
+        `Optimised forecast: start ${formatLocalDateTime(state.routePlan.departureAt)} · ${duration} min · ` +
+        `peak ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · heights at 20/40/60/80%: ` +
+        `${profile}, then land at launch elevation.${windowText}`;
       setStatus(
         elements.route_status,
         state.routePlan.reachesDestination
-          ? `The optimised forecast endpoint is ${missDistance} from the destination, within the 100 m acceptance distance.`
-          : `The forecast winds do not support this destination inside the search limits. The closest endpoint still misses by ${missDistance}; the shown track is best-effort only.`,
+          ? `The optimised forecast endpoint is ${missDistance} from the destination, within the 100 m acceptance distance at the reported start time.`
+          : `The forecast winds do not support this destination inside the selected day and search limits. The closest endpoint still misses by ${missDistance}; the shown start time and track are best-effort only.`,
         state.routePlan.reachesDestination ? "good" : "error",
       );
       state.forecastLanding = state.track.at(-1);
@@ -583,7 +672,7 @@ function recomputeTrack({ fit = false } = {}) {
       setMarker("intended", null);
       setStatus(
         elements.route_status,
-        "Set a destination to optimise flight duration and four in-flight altitude controls.",
+        "Set a destination to optimise start time, flight duration and four in-flight altitude controls.",
       );
     }
     updateSources();
@@ -594,20 +683,26 @@ function recomputeTrack({ fit = false } = {}) {
     elements.forecast_summary.hidden = !state.track;
     if (state.track) {
       elements.forecast_distance.textContent = `${(forecastDistanceMetres(state.track) / 1000).toFixed(1)} km forecast drift`;
-      elements.forecast_validity.textContent = `${state.routePlan.durationMinutes.toFixed(1)} min · hourly wind from departure`;
+      elements.forecast_validity.textContent =
+        `${formatLocalDateTime(state.routePlan.departureAt)} · ` +
+        `${state.routePlan.durationMinutes.toFixed(1)} min · hourly wind interpolation`;
     }
     setStatus(
       elements.landing_status,
       state.manualLanding
-        ? `Destination retained. ${state.routePlan.evaluatedCandidateCount} duration and height refinements were evaluated.`
-        : `The purple envelope bounds ${state.landingCandidateCount} coarse duration and height forecasts. It is not a safe-landing assessment.`,
+        ? `Destination retained. ${state.routePlan.evaluatedCandidateCount} start-time, duration and height refinements were evaluated.`
+        : `The purple envelope bounds ${state.landingCandidateCount} coarse start-time, duration and height forecasts. It is not a safe-landing assessment.`,
       "good",
     );
     setStatus(
       elements.wind_status,
-      `Hourly UKMO wind forecast starts ${formatUtc(state.field.validAt)} across ` +
+      `Hourly UKMO wind forecast covers ${formatLocalDay(departureSearch.dayStart)} across ` +
         `${state.field.columns.length} source points in a roughly ` +
-        `${Math.round(WIND_GRID_SPAN_METRES / 1000)} km square · model data, not an observation.`,
+        `${Math.round(WIND_GRID_SPAN_METRES / 1000)} km square. Arrows show ` +
+        `${formatLocalTime(state.routePlan?.departureAt ?? new Date(
+          departureSearch.dayStart.getTime() +
+            departureSearch.minimumDepartureOffsetMinutes * 60_000,
+        ))} · model data, not an observation.`,
       "good",
     );
     if (fit) fitForecast();
@@ -630,9 +725,9 @@ function recomputeTrack({ fit = false } = {}) {
 
 async function refreshForecast() {
   if (!state.launch) return;
-  let departure;
+  let departureSearch;
   try {
-    departure = selectedDeparture();
+    departureSearch = selectedDepartureSearch();
     validLaunchSettings();
   } catch (error) {
     setStatus(elements.wind_status, error.message, "error");
@@ -653,7 +748,7 @@ async function refreshForecast() {
     if (!response.ok) throw new Error(`Wind service returned ${response.status}.`);
     const payload = await response.json();
     if (generation !== state.forecastGeneration) return;
-    state.field = parseOpenMeteoForecast(payload, departure);
+    state.field = parseOpenMeteoForecast(payload, departureSearch.dayStart);
     recomputeTrack({ fit: true });
   } catch (error) {
     if (error.name === "AbortError") return;
@@ -720,7 +815,7 @@ async function chooseLanding(point) {
   elements.clear_destination.disabled = false;
   setStatus(
     elements.landing_status,
-    `Destination set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. Optimising duration and altitude profile…`,
+    `Destination set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. Optimising start time, duration and altitude profile…`,
     "good",
   );
   await new Promise((resolve) => {
@@ -773,7 +868,7 @@ async function generatePlanCode() {
     const gpx = buildFlightPlanGpx({
       name,
       track: state.track,
-      departureAt: selectedDeparture(),
+      departureAt: state.routePlan.departureAt,
       launch: state.launch,
       forecastLanding: state.forecastLanding,
       intendedLanding: state.intendedLanding,

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -1,13 +1,14 @@
 import {
+  WIND_GRID_SPAN_METRES,
   WIND_LEVELS_METRES_MSL,
   buildFlightPlanGpx,
   circlePolygon,
   forecastDistanceMetres,
   forecastLandingEnvelope,
+  interpolatedVectorAtPosition,
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
   planWindRouteToDestination,
-  vectorAtAltitude,
 } from "./planner-core.mjs";
 
 // Keep the installed-app hand-off on its already-shipped associated domain.
@@ -15,6 +16,7 @@ import {
 const APP_LINK_ORIGIN = "https://balloon-crumbs.tailendcharlie.app";
 const FORECAST_AREA_RADIUS_METRES = 750;
 const INTENDED_AREA_RADIUS_METRES = 400;
+const WIND_MARKER_SPACING_PIXELS = 150;
 const DEFAULT_CENTER = [-2.5, 54.4];
 const MAP_PALETTES = Object.freeze({
   dark: {
@@ -429,13 +431,49 @@ function clearWindMarkers() {
   state.windMarkers = [];
 }
 
+function windDisplayPositions() {
+  const columns = state.field?.columns ?? [];
+  const canvas = state.map?.getCanvas();
+  if (!canvas || columns.length === 0) return [];
+  const latitudes = columns.map((column) => column.position.latitude);
+  const longitudes = columns.map((column) => column.position.longitude);
+  const minimumLatitude = Math.min(...latitudes);
+  const maximumLatitude = Math.max(...latitudes);
+  const minimumLongitude = Math.min(...longitudes);
+  const maximumLongitude = Math.max(...longitudes);
+  const positions = [];
+  for (
+    let y = WIND_MARKER_SPACING_PIXELS / 2;
+    y < canvas.clientHeight;
+    y += WIND_MARKER_SPACING_PIXELS
+  ) {
+    for (
+      let x = WIND_MARKER_SPACING_PIXELS / 2;
+      x < canvas.clientWidth;
+      x += WIND_MARKER_SPACING_PIXELS
+    ) {
+      const point = state.map.unproject([x, y]);
+      if (
+        point.lat < minimumLatitude ||
+        point.lat > maximumLatitude ||
+        point.lng < minimumLongitude ||
+        point.lng > maximumLongitude
+      ) {
+        continue;
+      }
+      positions.push({ latitude: point.lat, longitude: point.lng });
+    }
+  }
+  return positions;
+}
+
 function updateWindMarkers() {
   clearWindMarkers();
   const altitude = selectedWindLevel();
   elements.wind_altitude_label.textContent = `${altitude} m MSL`;
   if (!state.field || !elements.wind_toggle.checked) return;
-  for (const column of state.field.columns) {
-    const vector = vectorAtAltitude(column, altitude);
+  for (const position of windDisplayPositions()) {
+    const vector = interpolatedVectorAtPosition(state.field, position, altitude);
     if (!vector) continue;
     const element = document.createElement("div");
     element.className = "wind-marker";
@@ -449,7 +487,7 @@ function updateWindMarkers() {
     element.append(arrow, speed);
     state.windMarkers.push(
       new maplibregl.Marker({ element, anchor: "center" })
-        .setLngLat([column.position.longitude, column.position.latitude])
+        .setLngLat([position.longitude, position.latitude])
         .addTo(state.map),
     );
   }
@@ -567,7 +605,9 @@ function recomputeTrack({ fit = false } = {}) {
     );
     setStatus(
       elements.wind_status,
-      `Hourly UKMO wind forecast starts ${formatUtc(state.field.validAt)} · model data, not an observation.`,
+      `Hourly UKMO wind forecast starts ${formatUtc(state.field.validAt)} across ` +
+        `${state.field.columns.length} source points in a roughly ` +
+        `${Math.round(WIND_GRID_SPAN_METRES / 1000)} km square · model data, not an observation.`,
       "good",
     );
     if (fit) fitForecast();
@@ -837,6 +877,8 @@ async function start() {
       addPlannerLayers(state.map);
       applyMapTheme();
       updateSources();
+      state.map.on("moveend", updateWindMarkers);
+      state.map.on("resize", updateWindMarkers);
       state.map.on("click", (event) => {
         if (state.mode === "launch") chooseLaunch(event.lngLat);
         else if (state.mode === "landing") void chooseLanding(event.lngLat);

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -74,7 +74,7 @@
             <span>3</span>
             <div>
               <h2 id="wind-title">Wind layer</h2>
-              <p>UKMO UKV forecast via Open-Meteo.</p>
+              <p>UKMO UKV forecast via Open-Meteo across a wide 5×5 grid.</p>
             </div>
             <label class="switch" title="Show or hide wind arrows">
               <input type="checkbox" id="wind-toggle" checked />
@@ -87,7 +87,7 @@
             <input type="range" id="wind-altitude" min="0" max="13" step="1" value="7" />
           </label>
           <p class="status" id="wind-status" role="status">Set a launch point to load wind.</p>
-          <p class="small muted">Arrows point downwind; labels show km/h. Height levels are metres above mean sea level.</p>
+          <p class="small muted">Arrows are spatially interpolated between the 25 source points across the visible sampling area. They point downwind; labels show km/h. Height levels are metres above mean sea level.</p>
         </section>
 
         <section class="panel-section" aria-labelledby="landing-title">

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -52,12 +52,12 @@
             <span>2</span>
             <div>
               <h2 id="flight-title">Forecast setup</h2>
-              <p>Set only what the optimiser cannot choose: departure and ground elevation.</p>
+              <p>Choose the day and ground elevation; the optimiser searches the start time.</p>
             </div>
           </div>
           <label class="field">
-            <span>Departure (local time)</span>
-            <input type="datetime-local" id="departure-time" />
+            <span>Flight date to search</span>
+            <input type="date" id="departure-time" />
           </label>
           <label class="field">
             <span>Launch elevation</span>
@@ -66,7 +66,7 @@
               <i>m MSL</i>
             </span>
           </label>
-          <p class="search-limits small">The destination search chooses a 10–180 minute duration and four altitude controls between launch elevation and 2,000 m MSL. Its resulting peak altitude is an output, not an input.</p>
+          <p class="search-limits small">The destination search tries the remaining start times on the selected day, a 10–180 minute duration and four altitude controls between launch elevation and 2,000 m MSL. Start time and peak altitude are outputs, not inputs.</p>
         </section>
 
         <section class="panel-section" aria-labelledby="wind-title">
@@ -95,7 +95,7 @@
             <span>4</span>
             <div>
               <h2 id="landing-title">Destination and landing envelope</h2>
-              <p>Optimise duration and a changing altitude profile toward a chosen destination.</p>
+              <p>Optimise start time, duration and a changing altitude profile toward a destination.</p>
             </div>
           </div>
           <div class="button-row">
@@ -105,7 +105,7 @@
           <p class="status" id="landing-status">Waiting for a wind forecast.</p>
           <p class="status" id="route-status" role="status">Set a launch point to calculate the landing envelope.</p>
           <p class="route-strategy" id="route-strategy" hidden></p>
-          <p class="small muted">The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
+          <p class="small muted">The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match; its reported time window only applies to that forecast profile. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
         </section>
 
         <section class="panel-section" aria-labelledby="airspace-title">

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -222,8 +222,8 @@ function vectorInColumns(columns, position, altitudeMetresMsl) {
   return vectorAtAltitude(nearest, altitudeMetresMsl);
 }
 
-export function interpolatedVectorAtPosition(field, position, altitudeMetresMsl) {
-  const candidates = (field?.columns ?? [])
+function interpolatedVectorInColumns(columns, position, altitudeMetresMsl) {
+  const candidates = columns
     .map((column) => ({
       distanceMetres: distanceMetres(column.position, position),
       vector: vectorAtAltitude(column, altitudeMetresMsl),
@@ -247,6 +247,51 @@ export function interpolatedVectorAtPosition(field, position, altitudeMetresMsl)
     altitudeMetresMsl,
     eastMetresPerSecond / totalWeight,
     northMetresPerSecond / totalWeight,
+  );
+}
+
+export function interpolatedVectorAtPosition(
+  field,
+  position,
+  altitudeMetresMsl,
+  elapsedSeconds = 0,
+) {
+  const slices = field?.timeSlices ?? [];
+  if (slices.length === 0) {
+    return interpolatedVectorInColumns(field?.columns ?? [], position, altitudeMetresMsl);
+  }
+  const requestedAt = field.requestedAt instanceof Date ? field.requestedAt : field.validAt;
+  const targetTime = requestedAt.getTime() + finiteNumber(elapsedSeconds, "elapsed seconds") * 1000;
+  let upperIndex = slices.findIndex((slice) => slice.validAt.getTime() >= targetTime);
+  if (upperIndex < 0) upperIndex = slices.length - 1;
+  const lowerIndex = Math.max(0, upperIndex - 1);
+  const lower = slices[lowerIndex];
+  const upper = slices[upperIndex];
+  const lowerVector = interpolatedVectorInColumns(
+    lower.columns,
+    position,
+    altitudeMetresMsl,
+  );
+  const upperVector = interpolatedVectorInColumns(
+    upper.columns,
+    position,
+    altitudeMetresMsl,
+  );
+  if (!lowerVector) return upperVector;
+  if (!upperVector || lowerIndex === upperIndex) return lowerVector;
+  const interval = upper.validAt.getTime() - lower.validAt.getTime();
+  const fraction =
+    interval <= 0
+      ? 0
+      : Math.max(0, Math.min(1, (targetTime - lower.validAt.getTime()) / interval));
+  const lowerComponents = components(lowerVector);
+  const upperComponents = components(upperVector);
+  return vectorFromComponents(
+    altitudeMetresMsl,
+    lowerComponents.eastMetresPerSecond +
+      (upperComponents.eastMetresPerSecond - lowerComponents.eastMetresPerSecond) * fraction,
+    lowerComponents.northMetresPerSecond +
+      (upperComponents.northMetresPerSecond - lowerComponents.northMetresPerSecond) * fraction,
   );
 }
 
@@ -363,12 +408,21 @@ function forecastTrackWithAltitudeProfile({
   launch,
   durationMinutes,
   altitudeAtFraction,
+  departureOffsetSeconds = 0,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   let position = validPoint(launch, "launch point");
   const durationSeconds = Math.round(finiteNumber(durationMinutes, "flight duration") * 60);
+  const forecastOffsetSeconds = Math.round(
+    finiteNumber(departureOffsetSeconds, "departure offset"),
+  );
   const step = Math.round(finiteNumber(stepSeconds, "forecast step"));
-  if (durationSeconds < 600 || durationSeconds > 6 * 60 * 60 || step < 10) {
+  if (
+    durationSeconds < 600 ||
+    durationSeconds > 6 * 60 * 60 ||
+    forecastOffsetSeconds < 0 ||
+    step < 10
+  ) {
     throw new RangeError("Flight duration or forecast step is outside the supported range.");
   }
   const points = [];
@@ -376,7 +430,12 @@ function forecastTrackWithAltitudeProfile({
   while (true) {
     const fraction = elapsedSeconds / durationSeconds;
     const altitudeMetresMsl = altitudeAtFraction(fraction);
-    const vector = vectorAtPosition(field, position, altitudeMetresMsl, elapsedSeconds);
+    const vector = vectorAtPosition(
+      field,
+      position,
+      altitudeMetresMsl,
+      forecastOffsetSeconds + elapsedSeconds,
+    );
     if (!vector) throw new Error("The wind field does not cover the forecast flight.");
     points.push({ ...position, altitudeMetresMsl, elapsedSeconds, wind: vector });
     if (elapsedSeconds >= durationSeconds) break;
@@ -393,12 +452,14 @@ export function forecastFlightTrack({
   launchElevationMetresMsl,
   maximumAltitudeMetresMsl,
   durationMinutes,
+  departureOffsetSeconds = 0,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   return forecastTrackWithAltitudeProfile({
     field,
     launch,
     durationMinutes,
+    departureOffsetSeconds,
     stepSeconds,
     altitudeAtFraction: (fraction) =>
       altitudeForFlightFraction({
@@ -416,12 +477,14 @@ export function forecastAltitudeStrategyTrack({
   firstCruiseAltitudeMetresMsl,
   secondCruiseAltitudeMetresMsl,
   durationMinutes,
+  departureOffsetSeconds = 0,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   return forecastTrackWithAltitudeProfile({
     field,
     launch,
     durationMinutes,
+    departureOffsetSeconds,
     stepSeconds,
     altitudeAtFraction: (fraction) =>
       altitudeForStrategyFraction({
@@ -439,12 +502,14 @@ export function forecastAltitudeProfileTrack({
   launchElevationMetresMsl,
   controlAltitudesMetresMsl,
   durationMinutes,
+  departureOffsetSeconds = 0,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   return forecastTrackWithAltitudeProfile({
     field,
     launch,
     durationMinutes,
+    departureOffsetSeconds,
     stepSeconds,
     altitudeAtFraction: (fraction) =>
       altitudeForProfileFraction({
@@ -475,6 +540,27 @@ function routeDurations(minimumDurationMinutes, maximumDurationMinutes, stepMinu
   for (let duration = minimum; duration <= maximum; duration += step) durations.push(duration);
   if (durations.at(-1) !== maximum) durations.push(maximum);
   return durations;
+}
+
+function routeDepartureOffsets(
+  minimumDepartureOffsetMinutes,
+  maximumDepartureOffsetMinutes,
+  stepMinutes = 120,
+) {
+  const minimum = Math.round(
+    finiteNumber(minimumDepartureOffsetMinutes, "minimum departure offset"),
+  );
+  const maximum = Math.round(
+    finiteNumber(maximumDepartureOffsetMinutes, "maximum departure offset"),
+  );
+  const step = Math.round(finiteNumber(stepMinutes, "departure search step"));
+  if (minimum < 0 || maximum > 25 * 60 - 1 || minimum > maximum || step <= 0) {
+    throw new RangeError("Departure search is outside the selected day.");
+  }
+  const offsets = [];
+  for (let offset = minimum; offset <= maximum; offset += step) offsets.push(offset);
+  if (offsets.at(-1) !== maximum) offsets.push(maximum);
+  return offsets;
 }
 
 function profileIsFeasible({
@@ -540,6 +626,7 @@ function coarseLandingCandidates({
   maximumDurationMinutes,
   altitudeCeilingMetresMsl,
   maximumVerticalRateMetresPerSecond,
+  departureOffsetMinutes = 0,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   const target = destination ? validPoint(destination, "destination") : null;
@@ -575,13 +662,77 @@ function coarseLandingCandidates({
           launchElevationMetresMsl,
           controlAltitudesMetresMsl,
           durationMinutes,
+          departureOffsetSeconds: departureOffsetMinutes * 60,
           stepSeconds,
         });
         const landing = track.at(-1);
         candidates.push({
+          departureOffsetMinutes,
           durationMinutes,
           controlAltitudesMetresMsl,
           peakAltitudeMetresMsl: Math.max(launchElevationMetresMsl, ...controlAltitudesMetresMsl),
+          landing,
+          ...(target ? { missDistanceMetres: distanceMetres(landing, target) } : {}),
+        });
+      }
+    }
+  }
+  return candidates;
+}
+
+function coarseFlexibleStartCandidates({
+  field,
+  launch,
+  launchElevationMetresMsl,
+  destination,
+  minimumDurationMinutes,
+  maximumDurationMinutes,
+  altitudeCeilingMetresMsl,
+  maximumVerticalRateMetresPerSecond,
+  minimumDepartureOffsetMinutes,
+  maximumDepartureOffsetMinutes,
+  departureSearchStepMinutes,
+  stepSeconds = DEFAULT_STEP_SECONDS,
+}) {
+  const target = destination ? validPoint(destination, "destination") : null;
+  const altitudes = strategyAltitudes(launchElevationMetresMsl, altitudeCeilingMetresMsl);
+  const durations = routeDurations(minimumDurationMinutes, maximumDurationMinutes);
+  const departureOffsets = routeDepartureOffsets(
+    minimumDepartureOffsetMinutes,
+    maximumDepartureOffsetMinutes,
+    departureSearchStepMinutes,
+  );
+  const candidates = [];
+  for (const departureOffsetMinutes of departureOffsets) {
+    for (const durationMinutes of durations) {
+      for (const altitude of altitudes) {
+        const controlAltitudesMetresMsl = [altitude, altitude, altitude, altitude];
+        if (
+          !profileIsFeasible({
+            controlAltitudesMetresMsl,
+            launchElevationMetresMsl,
+            altitudeCeilingMetresMsl,
+            durationMinutes,
+            maximumVerticalRateMetresPerSecond,
+          })
+        ) {
+          continue;
+        }
+        const track = forecastAltitudeProfileTrack({
+          field,
+          launch,
+          launchElevationMetresMsl,
+          controlAltitudesMetresMsl,
+          durationMinutes,
+          departureOffsetSeconds: departureOffsetMinutes * 60,
+          stepSeconds,
+        });
+        const landing = track.at(-1);
+        candidates.push({
+          departureOffsetMinutes,
+          durationMinutes,
+          controlAltitudesMetresMsl,
+          peakAltitudeMetresMsl: Math.max(launchElevationMetresMsl, altitude),
           landing,
           ...(target ? { missDistanceMetres: distanceMetres(landing, target) } : {}),
         });
@@ -599,7 +750,16 @@ function routeSearchSettings(options) {
   const altitudeCeilingMetresMsl =
     options.altitudeCeilingMetresMsl ?? ROUTE_SEARCH_LIMITS.altitudeCeilingMetresMsl;
   const maximumVerticalRateMetresPerSecond = options.maximumVerticalRateMetresPerSecond ?? 5;
+  const minimumDepartureOffsetMinutes = options.minimumDepartureOffsetMinutes ?? 0;
+  const maximumDepartureOffsetMinutes =
+    options.maximumDepartureOffsetMinutes ?? minimumDepartureOffsetMinutes;
+  const departureSearchStepMinutes = options.departureSearchStepMinutes ?? 120;
   routeDurations(minimumDurationMinutes, maximumDurationMinutes);
+  routeDepartureOffsets(
+    minimumDepartureOffsetMinutes,
+    maximumDepartureOffsetMinutes,
+    departureSearchStepMinutes,
+  );
   if (altitudeCeilingMetresMsl < options.launchElevationMetresMsl) {
     throw new RangeError("Altitude ceiling must not be below launch.");
   }
@@ -608,12 +768,22 @@ function routeSearchSettings(options) {
     maximumDurationMinutes,
     altitudeCeilingMetresMsl,
     maximumVerticalRateMetresPerSecond,
+    minimumDepartureOffsetMinutes,
+    maximumDepartureOffsetMinutes,
+    departureSearchStepMinutes,
   };
 }
 
 export function forecastLandingEnvelope(options) {
   const settings = routeSearchSettings(options);
-  const candidates = coarseLandingCandidates({ ...options, ...settings });
+  const candidates =
+    settings.maximumDepartureOffsetMinutes > settings.minimumDepartureOffsetMinutes
+      ? coarseFlexibleStartCandidates({ ...options, ...settings })
+      : coarseLandingCandidates({
+          ...options,
+          ...settings,
+          departureOffsetMinutes: settings.minimumDepartureOffsetMinutes,
+        });
   return Object.freeze({
     candidates: Object.freeze(candidates),
     boundary: Object.freeze(convexHull(candidates.map((candidate) => candidate.landing))),
@@ -621,8 +791,12 @@ export function forecastLandingEnvelope(options) {
   });
 }
 
-function routeCandidateKey(durationMinutes, controlAltitudesMetresMsl) {
-  return `${Math.round(durationMinutes * 60)}:${controlAltitudesMetresMsl
+function routeCandidateKey(
+  departureOffsetMinutes,
+  durationMinutes,
+  controlAltitudesMetresMsl,
+) {
+  return `${Math.round(departureOffsetMinutes)}:${Math.round(durationMinutes * 60)}:${controlAltitudesMetresMsl
     .map((altitude) => Math.round(altitude))
     .join(",")}`;
 }
@@ -630,7 +804,11 @@ function routeCandidateKey(durationMinutes, controlAltitudesMetresMsl) {
 function bestUniqueCandidates(candidates, limit) {
   const unique = new Map();
   for (const candidate of candidates) {
-    const key = routeCandidateKey(candidate.durationMinutes, candidate.controlAltitudesMetresMsl);
+    const key = routeCandidateKey(
+      candidate.departureOffsetMinutes,
+      candidate.durationMinutes,
+      candidate.controlAltitudesMetresMsl,
+    );
     const existing = unique.get(key);
     if (!existing || candidate.missDistanceMetres < existing.missDistanceMetres) {
       unique.set(key, candidate);
@@ -651,12 +829,21 @@ export function planWindRouteToDestination(options) {
   } = options;
   const target = validPoint(destination, "destination");
   const settings = routeSearchSettings(options);
-  const coarseCandidates = coarseLandingCandidates({
-    ...options,
-    ...settings,
-    destination: target,
-    stepSeconds,
-  });
+  const coarseCandidates =
+    settings.maximumDepartureOffsetMinutes > settings.minimumDepartureOffsetMinutes
+      ? coarseFlexibleStartCandidates({
+          ...options,
+          ...settings,
+          destination: target,
+          stepSeconds,
+        })
+      : coarseLandingCandidates({
+          ...options,
+          ...settings,
+          destination: target,
+          departureOffsetMinutes: settings.minimumDepartureOffsetMinutes,
+          stepSeconds,
+        });
   if (coarseCandidates.length === 0) {
     throw new Error("No feasible altitude profiles were available inside the route-search limits.");
   }
@@ -665,7 +852,15 @@ export function planWindRouteToDestination(options) {
     settings.altitudeCeilingMetresMsl,
   );
   const evaluationCache = new Map();
-  const evaluate = (durationMinutes, controlAltitudesMetresMsl) => {
+  const evaluate = (
+    departureOffsetMinutes,
+    durationMinutes,
+    controlAltitudesMetresMsl,
+  ) => {
+    const boundedDepartureOffsetMinutes = Math.max(
+      settings.minimumDepartureOffsetMinutes,
+      Math.min(settings.maximumDepartureOffsetMinutes, Math.round(departureOffsetMinutes)),
+    );
     const boundedDurationMinutes = Math.max(
       settings.minimumDurationMinutes,
       Math.min(settings.maximumDurationMinutes, Math.round(durationMinutes * 60) / 60),
@@ -676,7 +871,11 @@ export function planWindRouteToDestination(options) {
         Math.min(settings.altitudeCeilingMetresMsl, Math.round(altitude)),
       ),
     );
-    const key = routeCandidateKey(boundedDurationMinutes, boundedAltitudes);
+    const key = routeCandidateKey(
+      boundedDepartureOffsetMinutes,
+      boundedDurationMinutes,
+      boundedAltitudes,
+    );
     if (evaluationCache.has(key)) return evaluationCache.get(key);
     if (
       !profileIsFeasible({
@@ -696,10 +895,12 @@ export function planWindRouteToDestination(options) {
       launchElevationMetresMsl,
       controlAltitudesMetresMsl: boundedAltitudes,
       durationMinutes: boundedDurationMinutes,
+      departureOffsetSeconds: boundedDepartureOffsetMinutes * 60,
       stepSeconds,
     });
     const landing = track.at(-1);
     const candidate = {
+      departureOffsetMinutes: boundedDepartureOffsetMinutes,
       durationMinutes: boundedDurationMinutes,
       controlAltitudesMetresMsl: boundedAltitudes,
       peakAltitudeMetresMsl: Math.max(launchElevationMetresMsl, ...boundedAltitudes),
@@ -713,7 +914,11 @@ export function planWindRouteToDestination(options) {
 
   let beam = bestUniqueCandidates(coarseCandidates, 10)
     .map((candidate) =>
-      evaluate(candidate.durationMinutes, candidate.controlAltitudesMetresMsl),
+      evaluate(
+        candidate.departureOffsetMinutes,
+        candidate.durationMinutes,
+        candidate.controlAltitudesMetresMsl,
+      ),
     )
     .filter(Boolean);
   for (let pass = 0; pass < 2; pass += 1) {
@@ -723,7 +928,11 @@ export function planWindRouteToDestination(options) {
         for (const altitude of altitudeLevels) {
           const controlAltitudes = [...seed.controlAltitudesMetresMsl];
           controlAltitudes[controlIndex] = altitude;
-          const candidate = evaluate(seed.durationMinutes, controlAltitudes);
+          const candidate = evaluate(
+            seed.departureOffsetMinutes,
+            seed.durationMinutes,
+            controlAltitudes,
+          );
           if (candidate) expanded.push(candidate);
         }
       }
@@ -732,22 +941,30 @@ export function planWindRouteToDestination(options) {
   }
 
   const refinementScales = [
-    [300, 200],
-    [120, 100],
-    [60, 50],
-    [30, 20],
-    [10, 10],
-    [5, 5],
-    [1, 1],
+    [60, 300, 200],
+    [30, 120, 100],
+    [10, 60, 50],
+    [5, 30, 20],
+    [1, 10, 10],
+    [1, 5, 5],
+    [1, 1, 1],
   ];
   const refined = [];
   for (const seed of beam.slice(0, 4)) {
     let best = seed;
-    for (const [durationStepSeconds, altitudeStepMetres] of refinementScales) {
+    for (const [departureStepMinutes, durationStepSeconds, altitudeStepMetres] of
+      refinementScales) {
       for (let attempt = 0; attempt < 6; attempt += 1) {
         const neighbours = [best];
         for (const direction of [-1, 1]) {
+          const departureCandidate = evaluate(
+            best.departureOffsetMinutes + direction * departureStepMinutes,
+            best.durationMinutes,
+            best.controlAltitudesMetresMsl,
+          );
+          if (departureCandidate) neighbours.push(departureCandidate);
           const durationCandidate = evaluate(
+            best.departureOffsetMinutes,
             best.durationMinutes + (direction * durationStepSeconds) / 60,
             best.controlAltitudesMetresMsl,
           );
@@ -755,7 +972,11 @@ export function planWindRouteToDestination(options) {
           for (let controlIndex = 0; controlIndex < 4; controlIndex += 1) {
             const controlAltitudes = [...best.controlAltitudesMetresMsl];
             controlAltitudes[controlIndex] += direction * altitudeStepMetres;
-            const altitudeCandidate = evaluate(best.durationMinutes, controlAltitudes);
+            const altitudeCandidate = evaluate(
+              best.departureOffsetMinutes,
+              best.durationMinutes,
+              controlAltitudes,
+            );
             if (altitudeCandidate) neighbours.push(altitudeCandidate);
           }
         }
@@ -769,8 +990,49 @@ export function planWindRouteToDestination(options) {
   const best = bestUniqueCandidates([...beam, ...refined], 1)[0];
   const directDistanceMetres = distanceMetres(launch, target);
   const acceptedMissDistanceMetres = ROUTE_SEARCH_LIMITS.acceptedMissDistanceMetres;
+  const searchDayStart =
+    field.requestedAt instanceof Date
+      ? field.requestedAt
+      : field.validAt instanceof Date
+        ? field.validAt
+        : new Date(0);
+  const departureAt = new Date(
+    searchDayStart.getTime() + best.departureOffsetMinutes * 60_000,
+  );
+  let departureWindow = null;
+  if (best.missDistanceMetres <= acceptedMissDistanceMetres) {
+    const matchesAt = (departureOffsetMinutes) =>
+      evaluate(
+        departureOffsetMinutes,
+        best.durationMinutes,
+        best.controlAltitudesMetresMsl,
+      ).missDistanceMetres <= acceptedMissDistanceMetres;
+    let startOffsetMinutes = best.departureOffsetMinutes;
+    while (
+      startOffsetMinutes > settings.minimumDepartureOffsetMinutes &&
+      matchesAt(startOffsetMinutes - 1)
+    ) {
+      startOffsetMinutes -= 1;
+    }
+
+    let endOffsetMinutes = best.departureOffsetMinutes;
+    while (
+      endOffsetMinutes < settings.maximumDepartureOffsetMinutes &&
+      matchesAt(endOffsetMinutes + 1)
+    ) {
+      endOffsetMinutes += 1;
+    }
+    departureWindow = Object.freeze({
+      startOffsetMinutes,
+      endOffsetMinutes,
+      startAt: new Date(searchDayStart.getTime() + startOffsetMinutes * 60_000),
+      endAt: new Date(searchDayStart.getTime() + endOffsetMinutes * 60_000),
+    });
+  }
   return Object.freeze({
     ...best,
+    departureAt,
+    departureWindow,
     destination: target,
     directDistanceMetres,
     acceptedMissDistanceMetres,

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -4,6 +4,8 @@ export const WIND_LEVELS_METRES_MSL = Object.freeze([
 
 const EARTH_RADIUS_METRES = 6_371_000;
 const DEFAULT_STEP_SECONDS = 60;
+export const WIND_GRID_SIDE_POINTS = 5;
+export const WIND_GRID_SPAN_METRES = 120_000;
 export const ROUTE_SEARCH_LIMITS = Object.freeze({
   minimumDurationMinutes: 10,
   maximumDurationMinutes: 180,
@@ -29,14 +31,30 @@ function validPoint(point, label = "point") {
 
 export function windForecastGrid(center) {
   const origin = validPoint(center, "forecast centre");
-  return Object.freeze([
-    ...[-0.04, 0, 0.04].flatMap((latitudeOffset) =>
-      [-0.06, 0, 0.06].map((longitudeOffset) => ({
-        latitude: Math.max(-90, Math.min(90, origin.latitude + latitudeOffset)),
-        longitude: Math.max(-180, Math.min(180, origin.longitude + longitudeOffset)),
-      })),
-    ),
-  ]);
+  const halfSpanMetres = WIND_GRID_SPAN_METRES / 2;
+  const stepMetres = WIND_GRID_SPAN_METRES / (WIND_GRID_SIDE_POINTS - 1);
+  const longitudeScale = Math.max(0.01, Math.cos((origin.latitude * Math.PI) / 180));
+  const points = [];
+  for (let northIndex = 0; northIndex < WIND_GRID_SIDE_POINTS; northIndex += 1) {
+    const northMetres = -halfSpanMetres + northIndex * stepMetres;
+    const latitude = Math.max(
+      -90,
+      Math.min(90, origin.latitude + (northMetres / EARTH_RADIUS_METRES) * (180 / Math.PI)),
+    );
+    for (let eastIndex = 0; eastIndex < WIND_GRID_SIDE_POINTS; eastIndex += 1) {
+      const eastMetres = -halfSpanMetres + eastIndex * stepMetres;
+      const longitude = Math.max(
+        -180,
+        Math.min(
+          180,
+          origin.longitude +
+            (eastMetres / (EARTH_RADIUS_METRES * longitudeScale)) * (180 / Math.PI),
+        ),
+      );
+      points.push({ latitude, longitude });
+    }
+  }
+  return Object.freeze(points);
 }
 
 export function openMeteoRequestUrl({ endpoint, center }) {
@@ -202,6 +220,34 @@ function vectorInColumns(columns, position, altitudeMetresMsl) {
     nearestDistance = candidateDistance;
   }
   return vectorAtAltitude(nearest, altitudeMetresMsl);
+}
+
+export function interpolatedVectorAtPosition(field, position, altitudeMetresMsl) {
+  const candidates = (field?.columns ?? [])
+    .map((column) => ({
+      distanceMetres: distanceMetres(column.position, position),
+      vector: vectorAtAltitude(column, altitudeMetresMsl),
+    }))
+    .filter((candidate) => candidate.vector)
+    .sort((first, second) => first.distanceMetres - second.distanceMetres)
+    .slice(0, 4);
+  if (candidates.length === 0) return null;
+  if (candidates[0].distanceMetres < 1) return candidates[0].vector;
+  let totalWeight = 0;
+  let eastMetresPerSecond = 0;
+  let northMetresPerSecond = 0;
+  for (const candidate of candidates) {
+    const weight = 1 / candidate.distanceMetres ** 2;
+    const candidateComponents = components(candidate.vector);
+    totalWeight += weight;
+    eastMetresPerSecond += candidateComponents.eastMetresPerSecond * weight;
+    northMetresPerSecond += candidateComponents.northMetresPerSecond * weight;
+  }
+  return vectorFromComponents(
+    altitudeMetresMsl,
+    eastMetresPerSecond / totalWeight,
+    northMetresPerSecond / totalWeight,
+  );
 }
 
 export function vectorAtPosition(field, position, altitudeMetresMsl, elapsedSeconds = 0) {

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  WIND_GRID_SIDE_POINTS,
+  WIND_GRID_SPAN_METRES,
   WIND_LEVELS_METRES_MSL,
   altitudeForFlightFraction,
   altitudeForProfileFraction,
@@ -11,6 +13,7 @@ import {
   forecastAltitudeProfileTrack,
   forecastLandingEnvelope,
   forecastFlightTrack,
+  interpolatedVectorAtPosition,
   moveWithWind,
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
@@ -29,14 +32,28 @@ function payload({ direction = 270, speed = 36 } = {}) {
   return { latitude: 51.5, longitude: -2.5, hourly };
 }
 
-test("wind request mirrors the app's bounded UKMO grid and height levels", () => {
+test("wind request covers a bounded wide-area UKMO grid and height levels", () => {
   const centre = { latitude: 51.5, longitude: -2.5 };
-  assert.equal(windForecastGrid(centre).length, 9);
+  const grid = windForecastGrid(centre);
+  assert.equal(grid.length, WIND_GRID_SIDE_POINTS ** 2);
+  assert.equal(WIND_GRID_SPAN_METRES, 120_000);
+  assert.ok(grid.some((point) => point.latitude === centre.latitude));
+  assert.ok(grid.some((point) => point.longitude === centre.longitude));
+  assert.ok(
+    Math.max(...grid.map((point) => point.latitude)) -
+      Math.min(...grid.map((point) => point.latitude)) >
+      1,
+  );
+  assert.ok(
+    Math.max(...grid.map((point) => point.longitude)) -
+      Math.min(...grid.map((point) => point.longitude)) >
+      1.5,
+  );
   const url = openMeteoRequestUrl({ endpoint: "/weather/v1/forecast", center: centre });
   assert.equal(url.pathname, "/weather/v1/forecast");
   assert.equal(url.searchParams.get("models"), "ukmo_seamless");
   assert.equal(url.searchParams.get("forecast_days"), "3");
-  assert.equal(url.searchParams.get("latitude").split(",").length, 9);
+  assert.equal(url.searchParams.get("latitude").split(",").length, 25);
   assert.match(url.searchParams.get("hourly"), /wind_speed_500m/);
   assert.match(url.searchParams.get("hourly"), /wind_direction_2000m/);
 });
@@ -75,6 +92,27 @@ test("vertical interpolation crosses north without wrapping south", () => {
   );
   assert.ok(vector.fromDegrees < 1 || vector.fromDegrees > 359);
   assert.ok(Math.abs(vector.speedKmh - 35.45) < 0.1);
+});
+
+test("wind display interpolates direction and speed between nearby source points", () => {
+  const field = {
+    columns: [
+      [-0.1, -0.1, 270],
+      [0.1, -0.1, 180],
+      [-0.1, 0.1, 270],
+      [0.1, 0.1, 180],
+    ].map(([latitude, longitude, fromDegrees]) => ({
+      position: { latitude, longitude },
+      vectors: [{ altitudeMetresMsl: 500, speedKmh: 36, fromDegrees }],
+    })),
+  };
+  const vector = interpolatedVectorAtPosition(
+    field,
+    { latitude: 0, longitude: 0 },
+    500,
+  );
+  assert.ok(Math.abs(vector.fromDegrees - 225) < 0.1);
+  assert.ok(Math.abs(vector.speedKmh - 25.46) < 0.1);
 });
 
 test("flight profile climbs, cruises and returns to launch elevation", () => {

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -80,6 +80,20 @@ test("wind vectors interpolate between hourly forecast slices during the flight"
   assert.ok(Math.abs(vector.speedKmh - 25.46) < 0.1);
 });
 
+test("spatially interpolated display vectors follow the chosen start time", () => {
+  const source = payload();
+  source.hourly.wind_direction_500m = [270, 180];
+  const field = parseOpenMeteoForecast(source, new Date("2026-08-21T08:00:00Z"));
+  const vector = interpolatedVectorAtPosition(
+    field,
+    { latitude: 51.5, longitude: -2.5 },
+    500,
+    30 * 60,
+  );
+  assert.ok(Math.abs(vector.fromDegrees - 225) < 0.1);
+  assert.ok(Math.abs(vector.speedKmh - 25.46) < 0.1);
+});
+
 test("vertical interpolation crosses north without wrapping south", () => {
   const vector = vectorAtAltitude(
     {
@@ -165,6 +179,24 @@ test("forecast track follows wind while maintaining its own altitude profile", (
   assert.ok(Math.abs(track.at(-1).altitudeMetresMsl - 100) < 1e-9);
 });
 
+test("forecast track can start from a later wind slice on the selected day", () => {
+  const source = payload();
+  for (const altitude of WIND_LEVELS_METRES_MSL) {
+    source.hourly[`wind_direction_${altitude}m`] = [270, 180];
+  }
+  const field = parseOpenMeteoForecast(source, new Date("2026-08-21T08:00:00Z"));
+  const track = forecastFlightTrack({
+    field,
+    launch: { latitude: 51.5, longitude: -2.5 },
+    launchElevationMetresMsl: 100,
+    maximumAltitudeMetresMsl: 100,
+    durationMinutes: 10,
+    departureOffsetSeconds: 60 * 60,
+  });
+  assert.ok(track.at(-1).latitude > track[0].latitude);
+  assert.ok(Math.abs(track.at(-1).longitude - track[0].longitude) < 0.001);
+});
+
 test("wind routing chooses duration automatically and refines a reachable endpoint within 100 m", () => {
   const launch = { latitude: 51.5, longitude: -2.5 };
   const vector = { altitudeMetresMsl: 100, speedKmh: 36, fromDegrees: 270 };
@@ -245,6 +277,48 @@ test("wind routing changes a multi-stage altitude profile and reports impossible
   });
   assert.equal(impossible.reachesDestination, false);
   assert.ok(impossible.missDistanceMetres > 20_000);
+});
+
+test("wind routing chooses a start time and reports its matching window", () => {
+  const launch = { latitude: 51.5, longitude: -2.5 };
+  const source = payload();
+  source.hourly.time = [
+    "2026-08-21T08:00",
+    "2026-08-21T09:00",
+    "2026-08-21T10:00",
+  ];
+  for (const altitude of WIND_LEVELS_METRES_MSL) {
+    source.hourly[`wind_speed_${altitude}m`] = [36, 36, 36];
+    source.hourly[`wind_direction_${altitude}m`] = [270, 180, 90];
+  }
+  const field = parseOpenMeteoForecast(source, new Date("2026-08-21T08:00:00Z"));
+  const expectedTrack = forecastAltitudeProfileTrack({
+    field,
+    launch,
+    launchElevationMetresMsl: 100,
+    controlAltitudesMetresMsl: [100, 100, 100, 100],
+    durationMinutes: 10,
+    departureOffsetSeconds: 60 * 60,
+  });
+  const result = planWindRouteToDestination({
+    field,
+    launch,
+    destination: expectedTrack.at(-1),
+    launchElevationMetresMsl: 100,
+    minimumDurationMinutes: 10,
+    maximumDurationMinutes: 10,
+    altitudeCeilingMetresMsl: 100,
+    minimumDepartureOffsetMinutes: 0,
+    maximumDepartureOffsetMinutes: 120,
+    departureSearchStepMinutes: 60,
+  });
+  assert.equal(result.reachesDestination, true);
+  assert.equal(result.departureOffsetMinutes, 60);
+  assert.equal(result.departureAt.toISOString(), "2026-08-21T09:00:00.000Z");
+  assert.ok(result.missDistanceMetres < 1);
+  assert.ok(result.departureWindow);
+  assert.ok(result.departureWindow.startAt <= result.departureAt);
+  assert.ok(result.departureWindow.endAt >= result.departureAt);
 });
 
 test("generated GPX names the forecast and intended landing without claiming a route", () => {


### PR DESCRIPTION
## Summary
- expand UKMO sampling to a bounded 5×5 grid spanning roughly 120 km
- render a viewport-aware, spatially and temporally interpolated wind field
- replace the fixed departure input with a selected-day search
- optimise start time alongside duration and four altitude controls
- report the chosen local start and, for 100 m matches, the contiguous approximate start window for that profile
- use the optimised departure for displayed wind arrows and generated GPX timestamps
- preserve explicit best-effort and aviation-safety limitations

## Verification
- `node --check apps/planner/planner-core.mjs`
- `node --check apps/planner/app.js`
- `node --check apps/planner/_worker.js`
- `node --test apps/planner/planner-core.test.mjs apps/planner/pages-worker.test.mjs` (22 passing)
- `git diff --check`
- live relay: 25 locations and 72 forecast hours loaded successfully
- Chrome: date search limited to supported days; 25 source points; dense wind overlay; selected local start shown for a live destination; no console errors

Closes #43
Closes #45