### PR TITLE
feat: add planner place search

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -4,8 +4,9 @@ Static application code for a balloon pilot's forecast flight plan. It keeps
 the short plan-code flow inherited from Tail End Charlie, but it does not
 pretend a balloon follows a road route:
 
-- the pilot selects a launch point, flight date, launch elevation and optional
-  destination;
+- the pilot can find a UK place with a submit-only OpenStreetMap search, choose
+  a result explicitly as the launch point, and then select a flight date, launch
+  elevation and optional destination;
 - UKMO UKV wind from Open-Meteo is sampled across a 5×5 grid spanning roughly
   120 km around the launch, at 14 MSL height levels, with hourly interpolation
   during the flight and spatially interpolated display arrows across the visible
@@ -39,6 +40,9 @@ The vendored MapLibre GL JS distribution and licence are copied from the pinned
 
 UK Met Office data obtained through Open-Meteo is attributed under CC BY-SA
 4.0. See `docs/weather-wind-source.md` for source, licence and safety limits.
+Place search uses the public OpenStreetMap Nominatim service through a bounded,
+cached Pages endpoint. It never runs autocomplete: only an explicit submitted
+query is sent, with a maximum of five UK results.
 
 ## Checks
 

--- a/apps/planner/_worker.js
+++ b/apps/planner/_worker.js
@@ -1,4 +1,6 @@
 const ORACLE_ORIGIN = "https://relay.balloon-crumbs.tailendcharlie.app";
+const NOMINATIM_ORIGIN = "https://nominatim.openstreetmap.org";
+const GEOCODE_CACHE_SECONDS = 7 * 24 * 60 * 60;
 
 const STATIC_SECURITY_HEADERS = {
   "Content-Security-Policy":
@@ -22,6 +24,26 @@ export function isOracleProxyPath(pathname) {
   );
 }
 
+export function isGeocodePath(pathname) {
+  return pathname === "/geocode/v1/search";
+}
+
+export function geocodeSearchUrl(requestUrl) {
+  const source = new URL(requestUrl);
+  const query = (source.searchParams.get("q") ?? "").trim().replace(/\s+/g, " ");
+  if (query.length < 2 || query.length > 100) {
+    throw new RangeError("Search text must be between 2 and 100 characters.");
+  }
+  const url = new URL("/search", NOMINATIM_ORIGIN);
+  url.searchParams.set("q", query);
+  url.searchParams.set("format", "jsonv2");
+  url.searchParams.set("addressdetails", "1");
+  url.searchParams.set("limit", "5");
+  url.searchParams.set("countrycodes", "gb");
+  url.searchParams.set("accept-language", "en-GB");
+  return url;
+}
+
 export function oracleUrl(requestUrl) {
   const source = new URL(requestUrl);
   return new URL(`${source.pathname}${source.search}`, ORACLE_ORIGIN).toString();
@@ -38,6 +60,7 @@ export function isReservedBackendPath(pathname) {
     pathname.startsWith("/api/") ||
     pathname.startsWith("/health/") ||
     pathname.startsWith("/weather/") ||
+    pathname.startsWith("/geocode/") ||
     pathname.startsWith("/maps/")
   );
 }
