### PR TITLE
feat: make vertical rate limits adjustable

### DIFF
--- a/apps/planner/README.md
+++ b/apps/planner/README.md
@@ -14,8 +14,9 @@ pretend a balloon follows a road route:
 - the destination optimiser searches start times across the selected day,
   10–180 minute durations and four changing altitude controls up to the highest
   pilot-selected maximum altitude, bounded by the highest 2,000 m MSL forecast
-  layer; the same ceiling constrains the representative track and landing
-  envelope;
+  layer; independent pilot-selected maximum ascent and descent rates constrain
+  every altitude stage, and the same ceiling and rate limits constrain the
+  representative track and landing envelope;
 - start time, an approximate matching window for the selected profile, duration,
   altitude profile and resulting peak altitude are optimiser outputs rather than
   pilot-supplied route inputs;
@@ -27,8 +28,9 @@ pretend a balloon follows a road route:
   destination reruns the optimiser without a separate placement action;
 - after launch, the next map click sets the destination directly, while dragging
   the initial yellow forecast endpoint converts it into the intended destination;
-- a flight-profile pane lists launch and landing times, duration, the altitude at
-  each 20% stage and each climb, level or descent change;
+- a flight-profile pane lists launch and landing times, duration, selected
+  vertical-rate limits, the altitude at each 20% stage and each climb, level or
+  descent rate;
 - the compact control panel keeps route inputs and results together, with wind,
   chart and sharing controls grouped below and longer guidance in disclosures;
 - the basemap and planner controls can switch between light and dark themes,
@@ -70,5 +72,6 @@ These are forecasts, not aviation briefings or primary navigation. The planner
 does not present a track as controllable, and it does not hide missing forecast
 data behind a synthetic fallback. The landing envelope is not a safe-landing
 assessment and does not mean that every point inside it is reachable. The
