### PR TITLE
feat: open flight planner from the mobile app

### DIFF
--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -34,6 +34,7 @@ import '../../services/build_identity.dart';
 import '../../services/basemap_configuration.dart';
 import '../../services/carplay_bridge.dart';
 import '../../services/gpx_import_source.dart';
+import '../../services/flight_planner_launcher.dart';
 import '../../services/stored_route_library.dart';
 import '../map/stored_route_picker.dart';
 import '../ride/previous_rides_screen.dart';
@@ -66,6 +67,7 @@ class HomeScreen extends StatefulWidget {
     this.openJoinGroup = false,
     this.onJoinGroupOpened,
     this.enableNativeServices = true,
+    this.flightPlannerLauncher = const FlightPlannerLauncher(),
   });
 
   final RideController controller;
@@ -106,6 +108,11 @@ class HomeScreen extends StatefulWidget {
   /// False in widget tests and plugin-less builds; the map backdrop stands
   /// down rather than waiting on a platform map that will never load.
   final bool enableNativeServices;
+
+  /// Opens the shared production pilot planner in the platform browser view.
+  /// Injected in tests so discoverability and failure handling do not require a
+  /// native browser plugin.
+  final FlightPlannerLauncher flightPlannerLauncher;
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -488,9 +495,21 @@ class _HomeScreenState extends State<HomeScreen> {
       useSafeArea: true,
       backgroundColor: const Color(0xFF171D25),
       builder: (sheetContext) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
+        child: ListView(
+          shrinkWrap: true,
           children: [
+            ListTile(
+              key: const Key('open-flight-planner'),
+              leading: const Icon(Icons.air_outlined),
+              title: const Text('Plan a balloon flight'),
+              subtitle: const Text(
+                'Wind route, landing envelope and timed altitude profile',
+              ),
+              onTap: () {
+                Navigator.of(sheetContext).pop();
+                unawaited(_openFlightPlanner());
+              },
+            ),
             ListTile(
               key: const Key('start-ride-simulator'),
               leading: const Icon(Icons.science_outlined),
@@ -545,6 +564,23 @@ class _HomeScreenState extends State<HomeScreen> {
               },
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openFlightPlanner() async {
+    var opened = false;
+    try {
+      opened = await widget.flightPlannerLauncher.open();
+    } on Object {
+      opened = false;
+    }
+    if (!mounted || opened) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text(
+          'Could not open the flight planner. Check your connection and try again.',
         ),
       ),
     );

--- a/apps/mobile/lib/services/flight_planner_launcher.dart
+++ b/apps/mobile/lib/services/flight_planner_launcher.dart
@@ -1,0 +1,23 @@
+import 'package:url_launcher/url_launcher.dart';
+
+typedef FlightPlannerUriOpener = Future<bool> Function(Uri uri);
+
+/// Opens the production pilot planner without sending the user out of the app.
+///
+/// Keeping the forecast UI hosted means the app and website use the same wind
+/// model, safety wording and current route-search implementation. The platform
+/// browser view still gives iOS and Android an obvious close control.
+class FlightPlannerLauncher {
+  const FlightPlannerLauncher({this.openUri});
+
+  static final plannerUri = Uri.https('balloon-crumbs.pages.dev', '/', const {
+    'source': 'mobile-app',
+  });
+
+  final FlightPlannerUriOpener? openUri;
+
+  Future<bool> open() => (openUri ?? _openInAppBrowser)(plannerUri);
+}
+
+Future<bool> _openInAppBrowser(Uri uri) =>
+    launchUrl(uri, mode: LaunchMode.inAppBrowserView);

--- a/apps/mobile/test/features/home/home_reachability_test.dart
+++ b/apps/mobile/test/features/home/home_reachability_test.dart
@@ -21,6 +21,7 @@ import 'package:balloon_crumbs/features/home/home_screen.dart';
 import 'package:balloon_crumbs/features/map/craft_icon.dart';
 import 'package:balloon_crumbs/internet/internet_relay_client.dart';
 import 'package:balloon_crumbs/services/nearby_bridge.dart';
+import 'package:balloon_crumbs/services/flight_planner_launcher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Every way into the app, by the words a rider can read (#306).
@@ -81,7 +82,10 @@ void main() {
     completedRides.dispose();
   });
 
-  Future<void> pumpHome(WidgetTester tester) async {
+  Future<void> pumpHome(
+    WidgetTester tester, {
+    FlightPlannerLauncher flightPlannerLauncher = const FlightPlannerLauncher(),
+  }) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData.dark(useMaterial3: true),
@@ -99,6 +103,7 @@ void main() {
           // wait forever here on a platform map and a location plugin that
           // never answer, and pumpAndSettle would time out.
           enableNativeServices: false,
+          flightPlannerLauncher: flightPlannerLauncher,
         ),
       ),
     );
@@ -196,6 +201,49 @@ void main() {
 
     expect(find.text('Try a simulated ride'), findsOneWidget);
     expect(find.text('Record a route'), findsOneWidget);
+  });
+
+  testWidgets('the balloon flight planner is reachable and opens in place', (
+    tester,
+  ) async {
+    Uri? openedUri;
+    await pumpHome(
+      tester,
+      flightPlannerLauncher: FlightPlannerLauncher(
+        openUri: (uri) async {
+          openedUri = uri;
+          return true;
+        },
+      ),
+    );
+
+    await tester.tap(find.text('More'));
+    await tester.pumpAndSettle();
+    expect(find.text('Plan a balloon flight'), findsOneWidget);
+    expect(find.textContaining('timed altitude profile'), findsOneWidget);
+
+    await tester.tap(find.text('Plan a balloon flight'));
+    await tester.pumpAndSettle();
+
+    expect(openedUri, FlightPlannerLauncher.plannerUri);
+    expect(openedUri?.host, 'balloon-crumbs.pages.dev');
+  });
+
+  testWidgets('a flight planner launch failure is explained', (tester) async {
+    await pumpHome(
+      tester,
+      flightPlannerLauncher: FlightPlannerLauncher(openUri: (_) async => false),
+    );
+
+    await tester.tap(find.text('More'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Plan a balloon flight'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Could not open the flight planner'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('joining by QR is offered in words, not only as an icon', (

--- a/apps/mobile/test/services/flight_planner_launcher_test.dart
+++ b/apps/mobile/test/services/flight_planner_launcher_test.dart
@@ -1,0 +1,23 @@
+import 'package:balloon_crumbs/services/flight_planner_launcher.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'opens the production planner with a mobile-app source marker',
+    () async {
+      Uri? openedUri;
+      final launcher = FlightPlannerLauncher(
+        openUri: (uri) async {
+          openedUri = uri;
+          return true;
+        },
+      );
+
+      expect(await launcher.open(), isTrue);
+      expect(openedUri?.scheme, 'https');
+      expect(openedUri?.host, 'balloon-crumbs.pages.dev');
+      expect(openedUri?.path, '/');
+      expect(openedUri?.queryParameters, const {'source': 'mobile-app'});
+    },
+  );
+}

--- a/docs/tester-release-notes.md
+++ b/docs/tester-release-notes.md
@@ -5,6 +5,16 @@ version, Play version code, commit, destination track, and recent changes. Copy
 the tester-facing entry here after each release so an installed build can be
 matched to its changes.
 
+## Next tester build
+
+- Adds **Plan a balloon flight** to the home map's More menu and opens the live
+  planner in the iOS/Android in-app browser.
+- Includes the planner's maximum-altitude landing envelope, draggable launch
+  and destination points, wind-route search, and timed altitude profile without
+  maintaining a second forecast implementation in the app.
+- Keeps the planner's Open-Meteo/OpenAIP source labels and advisory safety
+  warning visible.
+
 ## 1.0.1 (Play build 26 / TestFlight build 27) — 21 August 2026
 
 - Adds UKMO forecast wind from Open-Meteo to the balloon map, with downwind


### PR DESCRIPTION
## Summary
- add a clearly labelled **Plan a balloon flight** action to the home map More menu
- open the production planner in the platform in-app browser so mobile and web share the max-altitude envelope, draggable endpoints, wind optimisation and timed altitude profile
- make the expanded More sheet scroll on short screens and report launch failures in plain language
- add tester release notes and coverage for discoverability, URL selection, success and failure

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (1,710 passed; 24 expected skips)

Closes #54