### PR TITLE
Fix tester plan codes and app links

### DIFF
--- a/.github/workflows/android-internal.yml
+++ b/.github/workflows/android-internal.yml
@@ -121,9 +121,17 @@ jobs:
           BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_ANDROID_APP_ID }}
         run: |
           set -euo pipefail
-          if test -z "${BALLOON_CRUMBS_API_BASE_URL:-}"; then
-            echo "::warning::No BALLOON_CRUMBS_API_BASE_URL repository variable; this build has nearby transport but no relay."
-          fi
+          case "${BALLOON_CRUMBS_API_BASE_URL:-}" in
+            https://*/api|https://*/api/) ;;
+            "")
+              echo "::error::BALLOON_CRUMBS_API_BASE_URL is required for tester releases." >&2
+              exit 1
+              ;;
+            *)
+              echo "::error::BALLOON_CRUMBS_API_BASE_URL must be an HTTPS relay base ending in /api." >&2
+              exit 1
+              ;;
+          esac
           if test -z "${BALLOON_CRUMBS_OPENAIP_API_KEY:-}"; then
             echo "::error::Missing BALLOON_CRUMBS_OPENAIP_API_KEY; tester releases must include the selected advisory airspace layer." >&2
             exit 1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -116,9 +116,17 @@ jobs:
         run: |
           set -euo pipefail
           eval "$("$GITHUB_WORKSPACE/tools/build-identity.sh" pubspec.yaml testflight "$BUILD_NUMBER" | sed 's/^/export /')"
-          if [ -z "${BALLOON_CRUMBS_API_BASE_URL:-}" ]; then
-            echo "::warning::No BALLOON_CRUMBS_API_BASE_URL repository variable; this build cannot reach a relay. Nearby transport still works and the app says so on its status card."
-          fi
+          case "${BALLOON_CRUMBS_API_BASE_URL:-}" in
+            https://*/api|https://*/api/) ;;
+            "")
+              echo "::error::BALLOON_CRUMBS_API_BASE_URL is required for tester releases." >&2
+              exit 1
+              ;;
+            *)
+              echo "::error::BALLOON_CRUMBS_API_BASE_URL must be an HTTPS relay base ending in /api." >&2
+              exit 1
+              ;;
+          esac
           if [ -z "${BALLOON_CRUMBS_OPENAIP_API_KEY:-}" ]; then
             echo "::error::Missing BALLOON_CRUMBS_OPENAIP_API_KEY; tester releases must include the selected advisory airspace layer." >&2
             exit 1

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -111,7 +111,7 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data
                     android:scheme="https"
-                    android:host="balloon-crumbs.invalid"
+                    android:host="balloon-crumbs.tailendcharlie.app"
                     android:path="/planner.html" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
@@ -120,7 +120,7 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data
                     android:scheme="https"
-                    android:host="balloon-crumbs.invalid"
+                    android:host="balloon-crumbs.tailendcharlie.app"
                     android:path="/join.html" />
             </intent-filter>
             <!-- Opening a .gpx file (Files, a browser download, Mail) with a

