### PR TITLE
fix: restore planner flight track

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -17,6 +17,9 @@ pretend a balloon follows a road route:
 - start time, an approximate matching window for the selected profile, duration,
   altitude profile and resulting peak altitude are optimiser outputs rather than
   pilot-supplied route inputs;
+- before a destination is chosen, a clearly labelled representative 60-minute
+  forecast keeps a visible altitude-coloured track, start time, duration, peak
+  altitude and forecast landing on the map;
 - the basemap and planner controls can switch between light and dark themes,
   with an explicit tile-load indicator and retry action;
 - OpenAIP's combined aeronautical chart is visible with a plain-language key;

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -5,6 +5,7 @@ import {
   circlePolygon,
   forecastDistanceMetres,
   forecastLandingEnvelope,
+  forecastRepresentativeRoute,
   interpolatedVectorAtPosition,
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
@@ -397,7 +398,7 @@ function applyMapTheme() {
     state.map.setPaintProperty(
       "forecast-track-casing",
       "line-color",
-      themeName === "dark" ? "#11151c" : "#ffffff",
+      themeName === "dark" ? "#ffffff" : "#11151c",
     );
   }
 }
@@ -514,9 +515,9 @@ function addPlannerLayers(map) {
     type: "line",
     source: "forecast-track",
     paint: {
-      "line-color": selectedMapTheme() === "dark" ? "#11151c" : "#ffffff",
-      "line-width": 9,
-      "line-opacity": 0.8,
+      "line-color": selectedMapTheme() === "dark" ? "#ffffff" : "#11151c",
+      "line-width": 12,
+      "line-opacity": 1,
     },
     layout: { "line-cap": "round", "line-join": "round" },
   });
@@ -530,16 +531,16 @@ function addPlannerLayers(map) {
         ["linear"],
         ["get", "altitude"],
         0,
-        "#4ea5ff",
+        "#00c8ff",
         500,
-        "#55e1d2",
+        "#00f5a0",
         1000,
-        "#ffd45e",
+        "#ffe600",
         2000,
-        "#ff6f8c",
+        "#ff245d",
       ],
-      "line-width": 5,
-      "line-opacity": 0.96,
+      "line-width": 7,
+      "line-opacity": 1,
     },
     layout: { "line-cap": "round", "line-join": "round" },
   });
