### PR TITLE
feat: add draggable planner endpoints

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -20,6 +20,11 @@ pretend a balloon follows a road route:
 - before a destination is chosen, a clearly labelled representative 60-minute
   forecast keeps a visible altitude-coloured track, start time, duration, peak
   altitude and forecast landing on the map;
+- placed launch and destination pins can be dragged directly; moving the launch
+  reloads its wind field while retaining the destination, and moving the
+  destination reruns the optimiser without a separate placement action;
+- the compact control panel keeps route inputs and results together, with wind,
+  chart and sharing controls grouped below and longer guidance in disclosures;
 - the basemap and planner controls can switch between light and dark themes,
   with an explicit tile-load indicator and retry action;
 - OpenAIP's combined aeronautical chart is visible with a plain-language key;

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -568,8 +568,10 @@ function addPlannerLayers(map) {
 function markerElement(kind, label) {
   const element = document.createElement("div");
   element.className = `map-marker ${kind}`;
-  element.title = label;
-  element.setAttribute("aria-label", label);
+  const draggable = kind === "launch" || kind === "intended";
+  if (draggable) element.classList.add("draggable");
+  element.title = draggable ? `${label} — drag to move` : label;
+  element.setAttribute("aria-label", draggable ? `${label}; drag to move` : label);
   return element;
 }
 
@@ -579,9 +581,29 @@ function setMarker(kind, point, label) {
     delete state.markers[kind];
     return;
   }
-  state.markers[kind] = new maplibregl.Marker({ element: markerElement(kind, label) })
+  const draggable = kind === "launch" || kind === "intended";
+  const marker = new maplibregl.Marker({
+    element: markerElement(kind, label),
+    draggable,
+  })
     .setLngLat([point.longitude, point.latitude])
     .addTo(state.map);
+  if (kind === "launch") {
+    marker.on("dragstart", () => {
+      setStatus(elements.launch_status, "Moving launch point…");
+    });
+    marker.on("dragend", () => {
+      chooseLaunch(marker.getLngLat(), { preserveDestination: true, fit: false });
+    });
+  } else if (kind === "intended") {
+    marker.on("dragstart", () => {
+      setStatus(elements.landing_status, "Moving destination…");
+    });
+    marker.on("dragend", () => {
+      void chooseLanding(marker.getLngLat(), { fit: false });
+    });
+  }
+  state.markers[kind] = marker;
 }
 
 function selectedWindLevel() {
@@ -746,19 +768,18 @@ function recomputeTrack({ fit = false } = {}) {
       const window = state.routePlan.departureWindow;
       const windowText = window
         ? window.startOffsetMinutes === window.endOffsetMinutes
-          ? ` Approximate matching start time with this profile: ${formatLocalTime(window.startAt)}.`
-          : ` Approximate matching start window with this profile: ${formatLocalTime(window.startAt)}–${formatLocalTime(window.endAt)}.`
+          ? ` · matching start ${formatLocalTime(window.startAt)}`
+          : ` · matching window ${formatLocalTime(window.startAt)}–${formatLocalTime(window.endAt)}`
         : "";
       elements.route_strategy.hidden = false;
       elements.route_strategy.textContent =
-        `Optimised forecast: start ${formatLocalDateTime(state.routePlan.departureAt)} · ${duration} min · ` +
-        `peak ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · heights at 20/40/60/80%: ` +
-        `${profile}, then land at launch elevation.${windowText}`;
+        `Best forecast · ${formatLocalDateTime(state.routePlan.departureAt)} · ${duration} min · ` +
+        `peak ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · profile ${profile} → land${windowText}`;
       setStatus(
         elements.route_status,
         state.routePlan.reachesDestination
-          ? `The optimised forecast endpoint is ${missDistance} from the destination, within the 100 m acceptance distance at the reported start time.`
-          : `The forecast winds do not support this destination inside the selected day and search limits. The closest endpoint still misses by ${missDistance}; the shown start time and track are best-effort only.`,
+          ? `Forecast lands ${missDistance} from the destination — within 100 m.`
+          : `Closest forecast misses the destination by ${missDistance}; no match within 100 m.`,
         state.routePlan.reachesDestination ? "good" : "error",
       );
       state.forecastLanding = state.track.at(-1);
@@ -776,15 +797,14 @@ function recomputeTrack({ fit = false } = {}) {
       state.landingCandidateCount = envelope.candidates.length;
       elements.route_strategy.hidden = false;
       elements.route_strategy.textContent =
-        `Representative forecast: start ${formatLocalDateTime(state.routePlan.departureAt)} · ` +
+        `Representative · ${formatLocalDateTime(state.routePlan.departureAt)} · ` +
         `${state.routePlan.durationMinutes.toFixed(0)} min · peak ` +
-        `${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL, then descend to launch elevation. ` +
-        "Set a destination to optimise start time, duration and a changing altitude profile.";
+        `${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · returns to launch elevation`;
       setMarker("forecast", state.forecastLanding, "Forecast landing");
       setMarker("intended", null);
       setStatus(
         elements.route_status,
-        "Showing a representative drift forecast so the track and flight details remain visible before a destination is chosen.",
+        "Representative drift shown. Place a destination to optimise the flight.",
         "good",
       );
     }
@@ -804,19 +824,18 @@ function recomputeTrack({ fit = false } = {}) {
     setStatus(
       elements.landing_status,
       state.manualLanding
-        ? `Destination retained. ${state.routePlan.evaluatedCandidateCount} start-time, duration and height refinements were evaluated.`
-        : `The coloured line is a representative ${state.routePlan.durationMinutes.toFixed(0)}-minute drift forecast peaking at ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL. The purple envelope bounds ${state.landingCandidateCount} coarse start-time, duration and height forecasts; neither is a safe-landing assessment.`,
+        ? `Destination set; drag the green pin to adjust. ${state.routePlan.evaluatedCandidateCount} candidates checked.`
+        : `Envelope: ${state.landingCandidateCount} coarse forecasts. Not a safe-landing assessment.`,
       "good",
     );
     setStatus(
       elements.wind_status,
-      `Hourly UKMO wind forecast covers ${formatLocalDay(departureSearch.dayStart)} across ` +
-        `${state.field.columns.length} source points in a roughly ` +
-        `${Math.round(WIND_GRID_SPAN_METRES / 1000)} km square. Arrows show ` +
+      `Wind: ${formatLocalDay(departureSearch.dayStart)} · ${state.field.columns.length} points · ` +
+        `~${Math.round(WIND_GRID_SPAN_METRES / 1000)} km grid · ` +
         `${formatLocalTime(state.routePlan?.departureAt ?? new Date(
           departureSearch.dayStart.getTime() +
             departureSearch.minimumDepartureOffsetMinutes * 60_000,
-        ))} · model data, not an observation.`,
+        ))} model hour (not observed).`,
       "good",
     );
     if (fit) fitForecast();
@@ -837,7 +856,7 @@ function recomputeTrack({ fit = false } = {}) {
   }
 }
 
-async function refreshForecast() {
+async function refreshForecast({ fit = true } = {}) {
   if (!state.launch) return;
   let departureSearch;
   try {
@@ -863,7 +882,7 @@ async function refreshForecast() {
     const payload = await response.json();
     if (generation !== state.forecastGeneration) return;
     state.field = parseOpenMeteoForecast(payload, departureSearch.dayStart);
-    recomputeTrack({ fit: true });
+    recomputeTrack({ fit });
   } catch (error) {
     if (error.name === "AbortError") return;
     state.field = null;
@@ -889,37 +908,43 @@ async function refreshForecast() {
   }
 }
 
-function chooseLaunch(point) {
+function chooseLaunch(point, { preserveDestination = false, fit = true } = {}) {
+  const retainDestination =
+    preserveDestination && state.manualLanding && state.intendedLanding !== null;
   state.launch = { latitude: point.lat, longitude: point.lng };
-  state.manualLanding = false;
-  state.intendedLanding = null;
+  state.field = null;
+  if (!retainDestination) {
+    state.manualLanding = false;
+    state.intendedLanding = null;
+  }
   state.track = null;
   state.forecastLanding = null;
   state.landingEnvelope = [];
   state.landingCandidateCount = 0;
   state.routePlan = null;
-  elements.clear_destination.disabled = true;
+  clearWindMarkers();
+  elements.clear_destination.disabled = !retainDestination;
   elements.set_landing.disabled = true;
   elements.generate_code.disabled = true;
   elements.forecast_summary.hidden = true;
   elements.route_strategy.hidden = true;
   setMarker("launch", state.launch, "Launch");
   setMarker("forecast", null);
-  setMarker("intended", null);
+  if (!retainDestination) setMarker("intended", null);
   updateSources();
   setStatus(
     elements.launch_status,
-    `${state.launch.latitude.toFixed(5)}, ${state.launch.longitude.toFixed(5)}`,
+    `${state.launch.latitude.toFixed(5)}, ${state.launch.longitude.toFixed(5)} · Drag the blue pin to adjust.`,
     "good",
   );
   state.mode = null;
   elements.map_prompt.hidden = true;
   setStatus(elements.landing_status, "Waiting for the wind forecast.");
   setStatus(elements.route_status, "Calculating the landing envelope from this launch point…");
-  void refreshForecast();
+  void refreshForecast({ fit });
 }
 
-async function chooseLanding(point) {
+async function chooseLanding(point, { fit = true } = {}) {
   state.intendedLanding = { latitude: point.lat, longitude: point.lng };
   state.manualLanding = true;
   setMarker("intended", state.intendedLanding, "Destination");
@@ -929,13 +954,13 @@ async function chooseLanding(point) {
   elements.clear_destination.disabled = false;
   setStatus(
     elements.landing_status,
-    `Destination set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. Optimising start time, duration and altitude profile…`,
+    `Destination set at ${state.intendedLanding.latitude.toFixed(5)}, ${state.intendedLanding.longitude.toFixed(5)}. Drag the green pin to adjust; optimising route…`,
     "good",
   );
   await new Promise((resolve) => {
     window.requestAnimationFrame(() => window.setTimeout(resolve, 0));
   });
-  recomputeTrack({ fit: true });
+  recomputeTrack({ fit });
 }
 
 function clearDestination() {
@@ -951,8 +976,8 @@ function beginMapChoice(mode) {
   elements.map_prompt.hidden = false;
   elements.map_prompt.textContent =
     mode === "launch"
-      ? "Click the map to set the launch point"
-      : "Click the map to set the intended destination";
+      ? "Click the map to set the launch point; drag the pin later to adjust"
+      : "Click the map to set the intended destination; drag the pin later to adjust";
 }
 
 function useDeviceLocation() {

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -32,12 +32,12 @@
 
     <main class="planner-shell">
       <aside class="planner-panel" aria-label="Flight planning controls">
-        <section class="panel-section" aria-labelledby="launch-title">
+        <section class="panel-section route-section" aria-labelledby="launch-title">
           <div class="section-heading">
             <span>1</span>
             <div>
-              <h2 id="launch-title">Launch</h2>
-              <p>Search for a place, click the map, or use this device’s location.</p>
+              <h2 id="launch-title">Flight route</h2>
+              <p>Place the start and destination, then drag either pin to adjust it.</p>
             </div>
           </div>
           <form class="place-search" id="place-search-form">
@@ -56,42 +56,54 @@
           </form>
           <p class="status" id="place-search-status" role="status"></p>
           <ul class="place-search-results" id="place-search-results" aria-label="Place search results" hidden></ul>
-          <p class="small muted place-search-credit">Submit-only search using © OpenStreetMap contributors, ODbL. Do not enter personal or confidential information.</p>
           <div class="button-row">
-            <button type="button" id="set-launch">Set on map</button>
+            <button type="button" id="set-launch">Place start</button>
             <button type="button" id="use-location">Use my location</button>
           </div>
           <p class="status" id="launch-status" role="status">Choose a launch point.</p>
+          <div class="field-grid compact-fields">
+            <label class="field">
+              <span>Flight date</span>
+              <input type="date" id="departure-time" />
+            </label>
+            <label class="field">
+              <span>Launch elevation</span>
+              <span class="input-with-unit">
+                <input type="number" id="launch-elevation" min="-50" max="1000" step="10" value="100" />
+                <i>m MSL</i>
+              </span>
+            </label>
+          </div>
+          <div class="subsection-heading">
+            <strong>Destination</strong>
+            <span>Optional until you want an optimised route</span>
+          </div>
+          <div class="button-row">
+            <button type="button" id="set-landing" disabled>Place destination</button>
+            <button type="button" id="clear-destination" disabled>Clear destination</button>
+          </div>
+          <p class="status" id="landing-status">Waiting for a wind forecast.</p>
+          <p class="status" id="route-status" role="status">Set a launch point to calculate the landing envelope.</p>
+          <p class="route-strategy" id="route-strategy" hidden></p>
+          <details class="panel-help">
+            <summary>Planner help, safety and data</summary>
+            <p class="small muted">The search varies the remaining start times on the selected day, a 10–180 minute duration and four altitude controls up to 2,000 m MSL. The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
+            <p class="small muted place-search-credit">Submit-only search using © OpenStreetMap contributors, ODbL. Do not enter personal or confidential information.</p>
+          </details>
         </section>
 
-        <section class="panel-section" aria-labelledby="flight-title">
+        <section class="panel-section layers-section" aria-labelledby="layers-title">
           <div class="section-heading">
             <span>2</span>
             <div>
-              <h2 id="flight-title">Forecast setup</h2>
-              <p>Choose the day and ground elevation; the optimiser searches the start time.</p>
+              <h2 id="layers-title">Map layers</h2>
+              <p>Wind and advisory aeronautical context.</p>
             </div>
           </div>
-          <label class="field">
-            <span>Flight date to search</span>
-            <input type="date" id="departure-time" />
-          </label>
-          <label class="field">
-            <span>Launch elevation</span>
-            <span class="input-with-unit">
-              <input type="number" id="launch-elevation" min="-50" max="1000" step="10" value="100" />
-              <i>m MSL</i>
-            </span>
-          </label>
-          <p class="search-limits small">The destination search tries the remaining start times on the selected day, a 10–180 minute duration and four altitude controls between launch elevation and 2,000 m MSL. Start time and peak altitude are outputs, not inputs.</p>
-        </section>
-
-        <section class="panel-section" aria-labelledby="wind-title">
-          <div class="section-heading split-heading">
-            <span>3</span>
+          <div class="layer-control">
             <div>
-              <h2 id="wind-title">Wind layer</h2>
-              <p>UKMO UKV forecast via Open-Meteo across a wide 5×5 grid.</p>
+              <strong id="wind-title">Wind</strong>
+              <small>UKMO via Open-Meteo</small>
             </div>
             <label class="switch" title="Show or hide wind arrows">
               <input type="checkbox" id="wind-toggle" checked />
@@ -100,37 +112,14 @@
             </label>
           </div>
           <label class="range-field">
-            <span>Displayed altitude <strong id="wind-altitude-label">500 m MSL</strong></span>
+            <span>Altitude <strong id="wind-altitude-label">500 m MSL</strong></span>
             <input type="range" id="wind-altitude" min="0" max="13" step="1" value="7" />
           </label>
           <p class="status" id="wind-status" role="status">Set a launch point to load wind.</p>
-          <p class="small muted">Arrows are spatially interpolated between the 25 source points across the visible sampling area. They point downwind; labels show km/h. Height levels are metres above mean sea level.</p>
-        </section>
-
-        <section class="panel-section" aria-labelledby="landing-title">
-          <div class="section-heading">
-            <span>4</span>
+          <div class="layer-control airspace-control">
             <div>
-              <h2 id="landing-title">Destination and landing envelope</h2>
-              <p>Optimise start time, duration and a changing altitude profile toward a destination.</p>
-            </div>
-          </div>
-          <div class="button-row">
-            <button type="button" id="set-landing" disabled>Set destination on map</button>
-            <button type="button" id="clear-destination" disabled>Clear destination</button>
-          </div>
-          <p class="status" id="landing-status">Waiting for a wind forecast.</p>
-          <p class="status" id="route-status" role="status">Set a launch point to calculate the landing envelope.</p>
-          <p class="route-strategy" id="route-strategy" hidden></p>
-          <p class="small muted">The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match; its reported time window only applies to that forecast profile. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
-        </section>
-
-        <section class="panel-section" aria-labelledby="airspace-title">
-          <div class="section-heading split-heading">
-            <span>5</span>
-            <div>
-              <h2 id="airspace-title">Aeronautical chart</h2>
-              <p>OpenAIP advisory airspace context.</p>
+              <strong id="airspace-title">Aeronautical chart</strong>
+              <small>OpenAIP advisory airspace</small>
             </div>
             <label class="switch" title="Show or hide OpenAIP chart">
               <input type="checkbox" id="airspace-toggle" checked />
@@ -138,8 +127,9 @@
               <b>Show</b>
             </label>
           </div>
-          <details>
-            <summary>Chart key and limitations</summary>
+          <details class="panel-help">
+            <summary>Wind details and chart key</summary>
+            <p class="small muted">Wind arrows are spatially interpolated between 25 forecast points. They point downwind and show km/h; heights are metres above mean sea level.</p>
             <dl class="chart-key">
               <div><dt class="swatch controlled"></dt><dd>Purple/blue areas commonly mark controlled airspace.</dd></div>
               <div><dt class="swatch restricted"></dt><dd>Red areas commonly mark restricted, prohibited or danger areas.</dd></div>
@@ -150,32 +140,31 @@
           </details>
         </section>
 
-        <section class="panel-section generate-section" aria-labelledby="share-title">
-          <div class="section-heading">
-            <span>6</span>
-            <div>
-              <h2 id="share-title">Share with the crew</h2>
-              <p>Create the same short plan code flow used by TEC.</p>
+        <details class="panel-section generate-section share-disclosure">
+          <summary>
+            <span>3</span>
+            <span><strong id="share-title">Share with the crew</strong><small>Generate a short plan code</small></span>
+          </summary>
+          <div class="share-fields">
+            <label class="field">
+              <span>Plan name</span>
+              <input type="text" id="plan-name" maxlength="200" value="Forecast balloon flight" />
+            </label>
+            <button type="button" class="primary" id="generate-code" disabled>Generate plan code</button>
+            <p class="status" id="generate-status" role="status"></p>
+            <div class="code-result" id="code-result" hidden>
+              <span>Plan code</span>
+              <div><code id="plan-code"></code><button type="button" id="copy-code">Copy</button></div>
+              <a id="open-in-app" href="#">Open in Balloon Crumbs</a>
+              <p class="small muted" id="plan-expiry"></p>
             </div>
           </div>
-          <label class="field">
-            <span>Plan name</span>
-            <input type="text" id="plan-name" maxlength="200" value="Forecast balloon flight" />
-          </label>
-          <button type="button" class="primary" id="generate-code" disabled>Generate plan code</button>
-          <p class="status" id="generate-status" role="status"></p>
-          <div class="code-result" id="code-result" hidden>
-            <span>Plan code</span>
-            <div><code id="plan-code"></code><button type="button" id="copy-code">Copy</button></div>
-            <a id="open-in-app" href="#">Open in Balloon Crumbs</a>
-            <p class="small muted" id="plan-expiry"></p>
-          </div>
-        </section>
+        </details>
       </aside>
 
       <section class="map-shell" aria-label="Forecast flight map">
         <div id="map" class="map"></div>
-        <div class="map-prompt" id="map-prompt">Click the map to set the launch point</div>
+        <div class="map-prompt" id="map-prompt">Click the map to set the launch point; drag placed pins to adjust</div>
         <div class="map-status" id="map-status" role="status">
           <span id="map-status-text">Loading basemap tiles…</span>
           <button type="button" id="retry-map" hidden>Retry</button>

--- a/apps/planner/styles.css
+++ b/apps/planner/styles.css
@@ -82,8 +82,8 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
   max-height: calc(100vh - 8rem);
 }
 
-.panel-section { padding: 1.1rem 1.15rem 1.25rem; border-bottom: 1px solid #2d323d; }
-.section-heading { display: grid; grid-template-columns: 1.8rem 1fr; gap: 0.65rem; align-items: start; margin-bottom: 0.9rem; }
+.panel-section { padding: 0.9rem 1rem 1rem; border-bottom: 1px solid #2d323d; }
+.section-heading { display: grid; grid-template-columns: 1.8rem 1fr; gap: 0.65rem; align-items: start; margin-bottom: 0.7rem; }
 .section-heading > span {
   width: 1.8rem;
   height: 1.8rem;
@@ -107,23 +107,26 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .place-search-results { display: grid; gap: 0.4rem; list-style: none; margin: 0.55rem 0 0.7rem; padding: 0; }
 .place-search-results button { width: 100%; text-align: left; font-size: 0.76rem; line-height: 1.35; font-weight: 650; }
 .place-search-results button strong { display: block; color: var(--sky); margin-bottom: 0.12rem; }
-.place-search-credit { margin: 0.35rem 0 0.8rem; }
-.status { min-height: 1.25rem; margin: 0.7rem 0 0; color: var(--muted); font-size: 0.82rem; line-height: 1.45; }
+.place-search-credit { margin: 0.55rem 0 0; }
+.status { margin: 0.5rem 0 0; color: var(--muted); font-size: 0.79rem; line-height: 1.38; }
+.status:empty { display: none; }
 .status.error { color: #ffaaa0; }
 .status.good { color: #9be5bb; }
-.route-strategy { margin: 0.7rem 0 0; padding: 0.7rem 0.8rem; border: 1px solid #655a84; border-radius: 0.65rem; background: #1d1928; color: #d9cdf7; font-size: 0.8rem; line-height: 1.4; font-weight: 750; }
+.route-strategy { margin: 0.55rem 0 0; padding: 0.65rem 0.7rem; border: 1px solid #655a84; border-radius: 0.65rem; background: #1d1928; color: #d9cdf7; font-size: 0.76rem; line-height: 1.35; font-weight: 750; }
 .search-limits { margin: 0.75rem 0 0; padding: 0.65rem 0.75rem; border-left: 3px solid var(--purple); background: color-mix(in srgb, var(--purple) 9%, transparent); color: var(--muted); }
 .muted { color: var(--muted); }
 .small { font-size: 0.75rem; line-height: 1.45; }
 
-.field { display: grid; gap: 0.36rem; margin-top: 0.75rem; color: var(--muted); font-size: 0.78rem; font-weight: 700; }
+.field { display: grid; gap: 0.32rem; margin-top: 0.65rem; color: var(--muted); font-size: 0.76rem; font-weight: 700; }
 .field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
+.compact-fields { margin-top: 0.1rem; }
+.compact-fields .field { margin-top: 0.65rem; }
 input[type="text"], input[type="search"], input[type="number"], input[type="date"] {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--line);
   border-radius: 0.6rem;
-  padding: 0.68rem 0.75rem;
+  padding: 0.56rem 0.65rem;
   background: #11151c;
   color: var(--ink);
 }
@@ -131,7 +134,7 @@ input[type="text"], input[type="search"], input[type="number"], input[type="date
 .input-with-unit input { border: 0; background: transparent; }
 .input-with-unit i { font-style: normal; padding-right: 0.7rem; color: #8e97a7; font-weight: 650; white-space: nowrap; }
 
-.range-field { display: grid; gap: 0.55rem; font-size: 0.78rem; color: var(--muted); }
+.range-field { display: grid; gap: 0.35rem; margin-top: 0.45rem; font-size: 0.76rem; color: var(--muted); }
 .range-field > span { display: flex; justify-content: space-between; gap: 0.5rem; }
 .range-field strong { color: var(--sky); }
 input[type="range"] { accent-color: var(--sky); width: 100%; }
@@ -146,6 +149,18 @@ input[type="range"] { accent-color: var(--sky); width: 100%; }
 
 details { border: 1px solid var(--line); border-radius: 0.65rem; background: #12161d; padding: 0.65rem 0.75rem; }
 summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
+.subsection-heading { display: flex; justify-content: space-between; align-items: baseline; gap: 0.7rem; margin: 0.8rem 0 0.45rem; padding-top: 0.7rem; border-top: 1px solid var(--line); }
+.subsection-heading strong { font-size: 0.82rem; }
+.subsection-heading span { color: var(--muted); font-size: 0.68rem; text-align: right; }
+.panel-help { margin-top: 0.55rem; padding: 0.48rem 0.6rem; }
+.panel-help summary { font-size: 0.74rem; color: var(--muted); }
+.panel-help[open] summary { color: var(--ink); }
+.panel-help > p:last-child { margin-bottom: 0; }
+.layer-control { display: flex; align-items: center; justify-content: space-between; gap: 0.8rem; }
+.layer-control > div { display: grid; gap: 0.08rem; }
+.layer-control strong { font-size: 0.82rem; }
+.layer-control small { color: var(--muted); font-size: 0.68rem; }
+.airspace-control { margin-top: 0.7rem; padding-top: 0.7rem; border-top: 1px solid var(--line); }
 .chart-key { display: grid; gap: 0.5rem; margin: 0.75rem 0; }
 .chart-key div { display: grid; grid-template-columns: 1rem 1fr; gap: 0.55rem; align-items: start; }
 .chart-key dd, .chart-key dt { margin: 0; }
@@ -157,6 +172,26 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 .swatch.boundary { border-color: #c3ccd8; background: repeating-linear-gradient(45deg, transparent, transparent 2px, #c3ccd8 2px, #c3ccd8 3px); }
 
 .generate-section { background: #1b2029; }
+.share-disclosure { border: 0; border-radius: 0; margin: 0; }
+.share-disclosure > summary { display: grid; grid-template-columns: 1.8rem 1fr auto; gap: 0.65rem; align-items: center; list-style: none; }
+.share-disclosure > summary::-webkit-details-marker { display: none; }
+.share-disclosure > summary::after { content: "+"; grid-column: 3; grid-row: 1; color: var(--sky); font-size: 1.2rem; }
+.share-disclosure[open] > summary::after { content: "−"; }
+.share-disclosure > summary > span:first-child {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #303743;
+  color: var(--sky);
+  font-size: 0.8rem;
+  font-weight: 850;
+}
+.share-disclosure > summary > span:nth-child(2) { display: grid; gap: 0.12rem; }
+.share-disclosure > summary strong { font-size: 1rem; }
+.share-disclosure > summary small { color: var(--muted); font-size: 0.72rem; font-weight: 500; }
+.share-fields { padding-top: 0.25rem; }
 .code-result { margin-top: 0.85rem; padding: 0.85rem; border-radius: 0.7rem; border: 1px solid #3d5360; background: #111a21; }
 .code-result > span { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; }
 .code-result > div { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; margin: 0.3rem 0 0.65rem; }
@@ -191,6 +226,10 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 .legend-envelope { width: 1.4rem; height: 0.65rem; border: 2px dashed var(--purple); background: color-mix(in srgb, var(--purple) 18%, transparent); }
 
 .map-marker { width: 1.2rem; height: 1.2rem; border-radius: 50% 50% 50% 0; transform: rotate(-45deg); border: 2px solid #10141a; box-shadow: 0 2px 8px rgb(0 0 0 / 0.45); }
+.map-marker.draggable { cursor: grab; transition: width 120ms ease, height 120ms ease, box-shadow 120ms ease; }
+.map-marker.draggable:hover,
+.map-marker.draggable:focus-visible { width: 1.45rem; height: 1.45rem; box-shadow: 0 3px 12px rgb(0 0 0 / 0.58), 0 0 0 3px rgb(255 255 255 / 0.65); }
+.map-marker.draggable:active { cursor: grabbing; }
 .map-marker.launch { background: var(--sky); }
 .map-marker.forecast { background: var(--sun); }
 .map-marker.intended { background: var(--green); }
@@ -231,6 +270,7 @@ footer { min-height: 2.7rem; padding: 0.75rem 1rem; display: flex; justify-conte
 :root[data-theme="light"] .planner-panel { border-color: #cbc4bc; }
 :root[data-theme="light"] .panel-section { border-color: #d7d0c8; }
 :root[data-theme="light"] .section-heading > span { background: #dce7e9; }
+:root[data-theme="light"] .share-disclosure > summary > span:first-child { background: #dce7e9; }
 :root[data-theme="light"] input[type="text"],
 :root[data-theme="light"] input[type="search"],
 :root[data-theme="light"] input[type="number"],


### PR DESCRIPTION
## Summary
- make launch and destination pins directly draggable after placement
- preserve the destination and reload wind forecasts when the launch moves
- recalculate destination optimisation in place when its pin moves
- consolidate the panel into compact route and map-layer groups with collapsed help and sharing
- shorten visible forecast copy while preserving flight details and safety guidance

## Verification
- `node --test apps/planner/pages-worker.test.mjs apps/planner/planner-core.test.mjs`
- `node --check apps/planner/app.js`
- `node --check apps/planner/_worker.js`
- local Chrome: launch/destination placement and both drag flows verified; destination preserved after launch move; track and summary remain visible; no console errors

Closes #50