--- a/apps/mobile/android/app/src/main/kotlin/me/osholt/balloon_crumbs/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/me/osholt/balloon_crumbs/MainActivity.kt
@@ -293,7 +293,7 @@ class MainActivity : FlutterActivity() {
         val uri = intent.data ?: return
         if (
             uri.scheme != "https" ||
-            !uri.host.equals("balloon-crumbs.invalid", ignoreCase = true) ||
+            !uri.host.equals("balloon-crumbs.tailendcharlie.app", ignoreCase = true) ||
             uri.toString().length > 2048
         ) {
             return

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -490,7 +490,7 @@ import UserNotifications
   func handleIncomingAppLink(url: URL) {
     guard
       url.scheme == "https",
-      url.host?.lowercased() == "balloon-crumbs.invalid",
+      url.host?.lowercased() == "balloon-crumbs.tailendcharlie.app",
       url.absoluteString.count <= 2048
     else { return }
     switch url.path {

--- a/apps/mobile/lib/domain/app_links.dart
+++ b/apps/mobile/lib/domain/app_links.dart
@@ -12,20 +12,18 @@
 /// Tail End Charlie's own Apple App Site Association file, so standing this one
 /// up is a DNS record and a static file rather than a certificate and a server.
 /// Moving to a Balloon Crumbs domain later is a change to this one line, plus
-/// the two places outside Dart that have to agree with it.
+/// the native declarations and hosted association files that have to agree.
 ///
-/// **Three files must name this host, and nothing enforces it but a test.**
+/// **Every link layer must name this host, and nothing enforces it but a test.**
 ///
 ///  1. here, for building and parsing links;
-///  2. `ios/Runner/*.entitlements`, as `applinks:<host>`, or iOS will not offer
-///     the app when a link is tapped;
-///  3. `apps/website/.well-known/apple-app-site-association`, served by that
-///     host over HTTPS with no redirect, or iOS will not believe the app owns
-///     it.
+///  2. the iOS entitlement and native link bridge;
+///  3. the Android manifest and native link bridge;
+///  4. the hosted Apple and Android association files.
 ///
-/// `test/domain/app_links_test.dart` asserts all three agree. A universal link
-/// that is wrong in any one of them fails silently by opening Safari, which
-/// looks exactly like a link that was never meant to open the app.
+/// `test/domain/app_links_test.dart` asserts the checked-in layers agree. A link
+/// that is wrong in any one of them fails silently by opening the browser or by
+/// reaching the app without delivering its route code.
 library;
 
 /// The host that serves this app's association file.

--- a/apps/mobile/test/domain/app_links_test.dart
+++ b/apps/mobile/test/domain/app_links_test.dart
@@ -4,10 +4,8 @@ import 'dart:io';
 import 'package:balloon_crumbs/domain/app_links.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// A universal link needs three files to agree, and none of them can see the
-/// others: the Dart constant that builds and parses links, the iOS entitlement
-/// that lets the app claim the host, and the association file the host serves so
-/// Apple believes the claim.
+/// An app link needs independent Dart, native, platform and hosting layers to
+/// agree. None of them can see all of the others at build time.
 ///
 /// Disagreement fails silently. The link opens Safari, which is exactly what a
 /// link that was never meant to open the app does, so there is no error to
@@ -16,6 +14,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   const teamId = 'UY4624PH6X';
   const bundleId = 'dev.osholt.ballooncrumbs';
+  const playSigningSha256 =
+      'A9:B5:01:CD:17:2D:F9:45:5D:E9:54:65:31:DD:B9:5F:0A:47:59:F4:66:25:23:F4:57:BC:5D:D0:3E:36:7D:09';
 
   test('the host is real, not a reserved TLD', () {
     // The bug this replaced: `balloon-crumbs.invalid`. RFC 2606 reserves
@@ -39,6 +39,39 @@ void main() {
         entitlements,
         contains('<string>applinks:$appLinkHost</string>'),
         reason: '$name.entitlements does not claim $appLinkHost',
+      );
+    }
+  });
+
+  test('both native link bridges accept exactly this host', () {
+    final files = [
+      File('ios/Runner/AppDelegate.swift'),
+      File(
+        'android/app/src/main/kotlin/me/osholt/balloon_crumbs/MainActivity.kt',
+      ),
+      File('android/app/src/main/AndroidManifest.xml'),
+    ];
+    for (final file in files) {
+      final source = file.readAsStringSync();
+      expect(
+        source,
+        contains(appLinkHost),
+        reason: '${file.path} does not accept $appLinkHost',
+      );
+      expect(
+        source,
+        isNot(contains('balloon-crumbs.invalid')),
+        reason: '${file.path} still contains the reserved placeholder host',
+      );
+    }
+  });
+
+  test('both hosted association-file copies are identical', () {
+    for (final name in ['apple-app-site-association', 'assetlinks.json']) {
+      expect(
+        File('../planner/.well-known/$name').readAsStringSync(),
+        File('../website/.well-known/$name').readAsStringSync(),
+        reason: '$name differs between the planner and website deployments',
       );
     }
   });
@@ -89,6 +122,27 @@ void main() {
       (component) => component['/'] == rideInvitationPath,
     );
     expect(invitation.containsKey('?'), isFalse);
+  });
+
+  test('Android App Links use the Play app-signing certificate', () {
+    final statements =
+        (jsonDecode(
+                  File(
+                    '../website/.well-known/assetlinks.json',
+                  ).readAsStringSync(),
+                )
+                as List)
+            .cast<Map<String, Object?>>();
+    expect(statements, hasLength(1));
+    expect(statements.single['relation'], [
+      'delegate_permission/common.handle_all_urls',
+    ]);
+    final target = Map<String, Object?>.from(
+      statements.single['target']! as Map,
+    );
+    expect(target['namespace'], 'android_app');
+    expect(target['package_name'], bundleId);
+    expect(target['sha256_cert_fingerprints'], [playSigningSha256]);
   });
 
   test('isAppLink accepts this app own links and nothing else', () {

--- a/apps/planner/.well-known/assetlinks.json
+++ b/apps/planner/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "dev.osholt.ballooncrumbs",
+      "sha256_cert_fingerprints": [
+        "A9:B5:01:CD:17:2D:F9:45:5D:E9:54:65:31:DD:B9:5F:0A:47:59:F4:66:25:23:F4:57:BC:5D:D0:3E:36:7D:09"
+      ]
+    }
+  }
+]