@@ -669,7 +670,7 @@ function updateWindMarkers() {
 }
 
 function updateSources() {
-  if (!state.map?.isStyleLoaded()) return;
+  if (!state.map) return;
   state.map.getSource("forecast-track")?.setData(lineCollection(state.track));
   state.map
     .getSource("landing-envelope")
@@ -689,8 +690,12 @@ function fitForecast() {
   if (state.intendedLanding) {
     bounds.extend([state.intendedLanding.longitude, state.intendedLanding.latitude]);
   }
-  for (const point of state.landingEnvelope) {
-    bounds.extend([point.longitude, point.latitude]);
+  // Prioritise the displayed flight: fitting the full 10–180 minute envelope
+  // can shrink a useful one-hour track until it is almost invisible.
+  if (!state.track || state.track.length < 2) {
+    for (const point of state.landingEnvelope) {
+      bounds.extend([point.longitude, point.latitude]);
+    }
   }
   if (!bounds.isEmpty()) state.map.fitBounds(bounds, { padding: 90, maxZoom: 11, duration: 700 });
 }
@@ -760,37 +765,47 @@ function recomputeTrack({ fit = false } = {}) {
       setMarker("forecast", state.forecastLanding, "Forecast landing");
       setMarker("intended", state.intendedLanding, "Destination");
     } else {
-      state.routePlan = null;
-      state.track = null;
-      state.forecastLanding = null;
       const envelope = forecastLandingEnvelope(settings);
+      state.routePlan = forecastRepresentativeRoute({
+        ...settings,
+        departureOffsetMinutes: departureSearch.minimumDepartureOffsetMinutes,
+      });
+      state.track = state.routePlan.track;
+      state.forecastLanding = state.routePlan.landing;
       state.landingEnvelope = envelope.boundary;
       state.landingCandidateCount = envelope.candidates.length;
-      elements.route_strategy.hidden = true;
-      setMarker("forecast", null);
+      elements.route_strategy.hidden = false;
+      elements.route_strategy.textContent =
+        `Representative forecast: start ${formatLocalDateTime(state.routePlan.departureAt)} · ` +
+        `${state.routePlan.durationMinutes.toFixed(0)} min · peak ` +
+        `${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL, then descend to launch elevation. ` +
+        "Set a destination to optimise start time, duration and a changing altitude profile.";
+      setMarker("forecast", state.forecastLanding, "Forecast landing");
       setMarker("intended", null);
       setStatus(
         elements.route_status,
-        "Set a destination to optimise start time, flight duration and four in-flight altitude controls.",
+        "Showing a representative drift forecast so the track and flight details remain visible before a destination is chosen.",
+        "good",
       );
     }
     updateSources();
     updateWindMarkers();
     elements.set_landing.disabled = false;
     elements.clear_destination.disabled = !state.manualLanding;
-    elements.generate_code.disabled = !state.track;
+    elements.generate_code.disabled = !state.track || !state.manualLanding;
     elements.forecast_summary.hidden = !state.track;
     if (state.track) {
       elements.forecast_distance.textContent = `${(forecastDistanceMetres(state.track) / 1000).toFixed(1)} km forecast drift`;
       elements.forecast_validity.textContent =
         `${formatLocalDateTime(state.routePlan.departureAt)} · ` +
-        `${state.routePlan.durationMinutes.toFixed(1)} min · hourly wind interpolation`;
+        `${state.routePlan.durationMinutes.toFixed(1)} min · ` +
+        `${state.manualLanding ? "optimised" : "representative"} · hourly wind interpolation`;
     }
     setStatus(
       elements.landing_status,
       state.manualLanding
         ? `Destination retained. ${state.routePlan.evaluatedCandidateCount} start-time, duration and height refinements were evaluated.`
-        : `The purple envelope bounds ${state.landingCandidateCount} coarse start-time, duration and height forecasts. It is not a safe-landing assessment.`,
+        : `The coloured line is a representative ${state.routePlan.durationMinutes.toFixed(0)}-minute drift forecast peaking at ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL. The purple envelope bounds ${state.landingCandidateCount} coarse start-time, duration and height forecasts; neither is a safe-landing assessment.`,
       "good",
     );
     setStatus(
@@ -989,7 +1004,7 @@ async function generatePlanCode() {
   } catch (error) {
     setStatus(elements.generate_status, `The plan could not be saved: ${error.message}`, "error");
   } finally {
-    elements.generate_code.disabled = !state.track;
+    elements.generate_code.disabled = !state.track || !state.manualLanding;
   }
 }
 

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -12,6 +12,10 @@ export const ROUTE_SEARCH_LIMITS = Object.freeze({
   altitudeCeilingMetresMsl: 2000,
   acceptedMissDistanceMetres: 100,
 });
+export const REPRESENTATIVE_FORECAST_DEFAULTS = Object.freeze({
+  durationMinutes: 60,
+  cruiseAltitudeMetresMsl: 500,
+});
 export const ROUTE_CONTROL_FRACTIONS = Object.freeze([0, 0.2, 0.4, 0.6, 0.8, 1]);
 
 function finiteNumber(value, label) {
@@ -467,6 +471,51 @@ export function forecastFlightTrack({
         launchElevationMetresMsl,
         maximumAltitudeMetresMsl,
       }),
+  });
+}
+
+export function forecastRepresentativeRoute({
+  field,
+  launch,
+  launchElevationMetresMsl,
+  departureOffsetMinutes = 0,
+  durationMinutes = REPRESENTATIVE_FORECAST_DEFAULTS.durationMinutes,
+  cruiseAltitudeMetresMsl = REPRESENTATIVE_FORECAST_DEFAULTS.cruiseAltitudeMetresMsl,
+  stepSeconds = DEFAULT_STEP_SECONDS,
+}) {
+  const launchElevation = finiteNumber(launchElevationMetresMsl, "launch elevation");
+  const departureOffset = finiteNumber(departureOffsetMinutes, "departure offset");
+  if (departureOffset < 0) throw new RangeError("Departure offset must not be negative.");
+  const peakAltitudeMetresMsl = Math.max(
+    launchElevation,
+    finiteNumber(cruiseAltitudeMetresMsl, "representative cruise altitude"),
+  );
+  const track = forecastFlightTrack({
+    field,
+    launch,
+    launchElevationMetresMsl: launchElevation,
+    maximumAltitudeMetresMsl: peakAltitudeMetresMsl,
+    durationMinutes,
+    departureOffsetSeconds: departureOffset * 60,
+    stepSeconds,
+  });
+  const forecastStart =
+    field?.requestedAt instanceof Date
+      ? field.requestedAt
+      : field?.validAt instanceof Date
+        ? field.validAt
+        : null;
+  if (!forecastStart || Number.isNaN(forecastStart.getTime())) {
+    throw new TypeError("The wind field does not identify its forecast start.");
+  }
+  return Object.freeze({
+    kind: "representative",
+    departureOffsetMinutes: departureOffset,
+    departureAt: new Date(forecastStart.getTime() + departureOffset * 60_000),
+    durationMinutes: finiteNumber(durationMinutes, "flight duration"),
+    peakAltitudeMetresMsl,
+    track,
+    landing: track.at(-1),
   });
 }
 

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -12,6 +12,7 @@ import {
   circlePolygon,
   forecastAltitudeProfileTrack,
   forecastLandingEnvelope,
+  forecastRepresentativeRoute,
   forecastFlightTrack,
   interpolatedVectorAtPosition,
   moveWithWind,
@@ -195,6 +196,23 @@ test("forecast track can start from a later wind slice on the selected day", () 
   });
   assert.ok(track.at(-1).latitude > track[0].latitude);
   assert.ok(Math.abs(track.at(-1).longitude - track[0].longitude) < 0.001);
