### PR TITLE
feat: add altitude ceiling and flight profile

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -13,7 +13,9 @@ pretend a balloon follows a road route:
   sampling area;
 - the destination optimiser searches start times across the selected day,
   10–180 minute durations and four changing altitude controls up to the highest
-  2,000 m MSL forecast layer;
+  pilot-selected maximum altitude, bounded by the highest 2,000 m MSL forecast
+  layer; the same ceiling constrains the representative track and landing
+  envelope;
 - start time, an approximate matching window for the selected profile, duration,
   altitude profile and resulting peak altitude are optimiser outputs rather than
   pilot-supplied route inputs;
@@ -23,6 +25,10 @@ pretend a balloon follows a road route:
 - placed launch and destination pins can be dragged directly; moving the launch
   reloads its wind field while retaining the destination, and moving the
   destination reruns the optimiser without a separate placement action;
+- after launch, the next map click sets the destination directly, while dragging
+  the initial yellow forecast endpoint converts it into the intended destination;
+- a flight-profile pane lists launch and landing times, duration, the altitude at
+  each 20% stage and each climb, level or descent change;
 - the compact control panel keeps route inputs and results together, with wind,
   chart and sharing controls grouped below and longer guidance in disclosures;
 - the basemap and planner controls can switch between light and dark themes,

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -1,6 +1,8 @@
 import {
+  ROUTE_CONTROL_FRACTIONS,
   WIND_GRID_SPAN_METRES,
   WIND_LEVELS_METRES_MSL,
+  altitudeForFlightFraction,
   buildFlightPlanGpx,
   circlePolygon,
   forecastDistanceMetres,
@@ -67,11 +69,15 @@ const elements = Object.fromEntries(
     "forecast-distance",
     "forecast-summary",
     "forecast-validity",
+    "flight-profile",
+    "flight-profile-title",
     "generate-code",
     "generate-status",
     "launch-elevation",
     "launch-status",
     "landing-status",
+    "max-altitude",
+    "max-altitude-label",
     "map",
     "map-prompt",
     "map-status",
@@ -85,9 +91,14 @@ const elements = Object.fromEntries(
     "place-search-results",
     "place-search-status",
     "place-search-submit",
+    "profile-duration",
+    "profile-landing",
+    "profile-limit",
+    "profile-stages",
+    "profile-start",
+    "profile-window",
     "retry-map",
     "route-status",
-    "route-strategy",
     "set-landing",
     "set-launch",
     "theme-label",
@@ -568,10 +579,12 @@ function addPlannerLayers(map) {
 function markerElement(kind, label) {
   const element = document.createElement("div");
   element.className = `map-marker ${kind}`;
-  const draggable = kind === "launch" || kind === "intended";
+  const draggable =
+    kind === "launch" || kind === "intended" || (kind === "forecast" && !state.manualLanding);
   if (draggable) element.classList.add("draggable");
-  element.title = draggable ? `${label} — drag to move` : label;
-  element.setAttribute("aria-label", draggable ? `${label}; drag to move` : label);
+  const dragInstruction = kind === "forecast" ? "drag to choose destination" : "drag to move";
+  element.title = draggable ? `${label} — ${dragInstruction}` : label;
+  element.setAttribute("aria-label", draggable ? `${label}; ${dragInstruction}` : label);
   return element;
 }
 
@@ -581,7 +594,8 @@ function setMarker(kind, point, label) {
     delete state.markers[kind];
     return;
   }
-  const draggable = kind === "launch" || kind === "intended";
+  const draggable =
+    kind === "launch" || kind === "intended" || (kind === "forecast" && !state.manualLanding);
   const marker = new maplibregl.Marker({
     element: markerElement(kind, label),
     draggable,
@@ -598,6 +612,13 @@ function setMarker(kind, point, label) {
   } else if (kind === "intended") {
     marker.on("dragstart", () => {
       setStatus(elements.landing_status, "Moving destination…");
+    });
+    marker.on("dragend", () => {
+      void chooseLanding(marker.getLngLat(), { fit: false });
+    });
+  } else if (kind === "forecast" && draggable) {
+    marker.on("dragstart", () => {
+      setStatus(elements.landing_status, "Drag the yellow endpoint to your intended destination…");
     });
     marker.on("dragend", () => {
       void chooseLanding(marker.getLngLat(), { fit: false });
@@ -722,6 +743,19 @@ function fitForecast() {
   if (!bounds.isEmpty()) state.map.fitBounds(bounds, { padding: 90, maxZoom: 11, duration: 700 });
 }
 
+function syncMaxAltitudeControl() {
+  const launchElevationMetresMsl = Number(elements.launch_elevation.value);
+  const minimum = Number.isFinite(launchElevationMetresMsl)
+    ? Math.min(2000, Math.max(100, Math.ceil(launchElevationMetresMsl / 50) * 50))
+    : 100;
+  elements.max_altitude.min = String(minimum);
+  if (Number(elements.max_altitude.value) < minimum) {
+    elements.max_altitude.value = String(minimum);
+  }
+  elements.max_altitude_label.textContent =
+    `${Number(elements.max_altitude.value).toLocaleString("en-GB")} m MSL`;
+}
+
 function validLaunchSettings() {
   const launchElevationMetresMsl = Number(elements.launch_elevation.value);
   if (
@@ -731,13 +765,92 @@ function validLaunchSettings() {
   ) {
     throw new Error("Choose a valid launch elevation in metres MSL.");
   }
-  return { launchElevationMetresMsl };
+  const altitudeCeilingMetresMsl = Number(elements.max_altitude.value);
+  if (
+    !Number.isFinite(altitudeCeilingMetresMsl) ||
+    altitudeCeilingMetresMsl < launchElevationMetresMsl ||
+    altitudeCeilingMetresMsl > 2000
+  ) {
+    throw new Error("Choose a maximum altitude between launch elevation and 2,000 m MSL.");
+  }
+  return { launchElevationMetresMsl, altitudeCeilingMetresMsl };
 }
 
 function formatMissDistance(distanceMetres) {
   return distanceMetres < 1000
     ? `${Math.round(distanceMetres)} m`
     : `${(distanceMetres / 1000).toFixed(1)} km`;
+}
+
+function renderFlightProfile() {
+  if (!state.routePlan) {
+    elements.flight_profile.hidden = true;
+    elements.profile_stages.replaceChildren();
+    return;
+  }
+  const { launchElevationMetresMsl, altitudeCeilingMetresMsl } = validLaunchSettings();
+  const departureAt = state.routePlan.departureAt;
+  const durationMinutes = state.routePlan.durationMinutes;
+  const landingAt = new Date(departureAt.getTime() + durationMinutes * 60_000);
+  const altitudes =
+    state.routePlan.kind === "representative"
+      ? ROUTE_CONTROL_FRACTIONS.map((fraction) =>
+          altitudeForFlightFraction({
+            fraction,
+            launchElevationMetresMsl,
+            maximumAltitudeMetresMsl: state.routePlan.peakAltitudeMetresMsl,
+          }),
+        )
+      : [
+          launchElevationMetresMsl,
+          ...state.routePlan.controlAltitudesMetresMsl,
+          launchElevationMetresMsl,
+        ];
+  const labels = ["Launch", "20%", "40%", "60%", "80%", "Landing"];
+  elements.flight_profile_title.textContent =
+    state.routePlan.kind === "representative" ? "Representative forecast" : "Optimised forecast";
+  elements.profile_limit.textContent =
+    `Maximum ${altitudeCeilingMetresMsl.toLocaleString("en-GB")} m MSL`;
+  elements.profile_start.textContent = formatLocalDateTime(departureAt);
+  elements.profile_landing.textContent = formatLocalDateTime(landingAt);
+  elements.profile_duration.textContent = `${durationMinutes.toFixed(1)} min`;
+  const window = state.routePlan.departureWindow;
+  elements.profile_window.hidden = !window;
+  elements.profile_window.textContent = window
+    ? window.startOffsetMinutes === window.endOffsetMinutes
+      ? `Matching start: ${formatLocalTime(window.startAt)}`
+      : `Matching start window: ${formatLocalTime(window.startAt)}–${formatLocalTime(window.endAt)}`
+    : "";
+  elements.profile_stages.replaceChildren();
+  for (const [index, fraction] of ROUTE_CONTROL_FRACTIONS.entries()) {
+    const row = document.createElement("tr");
+    const stage = document.createElement("td");
+    const time = document.createElement("td");
+    const altitude = document.createElement("td");
+    const change = document.createElement("td");
+    const roundedAltitude = Math.round(altitudes[index]);
+    stage.textContent = labels[index];
+    time.textContent = formatLocalTime(
+      new Date(departureAt.getTime() + durationMinutes * fraction * 60_000),
+    );
+    altitude.textContent = `${roundedAltitude.toLocaleString("en-GB")} m`;
+    if (index === 0) {
+      change.textContent = "—";
+      change.className = "level";
+    } else {
+      const difference = roundedAltitude - Math.round(altitudes[index - 1]);
+      change.textContent =
+        difference > 0
+          ? `↑ ${difference.toLocaleString("en-GB")} m`
+          : difference < 0
+            ? `↓ ${Math.abs(difference).toLocaleString("en-GB")} m`
+            : "—";
+      change.className = difference > 0 ? "climb" : difference < 0 ? "descent" : "level";
+    }
+    row.append(stage, time, altitude, change);
+    elements.profile_stages.append(row);
+  }
+  elements.flight_profile.hidden = false;
 }
 
 function recomputeTrack({ fit = false } = {}) {
@@ -759,22 +872,6 @@ function recomputeTrack({ fit = false } = {}) {
       state.landingEnvelope = state.routePlan.boundary;
       state.landingCandidateCount = state.routePlan.candidateCount;
       const missDistance = formatMissDistance(state.routePlan.missDistanceMetres);
-      const duration = Number.isInteger(state.routePlan.durationMinutes)
-        ? state.routePlan.durationMinutes.toFixed(0)
-        : state.routePlan.durationMinutes.toFixed(1);
-      const profile = state.routePlan.controlAltitudesMetresMsl
-        .map((altitude) => `${Math.round(altitude)} m`)
-        .join(" → ");
-      const window = state.routePlan.departureWindow;
-      const windowText = window
-        ? window.startOffsetMinutes === window.endOffsetMinutes
-          ? ` · matching start ${formatLocalTime(window.startAt)}`
-          : ` · matching window ${formatLocalTime(window.startAt)}–${formatLocalTime(window.endAt)}`
-        : "";
-      elements.route_strategy.hidden = false;
-      elements.route_strategy.textContent =
-        `Best forecast · ${formatLocalDateTime(state.routePlan.departureAt)} · ${duration} min · ` +
-        `peak ${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · profile ${profile} → land${windowText}`;
       setStatus(
         elements.route_status,
         state.routePlan.reachesDestination
@@ -783,8 +880,10 @@ function recomputeTrack({ fit = false } = {}) {
         state.routePlan.reachesDestination ? "good" : "error",
       );
       state.forecastLanding = state.track.at(-1);
-      setMarker("forecast", state.forecastLanding, "Forecast landing");
+      setMarker("forecast", state.forecastLanding, "Calculated forecast landing");
       setMarker("intended", state.intendedLanding, "Destination");
+      state.mode = null;
+      elements.map_prompt.hidden = true;
     } else {
       const envelope = forecastLandingEnvelope(settings);
       state.routePlan = forecastRepresentativeRoute({
@@ -795,13 +894,11 @@ function recomputeTrack({ fit = false } = {}) {
       state.forecastLanding = state.routePlan.landing;
       state.landingEnvelope = envelope.boundary;
       state.landingCandidateCount = envelope.candidates.length;
-      elements.route_strategy.hidden = false;
-      elements.route_strategy.textContent =
-        `Representative · ${formatLocalDateTime(state.routePlan.departureAt)} · ` +
-        `${state.routePlan.durationMinutes.toFixed(0)} min · peak ` +
-        `${Math.round(state.routePlan.peakAltitudeMetresMsl)} m MSL · returns to launch elevation`;
-      setMarker("forecast", state.forecastLanding, "Forecast landing");
+      setMarker("forecast", state.forecastLanding, "Forecast endpoint");
       setMarker("intended", null);
+      state.mode = "landing";
+      elements.map_prompt.hidden = false;
+      elements.map_prompt.textContent = "Click map or drag yellow endpoint";
       setStatus(
         elements.route_status,
         "Representative drift shown. Place a destination to optimise the flight.",
@@ -821,6 +918,7 @@ function recomputeTrack({ fit = false } = {}) {
         `${state.routePlan.durationMinutes.toFixed(1)} min · ` +
         `${state.manualLanding ? "optimised" : "representative"} · hourly wind interpolation`;
     }
+    renderFlightProfile();
     setStatus(
       elements.landing_status,
       state.manualLanding
@@ -849,7 +947,7 @@ function recomputeTrack({ fit = false } = {}) {
     elements.set_landing.disabled = true;
     elements.clear_destination.disabled = true;
     elements.forecast_summary.hidden = true;
-    elements.route_strategy.hidden = true;
+    renderFlightProfile();
     updateSources();
     setStatus(elements.wind_status, error.message, "error");
     setStatus(elements.route_status, "No route calculation is available with these settings.", "error");
@@ -897,7 +995,7 @@ async function refreshForecast({ fit = true } = {}) {
     elements.set_landing.disabled = true;
     elements.clear_destination.disabled = true;
     elements.forecast_summary.hidden = true;
-    elements.route_strategy.hidden = true;
+    renderFlightProfile();
     setStatus(
       elements.wind_status,
       `No usable live wind forecast: ${error.message} Do not substitute a guessed track.`,
@@ -927,7 +1025,7 @@ function chooseLaunch(point, { preserveDestination = false, fit = true } = {}) {
   elements.set_landing.disabled = true;
   elements.generate_code.disabled = true;
   elements.forecast_summary.hidden = true;
-  elements.route_strategy.hidden = true;
+  renderFlightProfile();
   setMarker("launch", state.launch, "Launch");
   setMarker("forecast", null);
   if (!retainDestination) setMarker("intended", null);
@@ -1065,7 +1163,12 @@ function bindControls() {
     }
   });
   elements.departure_time.addEventListener("change", () => void refreshForecast());
-  elements.launch_elevation.addEventListener("change", () => recomputeTrack({ fit: false }));
+  elements.launch_elevation.addEventListener("change", () => {
+    syncMaxAltitudeControl();
+    recomputeTrack({ fit: false });
+  });
+  elements.max_altitude.addEventListener("input", syncMaxAltitudeControl);
+  elements.max_altitude.addEventListener("change", () => recomputeTrack({ fit: true }));
   elements.generate_code.addEventListener("click", () => void generatePlanCode());
   elements.copy_code.addEventListener("click", () => void copyPlanCode());
 }
@@ -1074,6 +1177,7 @@ async function start() {
   elements.theme_toggle.checked = window.matchMedia("(prefers-color-scheme: dark)").matches;
   applyMapTheme();
   configureDepartureInput();
+  syncMaxAltitudeControl();
   updateClock();
   window.setInterval(updateClock, 1_000);
   bindControls();

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -37,7 +37,7 @@
             <span>1</span>
             <div>
               <h2 id="launch-title">Flight route</h2>
-              <p>Place the start and destination, then drag either pin to adjust it.</p>
+              <p>Place the start, then click the map or drag the yellow endpoint to choose a destination.</p>
             </div>
           </div>
           <form class="place-search" id="place-search-form">
@@ -74,9 +74,13 @@
               </span>
             </label>
           </div>
+          <label class="range-field ceiling-field">
+            <span>Maximum altitude <strong id="max-altitude-label">2,000 m MSL</strong></span>
+            <input type="range" id="max-altitude" min="100" max="2000" step="50" value="2000" />
+          </label>
           <div class="subsection-heading">
             <strong>Destination</strong>
-            <span>Optional until you want an optimised route</span>
+            <span>Click the map directly or drag the yellow endpoint</span>
           </div>
           <div class="button-row">
             <button type="button" id="set-landing" disabled>Place destination</button>
@@ -84,10 +88,9 @@
           </div>
           <p class="status" id="landing-status">Waiting for a wind forecast.</p>
           <p class="status" id="route-status" role="status">Set a launch point to calculate the landing envelope.</p>
-          <p class="route-strategy" id="route-strategy" hidden></p>
           <details class="panel-help">
             <summary>Planner help, safety and data</summary>
-            <p class="small muted">The search varies the remaining start times on the selected day, a 10–180 minute duration and four altitude controls up to 2,000 m MSL. The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
+            <p class="small muted">The search varies the remaining start times on the selected day, a 10–180 minute duration and four altitude controls up to the selected maximum altitude. The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
             <p class="small muted place-search-credit">Submit-only search using © OpenStreetMap contributors, ODbL. Do not enter personal or confidential information.</p>
           </details>
         </section>
@@ -173,9 +176,28 @@
           <strong id="forecast-distance"></strong>
           <span id="forecast-validity"></span>
         </div>
+        <section class="flight-profile-pane" id="flight-profile" aria-labelledby="flight-profile-title" hidden>
+          <div class="profile-pane-heading">
+            <div>
+              <span>Flight profile</span>
+              <strong id="flight-profile-title">Forecast</strong>
+            </div>
+            <span id="profile-limit"></span>
+          </div>
+          <div class="profile-times">
+            <div><span>Start</span><strong id="profile-start"></strong></div>
+            <div><span>Landing</span><strong id="profile-landing"></strong></div>
+            <div><span>Duration</span><strong id="profile-duration"></strong></div>
+          </div>
+          <p class="profile-window" id="profile-window" hidden></p>
+          <table aria-label="Timed altitude stages">
+            <thead><tr><th scope="col">Stage</th><th scope="col">Time</th><th scope="col">Altitude</th><th scope="col">Change</th></tr></thead>
+            <tbody id="profile-stages"></tbody>
+          </table>
+        </section>
         <div class="map-legend" aria-label="Map legend">
           <span><i class="legend-dot launch"></i>Launch</span>
-          <span><i class="legend-dot forecast"></i>Forecast landing</span>
+          <span><i class="legend-dot forecast"></i>Calculated landing (drag first endpoint)</span>
           <span><i class="legend-dot intended"></i>Destination</span>
           <span><i class="legend-line"></i>Altitude-coloured forecast track</span>
           <span><i class="legend-envelope"></i>Forecast landing envelope</span>

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -478,17 +478,25 @@ export function forecastRepresentativeRoute({
   field,
   launch,
   launchElevationMetresMsl,
+  altitudeCeilingMetresMsl = ROUTE_SEARCH_LIMITS.altitudeCeilingMetresMsl,
   departureOffsetMinutes = 0,
   durationMinutes = REPRESENTATIVE_FORECAST_DEFAULTS.durationMinutes,
   cruiseAltitudeMetresMsl = REPRESENTATIVE_FORECAST_DEFAULTS.cruiseAltitudeMetresMsl,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   const launchElevation = finiteNumber(launchElevationMetresMsl, "launch elevation");
+  const altitudeCeiling = finiteNumber(altitudeCeilingMetresMsl, "altitude ceiling");
+  if (altitudeCeiling < launchElevation) {
+    throw new RangeError("Altitude ceiling must not be below launch.");
+  }
   const departureOffset = finiteNumber(departureOffsetMinutes, "departure offset");
   if (departureOffset < 0) throw new RangeError("Departure offset must not be negative.");
   const peakAltitudeMetresMsl = Math.max(
     launchElevation,
-    finiteNumber(cruiseAltitudeMetresMsl, "representative cruise altitude"),
+    Math.min(
+      altitudeCeiling,
+      finiteNumber(cruiseAltitudeMetresMsl, "representative cruise altitude"),
+    ),
   );
   const track = forecastFlightTrack({
     field,
@@ -513,6 +521,7 @@ export function forecastRepresentativeRoute({
     departureOffsetMinutes: departureOffset,
     departureAt: new Date(forecastStart.getTime() + departureOffset * 60_000),
     durationMinutes: finiteNumber(durationMinutes, "flight duration"),
+    altitudeCeilingMetresMsl: altitudeCeiling,
     peakAltitudeMetresMsl,
     track,
     landing: track.at(-1),

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -215,6 +215,57 @@ test("launch-only forecast reports a representative track and flight details", (
   assert.ok(route.landing.longitude > route.track[0].longitude);
 });
 
+test("maximum altitude constrains the representative track and landing envelope", () => {
+  const source = payload();
+  for (const altitude of WIND_LEVELS_METRES_MSL) {
+    source.hourly[`wind_direction_${altitude}m`] =
+      altitude <= 100 ? [270, 270] : [180, 180];
+  }
+  const field = parseOpenMeteoForecast(source, new Date("2026-08-21T08:00:00Z"));
+  const launch = { latitude: 51.5, longitude: -2.5 };
+  const representative = forecastRepresentativeRoute({
+    field,
+    launch,
+    launchElevationMetresMsl: 100,
+    altitudeCeilingMetresMsl: 300,
+  });
+  assert.equal(representative.peakAltitudeMetresMsl, 300);
+  assert.ok(
+    representative.track.every((point) => point.altitudeMetresMsl <= 300),
+  );
+
+  const lowEnvelope = forecastLandingEnvelope({
+    field,
+    launch,
+    launchElevationMetresMsl: 100,
+    altitudeCeilingMetresMsl: 100,
+    minimumDurationMinutes: 40,
+    maximumDurationMinutes: 40,
+  });
+  const highEnvelope = forecastLandingEnvelope({
+    field,
+    launch,
+    launchElevationMetresMsl: 100,
+    altitudeCeilingMetresMsl: 1000,
+    minimumDurationMinutes: 40,
+    maximumDurationMinutes: 40,
+  });
+  assert.ok(lowEnvelope.candidates.every((candidate) => candidate.peakAltitudeMetresMsl <= 100));
+  assert.ok(highEnvelope.candidates.some((candidate) => candidate.peakAltitudeMetresMsl > 100));
+  assert.notDeepEqual(lowEnvelope.boundary, highEnvelope.boundary);
+  const constrainedRoute = planWindRouteToDestination({
+    field,
+    launch,
+    destination: highEnvelope.candidates.at(-1).landing,
+    launchElevationMetresMsl: 100,
+    altitudeCeilingMetresMsl: 300,
+    minimumDurationMinutes: 40,
+    maximumDurationMinutes: 40,
+  });
+  assert.ok(constrainedRoute.peakAltitudeMetresMsl <= 300);
+  assert.ok(constrainedRoute.controlAltitudesMetresMsl.every((altitude) => altitude <= 300));
+});
+
 test("wind routing chooses duration automatically and refines a reachable endpoint within 100 m", () => {
   const launch = { latitude: 51.5, longitude: -2.5 };
   const vector = { altitudeMetresMsl: 100, speedKmh: 36, fromDegrees: 270 };

--- a/apps/planner/styles.css
+++ b/apps/planner/styles.css
@@ -112,7 +112,6 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .status:empty { display: none; }
 .status.error { color: #ffaaa0; }
 .status.good { color: #9be5bb; }
-.route-strategy { margin: 0.55rem 0 0; padding: 0.65rem 0.7rem; border: 1px solid #655a84; border-radius: 0.65rem; background: #1d1928; color: #d9cdf7; font-size: 0.76rem; line-height: 1.35; font-weight: 750; }
 .search-limits { margin: 0.75rem 0 0; padding: 0.65rem 0.75rem; border-left: 3px solid var(--purple); background: color-mix(in srgb, var(--purple) 9%, transparent); color: var(--muted); }
 .muted { color: var(--muted); }
 .small { font-size: 0.75rem; line-height: 1.45; }
@@ -121,6 +120,7 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
 .compact-fields { margin-top: 0.1rem; }
 .compact-fields .field { margin-top: 0.65rem; }
+.ceiling-field { margin-top: 0.7rem; padding-top: 0.65rem; border-top: 1px solid var(--line); }
 input[type="text"], input[type="search"], input[type="number"], input[type="date"] {
   width: 100%;
   min-width: 0;
@@ -200,7 +200,7 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 
 .map-shell { position: relative; min-height: 42rem; background: #11141a; overflow: hidden; }
 .map { position: absolute; inset: 0; }
-.map-prompt, .forecast-summary, .map-legend, .map-status {
+.map-prompt, .forecast-summary, .flight-profile-pane, .map-legend, .map-status {
   position: absolute;
   z-index: 2;
   background: rgb(17 21 28 / 0.93);
@@ -216,6 +216,29 @@ summary { cursor: pointer; font-weight: 750; font-size: 0.82rem; }
 .forecast-summary { top: 1rem; right: 1rem; border-radius: 0.75rem; padding: 0.7rem 0.85rem; display: grid; gap: 0.15rem; }
 .forecast-summary strong { color: var(--sky); }
 .forecast-summary span { color: var(--muted); font-size: 0.72rem; }
+.flight-profile-pane { top: 5.25rem; right: 1rem; width: min(23rem, calc(100% - 2rem)); border-radius: 0.75rem; padding: 0.75rem 0.85rem; }
+.profile-pane-heading { display: flex; align-items: end; justify-content: space-between; gap: 0.75rem; padding-bottom: 0.55rem; border-bottom: 1px solid var(--line); }
+.profile-pane-heading > div { display: grid; gap: 0.1rem; }
+.profile-pane-heading > div > span { color: var(--muted); font-size: 0.66rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; }
+.profile-pane-heading strong { color: var(--sky); font-size: 0.95rem; }
+.profile-pane-heading > span { color: var(--muted); font-size: 0.68rem; font-weight: 750; }
+.profile-times { display: grid; grid-template-columns: 1fr 1fr auto; gap: 0.75rem; padding: 0.55rem 0; border-bottom: 1px solid var(--line); }
+.profile-times div { display: grid; gap: 0.08rem; }
+.profile-times span { color: var(--muted); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.profile-times strong { font-size: 0.72rem; font-variant-numeric: tabular-nums; }
+.profile-window { margin: 0; padding: 0.42rem 0 0.1rem; color: var(--purple); font-size: 0.68rem; font-weight: 750; }
+.flight-profile-pane table { width: 100%; border-collapse: collapse; margin-top: 0.35rem; font-size: 0.68rem; font-variant-numeric: tabular-nums; }
+.flight-profile-pane th { color: var(--muted); font-size: 0.6rem; text-align: left; text-transform: uppercase; letter-spacing: 0.06em; }
+.flight-profile-pane th,
+.flight-profile-pane td { padding: 0.28rem 0.25rem; border-bottom: 1px solid color-mix(in srgb, var(--line) 72%, transparent); }
+.flight-profile-pane th:first-child,
+.flight-profile-pane td:first-child { padding-left: 0; }
+.flight-profile-pane th:last-child,
+.flight-profile-pane td:last-child { padding-right: 0; text-align: right; }
+.flight-profile-pane tbody tr:last-child td { border-bottom: 0; }
+.flight-profile-pane .climb { color: var(--green); }
+.flight-profile-pane .descent { color: var(--sun); }
+.flight-profile-pane .level { color: var(--muted); }
 .map-legend { left: 1rem; bottom: 1.25rem; border-radius: 0.7rem; padding: 0.7rem; display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem 0.8rem; font-size: 0.7rem; color: #d7dce5; }
 .map-legend span { display: flex; align-items: center; gap: 0.4rem; }
 .legend-dot { width: 0.7rem; height: 0.7rem; border-radius: 50%; border: 2px solid #11151c; box-shadow: 0 0 0 1px currentColor; }
@@ -279,7 +302,6 @@ footer { min-height: 2.7rem; padding: 0.75rem 1rem; display: flex; justify-conte
 :root[data-theme="light"] details { background: #ffffff; }
 :root[data-theme="light"] .generate-section { background: #eee9e2; }
 :root[data-theme="light"] .code-result { background: #f8fbfc; }
-:root[data-theme="light"] .route-strategy { background: #eee9f7; color: #493b72; border-color: #a89acb; }
 :root[data-theme="light"] .status.good,
 :root[data-theme="light"] .map-status.good { color: #14683f; }
 :root[data-theme="light"] .status.error,
@@ -288,6 +310,7 @@ footer { min-height: 2.7rem; padding: 0.75rem 1rem; display: flex; justify-conte
 :root[data-theme="light"] .map-shell { background: #e2e6e9; }
 :root[data-theme="light"] .map-prompt,
 :root[data-theme="light"] .forecast-summary,
+:root[data-theme="light"] .flight-profile-pane,
 :root[data-theme="light"] .map-legend,
 :root[data-theme="light"] .map-status { background: rgb(255 255 255 / 0.92); color: #49434d; }
 :root[data-theme="light"] .map-legend { color: #3b3640; }
@@ -309,5 +332,6 @@ footer { min-height: 2.7rem; padding: 0.75rem 1rem; display: flex; justify-conte
   .field-grid { grid-template-columns: 1fr; }
   .map-legend { right: 0.65rem; left: 0.65rem; bottom: 0.65rem; }
   .forecast-summary { top: 3.8rem; right: 0.65rem; }
+  .flight-profile-pane { top: 7.4rem; right: 0.65rem; width: calc(100% - 1.3rem); max-height: calc(100% - 12rem); overflow-y: auto; }
   .map-prompt { width: calc(100% - 1.3rem); text-align: center; }
 }


### PR DESCRIPTION
## Summary
- add a pilot-selected maximum-altitude slider up to the 2,000 m MSL forecast limit
- constrain the representative track, landing envelope and destination optimiser to the selected ceiling
- accept a destination on the next map click after launch without requiring the placement button
- make the initial yellow forecast endpoint draggable and convert it into the intended destination
- add a map-side flight-profile pane with start, landing, duration, matching window, six timed altitude stages and climb/descent changes
- keep calculated landing and intended destination visually distinct after optimisation

## Verification
- `node --test apps/planner/pages-worker.test.mjs apps/planner/planner-core.test.mjs` (27 passed)
- `node --check apps/planner/app.js`
- `node --check apps/planner/_worker.js`
- local Chrome: 300 m ceiling reduced envelope to 288 candidates versus 640 at 1,000 m; direct map destination, draggable first endpoint, six-stage profile, start/landing times, matching window and no console errors verified

Closes #52