--- a/apps/planner/_headers
+++ b/apps/planner/_headers
@@ -9,3 +9,6 @@
   Content-Type: application/json
   Cache-Control: no-store
 
+/.well-known/assetlinks.json
+  Content-Type: application/json
+  Cache-Control: no-store

--- a/apps/planner/_worker.js
+++ b/apps/planner/_worker.js
@@ -173,7 +173,10 @@ async function serveAsset(request, env) {
     headers.set("Cache-Control", "no-store");
     headers.set("Pragma", "no-cache");
   }
-  if (url.pathname === "/.well-known/apple-app-site-association") {
+  if (
+    url.pathname === "/.well-known/apple-app-site-association" ||
+    url.pathname === "/.well-known/assetlinks.json"
+  ) {
     headers.set("Content-Type", "application/json");
     headers.set("Cache-Control", "no-store");
   }

--- a/apps/planner/pages-worker.test.mjs
+++ b/apps/planner/pages-worker.test.mjs
@@ -225,6 +225,29 @@ test("the associated-domain planner path serves the planner shell", async () => 
   assert.equal(response.headers.get("X-Frame-Options"), "DENY");
 });
 
+test("mobile association files are served as uncached JSON", async () => {
+  for (const path of [
+    "/.well-known/apple-app-site-association",
+    "/.well-known/assetlinks.json",
+  ]) {
+    const response = await worker.default.fetch(
+      new Request(`https://balloon-crumbs.tailendcharlie.app${path}`),
+      {
+        ASSETS: {
+          async fetch() {
+            return new Response("{}", {
+              headers: { "Content-Type": "application/octet-stream" },
+            });
+          },
+        },
+      },
+    );
+
+    assert.equal(response.headers.get("Content-Type"), "application/json");
+    assert.equal(response.headers.get("Cache-Control"), "no-store");
+  }
+});
+
 test("the old Pages planner path redirects to the root planner URL", async () => {
   const response = await worker.default.fetch(
     new Request("https://balloon-crumbs.pages.dev/plan/?example=yes"),

--- a/apps/website/.well-known/assetlinks.json
+++ b/apps/website/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "dev.osholt.ballooncrumbs",
+      "sha256_cert_fingerprints": [
+        "A9:B5:01:CD:17:2D:F9:45:5D:E9:54:65:31:DD:B9:5F:0A:47:59:F4:66:25:23:F4:57:BC:5D:D0:3E:36:7D:09"
+      ]
+    }
+  }
+]