@@ -46,6 +69,95 @@ async function proxyToOracle(request) {
   const upstreamRequest = new Request(oracleUrl(request.url), request);
   upstreamRequest.headers.delete("cookie");
   return fetch(upstreamRequest);
+}
+
+function jsonResponse(body, status, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json; charset=utf-8", ...headers },
+  });
+}
+
+function normaliseGeocodeResults(payload) {
+  if (!Array.isArray(payload)) return [];
+  return payload.slice(0, 5).flatMap((result) => {
+    const latitude = Number(result?.lat);
+    const longitude = Number(result?.lon);
+    const displayName = String(result?.display_name ?? "").trim();
+    if (
+      !displayName ||
+      !Number.isFinite(latitude) ||
+      latitude < -90 ||
+      latitude > 90 ||
+      !Number.isFinite(longitude) ||
+      longitude < -180 ||
+      longitude > 180
+    ) {
+      return [];
+    }
+    return [{ displayName, latitude, longitude }];
+  });
+}
+
+async function searchPlaces(request, ctx) {
+  if (request.method !== "GET") {
+    return jsonResponse({ error: "Place search only accepts GET requests." }, 405, {
+      Allow: "GET",
+    });
+  }
+
+  let upstreamUrl;
+  try {
+    upstreamUrl = geocodeSearchUrl(request.url);
+  } catch (error) {
+    return jsonResponse({ error: error.message }, 400);
+  }
+
+  const requestUrl = new URL(request.url);
+  requestUrl.search = new URLSearchParams({
+    q: upstreamUrl.searchParams.get("q").toLocaleLowerCase("en-GB"),
+  }).toString();
+  const cacheKey = new Request(requestUrl.toString(), { method: "GET" });
+  const cache = globalThis.caches?.default;
+  const cached = await cache?.match(cacheKey);
+  if (cached) return cached;
+
+  let upstreamResponse;
+  try {
+    upstreamResponse = await fetch(
+      new Request(upstreamUrl, {
+        headers: {
+          Accept: "application/json",
+          Referer: "https://balloon-crumbs.pages.dev/",
+          "User-Agent":
+            "BalloonCrumbsPlanner/1.0 (+https://balloon-crumbs.pages.dev/)",
+        },
+      }),
+    );
+  } catch {
+    return jsonResponse({ error: "The place-search provider is unavailable." }, 502);
+  }
+  if (!upstreamResponse.ok) {
+    return jsonResponse({ error: "The place-search provider is unavailable." }, 502);
+  }
+
+  let payload;
+  try {
+    payload = await upstreamResponse.json();
+  } catch {
+    return jsonResponse({ error: "The place-search provider returned invalid data." }, 502);
+  }
+  const response = jsonResponse(
+    { results: normaliseGeocodeResults(payload) },
+    200,
+    { "Cache-Control": `public, max-age=300, s-maxage=${GEOCODE_CACHE_SECONDS}` },
+  );
+  if (cache) {
+    const cacheWrite = cache.put(cacheKey, response.clone());
+    if (ctx?.waitUntil) ctx.waitUntil(cacheWrite);
+    else await cacheWrite;
+  }
+  return response;
 }
 
 async function serveAsset(request, env) {
@@ -74,11 +186,15 @@ async function serveAsset(request, env) {
 }
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
     if (isOracleProxyPath(url.pathname)) {
       return proxyToOracle(request);
+    }
+
+    if (isGeocodePath(url.pathname)) {
+      return searchPlaces(request, ctx);
     }
 
     if (isReservedBackendPath(url.pathname)) {

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -79,6 +79,11 @@ const elements = Object.fromEntries(
     "plan-code",
     "plan-expiry",
     "plan-name",
+    "place-search",
+    "place-search-form",
+    "place-search-results",
+    "place-search-status",
+    "place-search-submit",
     "retry-map",
     "route-status",
     "route-strategy",
@@ -110,6 +115,8 @@ const state = {
   windMarkers: [],
   forecastRequest: null,
   forecastGeneration: 0,
+  placeSearchRequest: null,
+  lastPlaceSearchAt: 0,
   mapTileFailures: 0,
 };
 
@@ -117,6 +124,98 @@ function setStatus(element, message, kind = "") {
   element.textContent = message;
   element.classList.toggle("error", kind === "error");
   element.classList.toggle("good", kind === "good");
+}
+
+function clearPlaceSearchResults() {
+  elements.place_search_results.replaceChildren();
+  elements.place_search_results.hidden = true;
+}
+
+function usePlaceSearchResult(result) {
+  clearPlaceSearchResults();
+  elements.place_search.value = result.displayName.split(",")[0];
+  state.map.easeTo({
+    center: [result.longitude, result.latitude],
+    zoom: 14,
+    duration: 700,
+  });
+  chooseLaunch({ lat: result.latitude, lng: result.longitude });
+  setStatus(
+    elements.place_search_status,
+    `Launch set at ${result.displayName}. Check the pin against the map before flight.`,
+    "good",
+  );
+}
+
+function renderPlaceSearchResults(results) {
+  clearPlaceSearchResults();
+  for (const result of results) {
+    const item = document.createElement("li");
+    const button = document.createElement("button");
+    button.type = "button";
+    button.setAttribute("aria-label", `Set launch at ${result.displayName}`);
+    const name = document.createElement("strong");
+    const detail = document.createElement("span");
+    const parts = result.displayName.split(",").map((part) => part.trim());
+    name.textContent = parts.shift() || result.displayName;
+    detail.textContent = parts.join(", ");
+    button.append(name, detail);
+    button.addEventListener("click", () => usePlaceSearchResult(result));
+    item.append(button);
+    elements.place_search_results.append(item);
+  }
+  elements.place_search_results.hidden = false;
+}
+
+async function searchForPlace(event) {
+  event.preventDefault();
+  const query = elements.place_search.value.trim().replace(/\s+/g, " ");
+  clearPlaceSearchResults();
+  if (query.length < 2 || query.length > 100) {
+    setStatus(elements.place_search_status, "Enter between 2 and 100 characters.", "error");
+    return;
+  }
+  if (!state.map) {
+    setStatus(elements.place_search_status, "Wait for the map to finish loading.", "error");
+    return;
+  }
+
+  state.placeSearchRequest?.abort();
+  const request = new AbortController();
+  state.placeSearchRequest = request;
+  elements.place_search_submit.disabled = true;
+  setStatus(elements.place_search_status, `Searching for “${query}”…`);
+  try {
+    const delay = Math.max(0, 1_100 - (Date.now() - state.lastPlaceSearchAt));
+    if (delay > 0) await new Promise((resolve) => window.setTimeout(resolve, delay));
+    state.lastPlaceSearchAt = Date.now();
+    const response = await fetch(`/geocode/v1/search?q=${encodeURIComponent(query)}`, {
+      headers: { Accept: "application/json" },
+      signal: request.signal,
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(body.error || `Place search returned ${response.status}.`);
+    const results = Array.isArray(body.results) ? body.results : [];
+    if (results.length === 0) {
+      setStatus(
+        elements.place_search_status,
+        `No UK places matched “${query}”. Try adding a nearby town or county.`,
+        "error",
+      );
+      return;
+    }
+    renderPlaceSearchResults(results);
+    setStatus(elements.place_search_status, "Choose a result to set it as the launch point.", "good");
+  } catch (error) {
+    if (error.name !== "AbortError") {
+      setStatus(elements.place_search_status, `Place search failed: ${error.message}`, "error");
+    }
+  } finally {
+    if (state.placeSearchRequest === request) {
+      state.placeSearchRequest = null;
+      elements.place_search_submit.disabled = !state.map;
+    }
+  }
 }
 
 function toLocalDateInputValue(date) {
@@ -907,6 +1006,7 @@ async function copyPlanCode() {
 }
 
 function bindControls() {
+  elements.place_search_form.addEventListener("submit", (event) => void searchForPlace(event));
   elements.set_launch.addEventListener("click", () => beginMapChoice("launch"));
   elements.set_landing.addEventListener("click", () => beginMapChoice("landing"));
   elements.clear_destination.addEventListener("click", clearDestination);
@@ -970,6 +1070,7 @@ async function start() {
     });
     state.map.on("load", () => {
       addPlannerLayers(state.map);
+      elements.place_search_submit.disabled = false;
       applyMapTheme();
       updateSources();
       state.map.on("moveend", updateWindMarkers);
@@ -981,7 +1082,9 @@ async function start() {
     });
   } catch (error) {
     elements.map.textContent = `Map unavailable: ${error.message}`;
+    elements.place_search_submit.disabled = true;
     setMapStatus("The basemap could not start.", "error", true);
+    setStatus(elements.place_search_status, "Place search is unavailable without the map.", "error");
     setStatus(elements.wind_status, "The map could not start, so no flight forecast was made.", "error");
   }
 }

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -37,9 +37,26 @@
             <span>1</span>
             <div>
               <h2 id="launch-title">Launch</h2>
-              <p>Click the map, or use this device’s location.</p>
+              <p>Search for a place, click the map, or use this device’s location.</p>
             </div>
           </div>
+          <form class="place-search" id="place-search-form">
+            <label for="place-search">Find a UK place</label>
+            <div>
+              <input
+                type="search"
+                id="place-search"
+                minlength="2"
+                maxlength="100"
+                autocomplete="off"
+                placeholder="e.g. Tuckers Grave"
+              />
+              <button type="submit" id="place-search-submit" disabled>Search</button>
+            </div>
+          </form>
+          <p class="status" id="place-search-status" role="status"></p>
+          <ul class="place-search-results" id="place-search-results" aria-label="Place search results" hidden></ul>
+          <p class="small muted place-search-credit">Submit-only search using © OpenStreetMap contributors, ODbL. Do not enter personal or confidential information.</p>
           <div class="button-row">
             <button type="button" id="set-launch">Set on map</button>
             <button type="button" id="use-location">Use my location</button>

--- a/apps/planner/pages-worker.test.mjs
+++ b/apps/planner/pages-worker.test.mjs
@@ -24,6 +24,7 @@ test("only bounded relay and provider paths are proxied", () => {
     "/health/ready",
     "/metrics",
     "/weather/v1/forecast/extra",
+    "/geocode/v1/search",
     "/maps/other/example",
     "/plan/",
   ]) {
@@ -36,6 +37,7 @@ test("unrecognised backend paths cannot fall through to the static site", async 
     "/health/ready",
     "/metrics",
     "/weather/v1/forecast/extra",
+    "/geocode/v1/other",
     "/maps/other/example",
   ]) {
     assert.equal(worker.isReservedBackendPath(pathname), true, pathname);
@@ -45,6 +47,116 @@ test("unrecognised backend paths cannot fall through to the static site", async 
     );
     assert.equal(response.status, 404, pathname);
   }
+});
+
+test("place search builds a bounded UK Nominatim query", () => {
+  assert.equal(worker.isGeocodePath("/geocode/v1/search"), true);
+  assert.equal(worker.isGeocodePath("/geocode/v1/search/extra"), false);
+  const url = worker.geocodeSearchUrl(
+    "https://balloon-crumbs.pages.dev/geocode/v1/search?q=%20Tuckers%20%20Grave%20",
+  );
+  assert.equal(url.origin, "https://nominatim.openstreetmap.org");
+  assert.equal(url.pathname, "/search");
+  assert.equal(url.searchParams.get("q"), "Tuckers Grave");
+  assert.equal(url.searchParams.get("format"), "jsonv2");
+  assert.equal(url.searchParams.get("limit"), "5");
+  assert.equal(url.searchParams.get("countrycodes"), "gb");
+  assert.throws(
+    () => worker.geocodeSearchUrl("https://balloon-crumbs.pages.dev/geocode/v1/search?q=x"),
+    /between 2 and 100/,
+  );
+});
+
+test("place search identifies the planner, sanitises results and caches them", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  let upstreamRequest;
+  let cachedRequest;
+  let cachedResponse;
+  const backgroundTasks = [];
+  globalThis.fetch = async (request) => {
+    upstreamRequest = request;
+    return Response.json([
+      {
+        display_name: "Tuckers Grave Inn, Faulkland, Somerset, England",
+        lat: "51.30312",
+        lon: "-2.34762",
+        ignored: "provider-specific data",
+      },
+      { display_name: "Invalid", lat: "not-a-number", lon: "-2.3" },
+    ]);
+  };
+  globalThis.caches = {
+    default: {
+      async match() {
+        return null;
+      },
+      async put(request, response) {
+        cachedRequest = request;
+        cachedResponse = response;
+      },
+    },
+  };
+
+  try {
+    const response = await worker.default.fetch(
+      new Request("https://balloon-crumbs.pages.dev/geocode/v1/search?q=Tuckers%20Grave"),
+      { ASSETS: { fetch: assert.fail } },
+      { waitUntil(task) { backgroundTasks.push(task); } },
+    );
+    await Promise.all(backgroundTasks);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("Cache-Control"), /s-maxage=604800/);
+    assert.equal(upstreamRequest.headers.get("Referer"), "https://balloon-crumbs.pages.dev/");
+    assert.match(upstreamRequest.headers.get("User-Agent"), /BalloonCrumbsPlanner/);
+    assert.equal(
+      new URL(upstreamRequest.url).searchParams.get("countrycodes"),
+      "gb",
+    );
+    assert.deepEqual(await response.json(), {
+      results: [
+        {
+          displayName: "Tuckers Grave Inn, Faulkland, Somerset, England",
+          latitude: 51.30312,
+          longitude: -2.34762,
+        },
+      ],
+    });
+    assert.equal(
+      cachedRequest.url,
+      "https://balloon-crumbs.pages.dev/geocode/v1/search?q=tuckers+grave",
+    );
+    assert.deepEqual(await cachedResponse.json(), {
+      results: [
+        {
+          displayName: "Tuckers Grave Inn, Faulkland, Somerset, England",
+          latitude: 51.30312,
+          longitude: -2.34762,
+        },
+      ],
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalCaches === undefined) delete globalThis.caches;
+    else globalThis.caches = originalCaches;
+  }
+});
+
+test("place search rejects invalid queries and non-GET requests", async () => {
+  const env = { ASSETS: { fetch: assert.fail } };
+  const invalid = await worker.default.fetch(
+    new Request("https://balloon-crumbs.pages.dev/geocode/v1/search?q=x"),
+    env,
+  );
+  assert.equal(invalid.status, 400);
+  const post = await worker.default.fetch(
+    new Request("https://balloon-crumbs.pages.dev/geocode/v1/search?q=Tuckers", {
+      method: "POST",
+    }),
+    env,
+  );
+  assert.equal(post.status, 405);
+  assert.equal(post.headers.get("Allow"), "GET");
 });
 
 test("the proxy preserves the bounded path and query on the Oracle origin", () => {

--- a/apps/planner/styles.css
+++ b/apps/planner/styles.css
@@ -100,6 +100,14 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .split-heading { grid-template-columns: 1.8rem 1fr auto; }
 
 .button-row { display: flex; gap: 0.55rem; flex-wrap: wrap; }
+.place-search { display: grid; gap: 0.36rem; margin-bottom: 0.2rem; }
+.place-search > label { color: var(--muted); font-size: 0.78rem; font-weight: 700; }
+.place-search > div { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.45rem; }
+.place-search > div button { padding-inline: 0.8rem; }
+.place-search-results { display: grid; gap: 0.4rem; list-style: none; margin: 0.55rem 0 0.7rem; padding: 0; }
+.place-search-results button { width: 100%; text-align: left; font-size: 0.76rem; line-height: 1.35; font-weight: 650; }
+.place-search-results button strong { display: block; color: var(--sky); margin-bottom: 0.12rem; }
+.place-search-credit { margin: 0.35rem 0 0.8rem; }
 .status { min-height: 1.25rem; margin: 0.7rem 0 0; color: var(--muted); font-size: 0.82rem; line-height: 1.45; }
 .status.error { color: #ffaaa0; }
 .status.good { color: #9be5bb; }
@@ -110,7 +118,7 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 
 .field { display: grid; gap: 0.36rem; margin-top: 0.75rem; color: var(--muted); font-size: 0.78rem; font-weight: 700; }
 .field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
-input[type="text"], input[type="number"], input[type="datetime-local"] {
+input[type="text"], input[type="search"], input[type="number"], input[type="date"] {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--line);
@@ -224,8 +232,9 @@ footer { min-height: 2.7rem; padding: 0.75rem 1rem; display: flex; justify-conte
 :root[data-theme="light"] .panel-section { border-color: #d7d0c8; }
 :root[data-theme="light"] .section-heading > span { background: #dce7e9; }
 :root[data-theme="light"] input[type="text"],
+:root[data-theme="light"] input[type="search"],
 :root[data-theme="light"] input[type="number"],
-:root[data-theme="light"] input[type="datetime-local"],
+:root[data-theme="light"] input[type="date"],
 :root[data-theme="light"] .input-with-unit { background: #ffffff; }
 :root[data-theme="light"] details { background: #ffffff; }
 :root[data-theme="light"] .generate-section { background: #eee9e2; }


### PR DESCRIPTION
## Summary
- add a submit-only UK place search to the launch-point controls
- proxy and cache bounded OpenStreetMap Nominatim searches at the edge
- let pilots confirm a result before moving the launch pin
- document attribution, privacy, and provider limitations

## Verification
- `node --check apps/planner/app.js`
- `node --check apps/planner/_worker.js`
- `node --test apps/planner/pages-worker.test.mjs apps/planner/planner-core.test.mjs`
- `git diff --check`
- browser-tested “Tuckers Grave” against the local Pages worker

Closes #46