+});
+
+test("launch-only forecast reports a representative track and flight details", () => {
+  const field = parseOpenMeteoForecast(payload(), new Date("2026-08-21T08:00:00Z"));
+  const route = forecastRepresentativeRoute({
+    field,
+    launch: { latitude: 51.5, longitude: -2.5 },
+    launchElevationMetresMsl: 100,
+    departureOffsetMinutes: 60,
+  });
+  assert.equal(route.kind, "representative");
+  assert.equal(route.departureAt.toISOString(), "2026-08-21T09:00:00.000Z");
+  assert.equal(route.durationMinutes, 60);
+  assert.equal(route.peakAltitudeMetresMsl, 500);
+  assert.equal(route.track.length, 61);
+  assert.deepEqual(route.landing, route.track.at(-1));
+  assert.ok(route.landing.longitude > route.track[0].longitude);
 });
 
 test("wind routing chooses duration automatically and refines a reachable endpoint within 100 m", () => {

--- a/apps/planner/styles.css
+++ b/apps/planner/styles.css
@@ -187,7 +187,7 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 .legend-dot.launch { background: var(--sky); color: var(--sky); }
 .legend-dot.forecast { background: var(--sun); color: var(--sun); }
 .legend-dot.intended { background: var(--green); color: var(--green); }
-.legend-line { width: 1.4rem; height: 0.25rem; border-radius: 1rem; background: linear-gradient(90deg, #4ea5ff, #55e1d2, #ffd45e, #ff6f8c); }
+.legend-line { width: 1.4rem; height: 0.3rem; border-radius: 1rem; background: linear-gradient(90deg, #00c8ff, #00f5a0, #ffe600, #ff245d); }
 .legend-envelope { width: 1.4rem; height: 0.65rem; border: 2px dashed var(--purple); background: color-mix(in srgb, var(--purple) 18%, transparent); }
 
 .map-marker { width: 1.2rem; height: 1.2rem; border-radius: 50% 50% 50% 0; transform: rotate(-45deg); border: 2px solid #10141a; box-shadow: 0 2px 8px rgb(0 0 0 / 0.45); }


### PR DESCRIPTION
## Summary
- restore a clearly labelled launch-only representative flight forecast
- show start time, 60-minute duration, peak altitude, drift distance and landing before a destination is chosen
- send route GeoJSON to MapLibre even while raster/vector tiles are still loading
- prioritise the displayed track when fitting the map and strengthen altitude-colour contrast
- preserve destination optimisation and keep plan sharing gated on a chosen destination

## Root cause
Destination optimisation made `state.track` null in the launch-only flow. In addition, `updateSources()` used `map.isStyleLoaded()` as a gate, so active OpenAIP/basemap tile loading could prevent a calculated track from ever reaching the GeoJSON source.

## Verification
- `node --check apps/planner/app.js`
- `node --check apps/planner/_worker.js`
- `node --test apps/planner/pages-worker.test.mjs apps/planner/planner-core.test.mjs` (26 passed)
- browser: Tuckers Grave launch-only forecast visibly renders track and full summary with no console errors
- browser: destination optimisation still replaces the representative track and reports its own start/duration/profile

Closes #48