--- a/apps/website/_headers
+++ b/apps/website/_headers
@@ -6,3 +6,8 @@
   Content-Type: application/json
   Cache-Control: no-store
   X-Content-Type-Options: nosniff
+
+/.well-known/assetlinks.json
+  Content-Type: application/json
+  Cache-Control: no-store
+  X-Content-Type-Options: nosniff

--- a/docs/android-internal-testing.md
+++ b/docs/android-internal-testing.md
@@ -60,11 +60,11 @@ The OpenAIP key is compiled into the tester app because OpenAIP's tile API is
 designed for map clients; keep it in Actions secrets so it is absent from the
 repository and can be rotated independently.
 
-Optional repository variables:
+Repository variables:
 
 | Variable | Purpose |
 | --- | --- |
-| `BALLOON_CRUMBS_API_BASE_URL` | HTTPS relay base URL; unset builds remain nearby/offline-only and say so |
+| `BALLOON_CRUMBS_API_BASE_URL` | Required tester relay base: `https://balloon-crumbs.pages.dev/api` |
 | `BALLOON_CRUMBS_FIREBASE_API_KEY` | Android Firebase configuration |
 | `BALLOON_CRUMBS_FIREBASE_PROJECT_ID` | Android Firebase configuration |
 | `BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID` | Android Firebase configuration |
@@ -74,6 +74,11 @@ Push is enabled only when all four Firebase variables are present. Tester email
 configuration is also optional and is documented in the workflow's variable
 names; the default release mode is `dry-run`, so no mail can be sent during the
 first setup run.
+
+Android App Links are verified against the Play app-signing certificate in
+`apps/planner/.well-known/assetlinks.json`. Use Play Console's generated Digital
+Asset Links statement when the app-signing key changes; the upload-key
+fingerprint is not sufficient for Play-installed builds.
 
 ## Releasing
 

--- a/docs/tester-release-notes.md
+++ b/docs/tester-release-notes.md
@@ -7,6 +7,12 @@ matched to its changes.
 
 ## Next tester build
 
+- Fixes web-planner codes so the app loads the saved flight through the live
+  relay instead of receiving the planner webpage as an invalid response.
+- Fixes **Open in Balloon Crumbs** for both iOS and Play-installed Android
+  builds by aligning the native link handlers and signed domain association.
+- Restores the same relay path for creating and joining live rides with a
+  six-digit ride code.
 - Adds **Plan a balloon flight** to the home map's More menu and opens the live
   planner in the iOS/Android in-app browser.
 - Includes the planner's maximum-altitude landing envelope, draggable launch

--- a/docs/testflight.md
+++ b/docs/testflight.md
@@ -116,16 +116,13 @@ The version inherited from Tail End Charlie is `1.0.1+22`, and builds 23 and 24
 are already spent — so the pubspec is behind reality, which is exactly the drift
 that made asking Apple the better answer.
 
-## Without a relay
+## Relay
 
-`BALLOON_CRUMBS_API_BASE_URL` has no default and no relay is deployed for this
-app yet. A build without it is still usable: nearby transport carries the
-journal between devices, and the app says `Set BALLOON_CRUMBS_API_BASE_URL - no
-server traffic` on its own status card rather than looking like a broken relay.
-The script warns and continues, because an honest offline build is worth having
-and a silent one is not.
-
-Export the variable to point at a deployed relay when there is one.
+Tester builds require `BALLOON_CRUMBS_API_BASE_URL` to be
+`https://balloon-crumbs.pages.dev/api`. The `/api` suffix is part of the relay
+base: mobile clients append `/v1/...` paths to it. The release workflow rejects
+an empty value or a URL without that suffix so a build cannot silently ship with
+broken ride and plan-code lookups.
 
 ## CI
 
@@ -153,9 +150,8 @@ Create these once, under Settings → Secrets and variables → Actions:
 | `APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64` | that key's `.p8`, base64 |
 | `BALLOON_CRUMBS_OPENAIP_API_KEY` | OpenAIP third-party application key for the advisory airspace layer |
 