-destination search does not account for airspace, terrain, legal limits, burner
-fuel, or the balloon's actual climb and descent performance.
+destination search does not account for airspace, terrain, legal limits or
+burner fuel. Its ascent and descent limits are pilot inputs; it cannot determine
+whether those values suit a balloon, conditions or phase of flight.

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -78,6 +78,10 @@ const elements = Object.fromEntries(
     "landing-status",
     "max-altitude",
     "max-altitude-label",
+    "max-ascent-rate",
+    "max-ascent-rate-label",
+    "max-descent-rate",
+    "max-descent-rate-label",
     "map",
     "map-prompt",
     "map-status",
@@ -756,6 +760,13 @@ function syncMaxAltitudeControl() {
     `${Number(elements.max_altitude.value).toLocaleString("en-GB")} m MSL`;
 }
 
+function syncVerticalRateControls() {
+  elements.max_ascent_rate_label.textContent =
+    `${Number(elements.max_ascent_rate.value).toFixed(1)} m/s`;
+  elements.max_descent_rate_label.textContent =
+    `${Number(elements.max_descent_rate.value).toFixed(1)} m/s`;
+}
+
 function validLaunchSettings() {
   const launchElevationMetresMsl = Number(elements.launch_elevation.value);
   if (
@@ -773,7 +784,24 @@ function validLaunchSettings() {
   ) {
     throw new Error("Choose a maximum altitude between launch elevation and 2,000 m MSL.");
   }
-  return { launchElevationMetresMsl, altitudeCeilingMetresMsl };
+  const maximumAscentRateMetresPerSecond = Number(elements.max_ascent_rate.value);
+  const maximumDescentRateMetresPerSecond = Number(elements.max_descent_rate.value);
+  if (
+    !Number.isFinite(maximumAscentRateMetresPerSecond) ||
+    maximumAscentRateMetresPerSecond < 0.1 ||
+    maximumAscentRateMetresPerSecond > 10 ||
+    !Number.isFinite(maximumDescentRateMetresPerSecond) ||
+    maximumDescentRateMetresPerSecond < 0.1 ||
+    maximumDescentRateMetresPerSecond > 10
+  ) {
+    throw new Error("Choose maximum ascent and descent rates between 0.1 and 10.0 m/s.");
+  }
+  return {
+    launchElevationMetresMsl,
+    altitudeCeilingMetresMsl,
+    maximumAscentRateMetresPerSecond,
+    maximumDescentRateMetresPerSecond,
+  };
 }
 
 function formatMissDistance(distanceMetres) {
@@ -788,7 +816,12 @@ function renderFlightProfile() {
     elements.profile_stages.replaceChildren();
     return;
   }
-  const { launchElevationMetresMsl, altitudeCeilingMetresMsl } = validLaunchSettings();
+  const {
+    launchElevationMetresMsl,
+    altitudeCeilingMetresMsl,
+    maximumAscentRateMetresPerSecond,
+    maximumDescentRateMetresPerSecond,
+  } = validLaunchSettings();
   const departureAt = state.routePlan.departureAt;
   const durationMinutes = state.routePlan.durationMinutes;
   const landingAt = new Date(departureAt.getTime() + durationMinutes * 60_000);
@@ -810,7 +843,9 @@ function renderFlightProfile() {
   elements.flight_profile_title.textContent =
     state.routePlan.kind === "representative" ? "Representative forecast" : "Optimised forecast";
   elements.profile_limit.textContent =
-    `Maximum ${altitudeCeilingMetresMsl.toLocaleString("en-GB")} m MSL`;
+    `Ceiling ${altitudeCeilingMetresMsl.toLocaleString("en-GB")} m · ` +
+    `↑ ${maximumAscentRateMetresPerSecond.toFixed(1)} · ` +
+    `↓ ${maximumDescentRateMetresPerSecond.toFixed(1)} m/s`;
   elements.profile_start.textContent = formatLocalDateTime(departureAt);
   elements.profile_landing.textContent = formatLocalDateTime(landingAt);
   elements.profile_duration.textContent = `${durationMinutes.toFixed(1)} min`;
@@ -839,11 +874,13 @@ function renderFlightProfile() {
       change.className = "level";
     } else {
       const difference = roundedAltitude - Math.round(altitudes[index - 1]);
+      const rateMetresPerSecond =
+        Math.abs(difference) / (durationMinutes * 60 * 0.2);
       change.textContent =
         difference > 0
-          ? `↑ ${difference.toLocaleString("en-GB")} m`
+          ? `↑ ${difference.toLocaleString("en-GB")} m · ${rateMetresPerSecond.toFixed(1)} m/s`
           : difference < 0
-            ? `↓ ${Math.abs(difference).toLocaleString("en-GB")} m`
+            ? `↓ ${Math.abs(difference).toLocaleString("en-GB")} m · ${rateMetresPerSecond.toFixed(1)} m/s`
             : "—";
       change.className = difference > 0 ? "climb" : difference < 0 ? "descent" : "level";
     }
@@ -1169,6 +1206,10 @@ function bindControls() {
   });
   elements.max_altitude.addEventListener("input", syncMaxAltitudeControl);
   elements.max_altitude.addEventListener("change", () => recomputeTrack({ fit: true }));
+  elements.max_ascent_rate.addEventListener("input", syncVerticalRateControls);
+  elements.max_ascent_rate.addEventListener("change", () => recomputeTrack({ fit: true }));
+  elements.max_descent_rate.addEventListener("input", syncVerticalRateControls);
+  elements.max_descent_rate.addEventListener("change", () => recomputeTrack({ fit: true }));
   elements.generate_code.addEventListener("click", () => void generatePlanCode());
   elements.copy_code.addEventListener("click", () => void copyPlanCode());
 }
@@ -1178,6 +1219,7 @@ async function start() {
   applyMapTheme();
   configureDepartureInput();
   syncMaxAltitudeControl();
+  syncVerticalRateControls();
   updateClock();
   window.setInterval(updateClock, 1_000);
   bindControls();

--- a/apps/planner/index.html
+++ b/apps/planner/index.html
@@ -78,6 +78,16 @@
             <span>Maximum altitude <strong id="max-altitude-label">2,000 m MSL</strong></span>
             <input type="range" id="max-altitude" min="100" max="2000" step="50" value="2000" />
           </label>
+          <div class="vertical-rate-fields" aria-label="Vertical rate limits">
+            <label class="range-field">
+              <span>Maximum ascent <strong id="max-ascent-rate-label">5.0 m/s</strong></span>
+              <input type="range" id="max-ascent-rate" min="0.1" max="10" step="0.1" value="5" />
+            </label>
+            <label class="range-field">
+              <span>Maximum descent <strong id="max-descent-rate-label">5.0 m/s</strong></span>
+              <input type="range" id="max-descent-rate" min="0.1" max="10" step="0.1" value="5" />
+            </label>
+          </div>
           <div class="subsection-heading">
             <strong>Destination</strong>
             <span>Click the map directly or drag the yellow endpoint</span>
@@ -90,7 +100,7 @@
           <p class="status" id="route-status" role="status">Set a launch point to calculate the landing envelope.</p>
           <details class="panel-help">
             <summary>Planner help, safety and data</summary>
-            <p class="small muted">The search varies the remaining start times on the selected day, a 10–180 minute duration and four altitude controls up to the selected maximum altitude. The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match. The optimiser does not assess airspace, terrain, legal limits, fuel or the balloon’s actual climb/descent performance.</p>
+            <p class="small muted">The search varies the remaining start times on the selected day, a 10–180 minute duration and four altitude controls up to the selected maximum altitude, while respecting the selected maximum ascent and descent rates. The purple boundary is a convex envelope of coarse forecast endpoints, not a guarantee that every point inside it is reachable or suitable for landing. A result within 100 m is marked as a forecast match. The rate limits are pilot inputs: the planner cannot verify that they suit the balloon, conditions or phase of flight, and it does not assess airspace, terrain, legal limits or fuel.</p>
             <p class="small muted place-search-credit">Submit-only search using © OpenStreetMap contributors, ODbL. Do not enter personal or confidential information.</p>
           </details>
         </section>

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -6,6 +6,8 @@ const EARTH_RADIUS_METRES = 6_371_000;
 const DEFAULT_STEP_SECONDS = 60;
 export const WIND_GRID_SIDE_POINTS = 5;
 export const WIND_GRID_SPAN_METRES = 120_000;
+export const DEFAULT_MAXIMUM_ASCENT_RATE_METRES_PER_SECOND = 5;
+export const DEFAULT_MAXIMUM_DESCENT_RATE_METRES_PER_SECOND = 5;
 export const ROUTE_SEARCH_LIMITS = Object.freeze({
   minimumDurationMinutes: 10,
   maximumDurationMinutes: 180,
@@ -22,6 +24,32 @@ function finiteNumber(value, label) {
   const number = Number(value);
   if (!Number.isFinite(number)) throw new TypeError(`${label} must be finite.`);
   return number;
+}
+
+function verticalRateLimits(options) {
+  const legacyLimit = options.maximumVerticalRateMetresPerSecond;
+  const maximumAscentRateMetresPerSecond = finiteNumber(
+    options.maximumAscentRateMetresPerSecond ??
+      legacyLimit ??
+      DEFAULT_MAXIMUM_ASCENT_RATE_METRES_PER_SECOND,
+    "maximum ascent rate",
+  );
+  const maximumDescentRateMetresPerSecond = finiteNumber(
+    options.maximumDescentRateMetresPerSecond ??
+      legacyLimit ??
+      DEFAULT_MAXIMUM_DESCENT_RATE_METRES_PER_SECOND,
+    "maximum descent rate",
+  );
+  if (
+    maximumAscentRateMetresPerSecond <= 0 ||
+    maximumDescentRateMetresPerSecond <= 0
+  ) {
+    throw new RangeError("Maximum ascent and descent rates must be greater than zero.");
+  }
+  return {
+    maximumAscentRateMetresPerSecond,
+    maximumDescentRateMetresPerSecond,
+  };
 }
 
 function validPoint(point, label = "point") {
@@ -482,6 +510,9 @@ export function forecastRepresentativeRoute({
   departureOffsetMinutes = 0,
   durationMinutes = REPRESENTATIVE_FORECAST_DEFAULTS.durationMinutes,
   cruiseAltitudeMetresMsl = REPRESENTATIVE_FORECAST_DEFAULTS.cruiseAltitudeMetresMsl,
+  maximumAscentRateMetresPerSecond,
+  maximumDescentRateMetresPerSecond,
+  maximumVerticalRateMetresPerSecond,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
   const launchElevation = finiteNumber(launchElevationMetresMsl, "launch elevation");
@@ -491,11 +522,22 @@ export function forecastRepresentativeRoute({
   }
   const departureOffset = finiteNumber(departureOffsetMinutes, "departure offset");
   if (departureOffset < 0) throw new RangeError("Departure offset must not be negative.");
+  const duration = finiteNumber(durationMinutes, "flight duration");
+  const rateLimits = verticalRateLimits({
+    maximumAscentRateMetresPerSecond,
+    maximumDescentRateMetresPerSecond,
+    maximumVerticalRateMetresPerSecond,
+  });
+  const maximumRateLimitedGainMetres = Math.min(
+    rateLimits.maximumAscentRateMetresPerSecond * duration * 60 * 0.2,
+    rateLimits.maximumDescentRateMetresPerSecond * duration * 60 * 0.3,
+  );
   const peakAltitudeMetresMsl = Math.max(
     launchElevation,
     Math.min(
       altitudeCeiling,
       finiteNumber(cruiseAltitudeMetresMsl, "representative cruise altitude"),
+      launchElevation + maximumRateLimitedGainMetres,
     ),
   );
   const track = forecastFlightTrack({
@@ -503,7 +545,7 @@ export function forecastRepresentativeRoute({
     launch,
     launchElevationMetresMsl: launchElevation,
     maximumAltitudeMetresMsl: peakAltitudeMetresMsl,
-    durationMinutes,
+    durationMinutes: duration,
     departureOffsetSeconds: departureOffset * 60,
     stepSeconds,
   });
@@ -520,9 +562,10 @@ export function forecastRepresentativeRoute({
     kind: "representative",
     departureOffsetMinutes: departureOffset,
     departureAt: new Date(forecastStart.getTime() + departureOffset * 60_000),
-    durationMinutes: finiteNumber(durationMinutes, "flight duration"),
+    durationMinutes: duration,
     altitudeCeilingMetresMsl: altitudeCeiling,
     peakAltitudeMetresMsl,
+    ...rateLimits,
     track,
     landing: track.at(-1),
   });
@@ -626,7 +669,8 @@ function profileIsFeasible({
   launchElevationMetresMsl,
   altitudeCeilingMetresMsl,
   durationMinutes,
-  maximumVerticalRateMetresPerSecond,
+  maximumAscentRateMetresPerSecond,
+  maximumDescentRateMetresPerSecond,
 }) {
   const launch = finiteNumber(launchElevationMetresMsl, "launch elevation");
   const ceiling = finiteNumber(altitudeCeilingMetresMsl, "altitude ceiling");
@@ -639,11 +683,13 @@ function profileIsFeasible({
   ) {
     return false;
   }
-  return altitudes.slice(1).every(
-    (altitude, index) =>
-      Math.abs(altitude - altitudes[index]) / segmentSeconds <=
-      maximumVerticalRateMetresPerSecond,
-  );
+  return altitudes.slice(1).every((altitude, index) => {
+    const changeMetres = altitude - altitudes[index];
+    const rateMetresPerSecond = Math.abs(changeMetres) / segmentSeconds;
+    return changeMetres >= 0
+      ? rateMetresPerSecond <= maximumAscentRateMetresPerSecond
+      : rateMetresPerSecond <= maximumDescentRateMetresPerSecond;
+  });
 }
 
 function convexHull(points) {
@@ -683,7 +729,8 @@ function coarseLandingCandidates({
   minimumDurationMinutes,
   maximumDurationMinutes,
   altitudeCeilingMetresMsl,
-  maximumVerticalRateMetresPerSecond,
+  maximumAscentRateMetresPerSecond,
+  maximumDescentRateMetresPerSecond,
   departureOffsetMinutes = 0,
   stepSeconds = DEFAULT_STEP_SECONDS,
 }) {
@@ -709,7 +756,8 @@ function coarseLandingCandidates({
             launchElevationMetresMsl,
             altitudeCeilingMetresMsl,
             durationMinutes,
-            maximumVerticalRateMetresPerSecond,
+            maximumAscentRateMetresPerSecond,
+            maximumDescentRateMetresPerSecond,
           })
         ) {
           continue;
@@ -746,7 +794,8 @@ function coarseFlexibleStartCandidates({
   minimumDurationMinutes,
   maximumDurationMinutes,
   altitudeCeilingMetresMsl,
-  maximumVerticalRateMetresPerSecond,
+  maximumAscentRateMetresPerSecond,
+  maximumDescentRateMetresPerSecond,
   minimumDepartureOffsetMinutes,
   maximumDepartureOffsetMinutes,
   departureSearchStepMinutes,
@@ -771,7 +820,8 @@ function coarseFlexibleStartCandidates({
             launchElevationMetresMsl,
             altitudeCeilingMetresMsl,
             durationMinutes,
-            maximumVerticalRateMetresPerSecond,
+            maximumAscentRateMetresPerSecond,
+            maximumDescentRateMetresPerSecond,
           })
         ) {
           continue;
@@ -807,7 +857,7 @@ function routeSearchSettings(options) {
     options.maximumDurationMinutes ?? ROUTE_SEARCH_LIMITS.maximumDurationMinutes;
   const altitudeCeilingMetresMsl =
     options.altitudeCeilingMetresMsl ?? ROUTE_SEARCH_LIMITS.altitudeCeilingMetresMsl;
-  const maximumVerticalRateMetresPerSecond = options.maximumVerticalRateMetresPerSecond ?? 5;
+  const rateLimits = verticalRateLimits(options);
   const minimumDepartureOffsetMinutes = options.minimumDepartureOffsetMinutes ?? 0;
   const maximumDepartureOffsetMinutes =
     options.maximumDepartureOffsetMinutes ?? minimumDepartureOffsetMinutes;
@@ -825,7 +875,7 @@ function routeSearchSettings(options) {
     minimumDurationMinutes,
     maximumDurationMinutes,
     altitudeCeilingMetresMsl,
-    maximumVerticalRateMetresPerSecond,
+    ...rateLimits,
     minimumDepartureOffsetMinutes,
     maximumDepartureOffsetMinutes,
     departureSearchStepMinutes,
@@ -941,7 +991,10 @@ export function planWindRouteToDestination(options) {
         launchElevationMetresMsl,
         altitudeCeilingMetresMsl: settings.altitudeCeilingMetresMsl,
         durationMinutes: boundedDurationMinutes,
-        maximumVerticalRateMetresPerSecond: settings.maximumVerticalRateMetresPerSecond,
+        maximumAscentRateMetresPerSecond:
+          settings.maximumAscentRateMetresPerSecond,
+        maximumDescentRateMetresPerSecond:
+          settings.maximumDescentRateMetresPerSecond,
       })
     ) {
       evaluationCache.set(key, null);

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -215,6 +215,22 @@ test("launch-only forecast reports a representative track and flight details", (
   assert.ok(route.landing.longitude > route.track[0].longitude);
 });
 
+test("representative forecast respects independent ascent and descent limits", () => {
+  const field = parseOpenMeteoForecast(payload(), new Date("2026-08-21T08:00:00Z"));
+  const route = forecastRepresentativeRoute({
+    field,
+    launch: { latitude: 51.5, longitude: -2.5 },
+    launchElevationMetresMsl: 100,
+    durationMinutes: 60,
+    cruiseAltitudeMetresMsl: 1000,
+    maximumAscentRateMetresPerSecond: 0.2,
+    maximumDescentRateMetresPerSecond: 0.1,
+  });
+  assert.equal(route.peakAltitudeMetresMsl, 208);
+  assert.equal(route.maximumAscentRateMetresPerSecond, 0.2);
+  assert.equal(route.maximumDescentRateMetresPerSecond, 0.1);
+});
+
 test("maximum altitude constrains the representative track and landing envelope", () => {
   const source = payload();
   for (const altitude of WIND_LEVELS_METRES_MSL) {
@@ -264,6 +280,63 @@ test("maximum altitude constrains the representative track and landing envelope"
   });
   assert.ok(constrainedRoute.peakAltitudeMetresMsl <= 300);
   assert.ok(constrainedRoute.controlAltitudesMetresMsl.every((altitude) => altitude <= 300));
+});
+
+test("landing envelope applies adjustable ascent and descent limits independently", () => {
+  const field = parseOpenMeteoForecast(payload(), new Date("2026-08-21T08:00:00Z"));
+  const settings = {
+    field,
+    launch: { latitude: 51.5, longitude: -2.5 },
+    launchElevationMetresMsl: 100,
+    altitudeCeilingMetresMsl: 1000,
+    minimumDurationMinutes: 10,
+    maximumDurationMinutes: 10,
+  };
+  const ascentLimited = forecastLandingEnvelope({
+    ...settings,
+    maximumAscentRateMetresPerSecond: 0.5,
+    maximumDescentRateMetresPerSecond: 10,
+  });
+  const descentLimited = forecastLandingEnvelope({
+    ...settings,
+    maximumAscentRateMetresPerSecond: 10,
+    maximumDescentRateMetresPerSecond: 0.5,
+  });
+  const segmentSeconds = 120;
+  const rates = (candidate) => {
+    const altitudes = [100, ...candidate.controlAltitudesMetresMsl, 100];
+    return altitudes.slice(1).map(
+      (altitude, index) => (altitude - altitudes[index]) / segmentSeconds,
+    );
+  };
+  assert.ok(
+    ascentLimited.candidates.every((candidate) =>
+      rates(candidate).every((rate) => rate <= 0.5 + Number.EPSILON),
+    ),
+  );
+  assert.ok(
+    ascentLimited.candidates.some((candidate) =>
+      rates(candidate).some((rate) => rate < -0.5),
+    ),
+  );
+  assert.ok(
+    descentLimited.candidates.every((candidate) =>
+      rates(candidate).every((rate) => rate >= -0.5 - Number.EPSILON),
+    ),
+  );
+  assert.ok(
+    descentLimited.candidates.some((candidate) =>
+      rates(candidate).some((rate) => rate > 0.5),
+    ),
+  );
+  assert.throws(
+    () =>
+      forecastLandingEnvelope({
+        ...settings,
+        maximumAscentRateMetresPerSecond: 0,
+      }),
+    /greater than zero/,
+  );
 });
 
 test("wind routing chooses duration automatically and refines a reachable endpoint within 100 m", () => {

--- a/apps/planner/styles.css
+++ b/apps/planner/styles.css
@@ -121,6 +121,9 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .compact-fields { margin-top: 0.1rem; }
 .compact-fields .field { margin-top: 0.65rem; }
 .ceiling-field { margin-top: 0.7rem; padding-top: 0.65rem; border-top: 1px solid var(--line); }
+.vertical-rate-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
+.vertical-rate-fields .range-field > span { display: grid; gap: 0.08rem; }
+.vertical-rate-fields .range-field strong { font-variant-numeric: tabular-nums; }
 input[type="text"], input[type="search"], input[type="number"], input[type="date"] {
   width: 100%;
   min-width: 0;


### PR DESCRIPTION
Closes #56

## Summary
- add separate maximum ascent and descent sliders to the pilot planner
- constrain representative, envelope, and destination routes with asymmetric vertical rates
- report configured limits and actual stage rates in the flight profile
- preserve the previous 5 m/s default and legacy single-rate API option
- clarify that rate limits are advisory pilot inputs

## Verification
- `node --test apps/planner/planner-core.test.mjs`
- `node --test apps/planner/pages-worker.test.mjs`
- `node --check apps/planner/app.js`
- `node --check apps/planner/planner-core.mjs`
- `git diff --check`
- headless Chrome desktop visual QA