-Optionally set the `BALLOON_CRUMBS_API_BASE_URL` **variable** (not a secret) to a
-deployed relay. Without it the build warns and ships without relay access, which
-the app says on its own status card.
+Set the `BALLOON_CRUMBS_API_BASE_URL` **variable** (not a secret) to
+`https://balloon-crumbs.pages.dev/api`.
 
 To produce the two base64 values:
 
@@ -206,43 +202,42 @@ and a static file rather than a certificate and a server. Moving to a Balloon
 Crumbs domain later is one line in `lib/domain/app_links.dart` plus the two
 files that have to agree with it.
 
-Three things must name the same host, and only a test enforces it
+The Dart parser, native bridges, platform declarations and hosted association
+files must name the same host. A test enforces the checked-in copies
 (`test/domain/app_links_test.dart`):
 
 | where | what |
 | --- | --- |
 | `lib/domain/app_links.dart` | `appLinkHost`, used to build and parse links |
 | `ios/Runner/{DebugProfile,Release}.entitlements` | `applinks:<host>` |
+| `ios/Runner/AppDelegate.swift` | accepts incoming links from `<host>` |
+| `android/app/src/main/AndroidManifest.xml` and `MainActivity.kt` | claim and accept `<host>` |
 | `apps/website/.well-known/apple-app-site-association` | `appIDs: ["UY4624PH6X.dev.osholt.ballooncrumbs"]` |
+| `apps/website/.well-known/assetlinks.json` | Play app-signing certificate and Android package |
 
 Get any one of them wrong and the failure is silent: the link opens Safari,
 which is exactly what a link that was never meant to open the app does. There is
 no error to notice, only somebody saying it did nothing.
 
-### What still has to happen for a tapped link to work
+### Verifying tapped links
 
-The app side is done. The hosting side is not, and it is account access rather
-than code:
+The custom domain is served by the planner's Cloudflare Pages project. Confirm
+both platform association files are reachable directly over HTTPS with no
+redirect:
 
-1. Point `balloon-crumbs.tailendcharlie.app` at something that serves
-   `apps/website/`. A Cloudflare Pages project on this repository with that
-   custom domain is the cheapest option and matches how the sibling domain is
-   already served.
-2. Confirm the file is reachable at exactly
-   `https://balloon-crumbs.tailendcharlie.app/.well-known/apple-app-site-association`,
-   over HTTPS, with **no redirect** — Apple does not follow one:
+```bash
+curl -sSI https://balloon-crumbs.tailendcharlie.app/.well-known/apple-app-site-association
+curl -sSI https://balloon-crumbs.tailendcharlie.app/.well-known/assetlinks.json
+```
 
-   ```bash
-   curl -sSI https://balloon-crumbs.tailendcharlie.app/.well-known/apple-app-site-association
-   ```
+Ship a replacement build after changing an entitlement, manifest, native link
+bridge, package identity or signing certificate. iOS and Android verify the
+association when the app is installed, so an existing installation can retain
+stale link handling until the corrected build is installed.
 
-3. Ship a build carrying the entitlement. iOS fetches the association file when
-   the app is installed, so a link tapped before that build is installed still
-   opens Safari.
-
-Until then the six-digit code is the mechanism that works, and it is offered
-alongside every link. That is not a fallback bolted on — it is why the invitation
-carries both.
+The six-digit ride code remains available alongside invitation links. Web
+planner codes are separate eight-character plan codes and load a route; they do
+not join a live ride.
 
 If the Caddy stack is ever the origin instead of Cloudflare, `deploy/Caddyfile`
 now serves the file with `Content-Type: application/json`. Its website block is


### PR DESCRIPTION
## Summary
- compile tester builds with the selected `/api` relay base and reject invalid release configuration
- align iOS and Android native link handling with the production host
- publish Play-signed Digital Asset Links metadata and cover every link layer

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (1,712 passed; 24 conditional skips)
- `flutter build apk --debug` with production relay base
- `flutter build ios --simulator --debug --no-codesign` with production relay base
- `node --test *.test.mjs` (30 passed)