### PR TITLE
fix: keep planner map theme in sync

### DIFF
--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -15,6 +15,7 @@ import {
   parseOpenMeteoForecast,
   planWindRouteToDestination,
 } from "./planner-core.mjs";
+import { applyThemePaint, themeStyle } from "./planner-theme.mjs";
 
 // Keep the installed-app hand-off on its already-shipped associated domain.
 // The planner itself is hosted at balloon-crumbs.pages.dev/planner.html.
@@ -23,43 +24,6 @@ const FORECAST_AREA_RADIUS_METRES = 750;
 const INTENDED_AREA_RADIUS_METRES = 400;
 const WIND_MARKER_SPACING_PIXELS = 150;
 const DEFAULT_CENTER = [-2.5, 54.4];
-const MAP_PALETTES = Object.freeze({
-  dark: {
-    background: "#14111b",
-    landcover: "#17201c",
-    park: "#17201c",
-    residential: "#181420",
-    water: "#1b2436",
-    building: "#201b29",
-    boundary: "#3a3247",
-    path: "#241f2e",
-    minor: "#2a2434",
-    tertiary: "#352e42",
-    primary: "#40374f",
-    motorway: "#4d4260",
-    label: "#8d84a0",
-    place: "#c4b9c0",
-    halo: "#14111b",
-  },
-  light: {
-    background: "#f1eee7",
-    landcover: "#dce8d5",
-    park: "#d4e6cd",
-    residential: "#e9e3dc",
-    water: "#b9dced",
-    building: "#ddd4ca",
-    boundary: "#a89bab",
-    path: "#d2c9bf",
-    minor: "#c7bdb2",
-    tertiary: "#b6a99e",
-    primary: "#9d8d83",
-    motorway: "#8d7b87",
-    label: "#514958",
-    place: "#302b34",
-    halo: "#f1eee7",
-  },
-});
-
 const elements = Object.fromEntries(
   [
     "airspace-toggle",
@@ -378,60 +342,11 @@ function selectedMapTheme() {
   return elements.theme_toggle.checked ? "dark" : "light";
 }
 
-function themePaintUpdates(themeName) {
-  const palette = MAP_PALETTES[themeName];
-  return [
-    ["background", "background-color", palette.background],
-    ["landcover-green", "fill-color", palette.landcover],
-    ["park", "fill-color", palette.park],
-    ["landuse-residential", "fill-color", palette.residential],
-    ["water", "fill-color", palette.water],
-    ["waterway", "line-color", palette.water],
-    ["building", "fill-color", palette.building],
-    ["boundary-admin", "line-color", palette.boundary],
-    ["road-path", "line-color", palette.path],
-    ["road-minor", "line-color", palette.minor],
-    ["road-tertiary", "line-color", palette.tertiary],
-    ["road-primary", "line-color", palette.primary],
-    ["road-motorway", "line-color", palette.motorway],
-    ["road-label", "text-color", palette.label],
-    ["road-label", "text-halo-color", palette.halo],
-    ["place-label", "text-color", palette.place],
-    ["place-label", "text-halo-color", palette.halo],
-  ];
-}
-
-function themeStyle(style, themeName) {
-  const layers = new Map((style.layers ?? []).map((layer) => [layer.id, layer]));
-  for (const [layerId, property, value] of themePaintUpdates(themeName)) {
-    const layer = layers.get(layerId);
-    if (layer) layer.paint = { ...(layer.paint ?? {}), [property]: value };
-  }
-  return style;
-}
-
 function applyMapTheme() {
   const themeName = selectedMapTheme();
   document.documentElement.dataset.theme = themeName;
   elements.theme_label.textContent = themeName === "dark" ? "Dark map" : "Light map";
-  if (!state.map?.isStyleLoaded()) return;
-  for (const [layerId, property, value] of themePaintUpdates(themeName)) {
-    if (state.map.getLayer(layerId)) state.map.setPaintProperty(layerId, property, value);
-  }
-  if (state.map.getLayer("openaip-chart")) {
-    state.map.setPaintProperty(
-      "openaip-chart",
-      "raster-opacity",
-      themeName === "dark" ? 0.76 : 0.62,
-    );
-  }
-  if (state.map.getLayer("forecast-track-casing")) {
-    state.map.setPaintProperty(
-      "forecast-track-casing",
-      "line-color",
-      themeName === "dark" ? "#ffffff" : "#11151c",
-    );
-  }
+  applyThemePaint(state.map, themeName);
 }
 
 function setMapStatus(message, kind = "", retry = false) {

--- a/apps/planner/planner-theme.mjs
+++ b/apps/planner/planner-theme.mjs
@@ -1,0 +1,94 @@
+export const MAP_PALETTES = Object.freeze({
+  dark: {
+    background: "#14111b",
+    landcover: "#17201c",
+    park: "#17201c",
+    residential: "#181420",
+    water: "#1b2436",
+    building: "#201b29",
+    boundary: "#3a3247",
+    path: "#241f2e",
+    minor: "#2a2434",
+    tertiary: "#352e42",
+    primary: "#40374f",
+    motorway: "#4d4260",
+    label: "#8d84a0",
+    place: "#c4b9c0",
+    halo: "#14111b",
+  },
+  light: {
+    background: "#f1eee7",
+    landcover: "#dce8d5",
+    park: "#d4e6cd",
+    residential: "#e9e3dc",
+    water: "#b9dced",
+    building: "#ddd4ca",
+    boundary: "#a89bab",
+    path: "#d2c9bf",
+    minor: "#c7bdb2",
+    tertiary: "#b6a99e",
+    primary: "#9d8d83",
+    motorway: "#8d7b87",
+    label: "#514958",
+    place: "#302b34",
+    halo: "#f1eee7",
+  },
+});
+
+export function themePaintUpdates(themeName) {
+  const palette = MAP_PALETTES[themeName];
+  return [
+    ["background", "background-color", palette.background],
+    ["landcover-green", "fill-color", palette.landcover],
+    ["park", "fill-color", palette.park],
+    ["landuse-residential", "fill-color", palette.residential],
+    ["water", "fill-color", palette.water],
+    ["waterway", "line-color", palette.water],
+    ["building", "fill-color", palette.building],
+    ["boundary-admin", "line-color", palette.boundary],
+    ["road-path", "line-color", palette.path],
+    ["road-minor", "line-color", palette.minor],
+    ["road-tertiary", "line-color", palette.tertiary],
+    ["road-primary", "line-color", palette.primary],
+    ["road-motorway", "line-color", palette.motorway],
+    ["road-label", "text-color", palette.label],
+    ["road-label", "text-halo-color", palette.halo],
+    ["place-label", "text-color", palette.place],
+    ["place-label", "text-halo-color", palette.halo],
+  ];
+}
+
+export function themeStyle(style, themeName) {
+  const layers = new Map((style.layers ?? []).map((layer) => [layer.id, layer]));
+  for (const [layerId, property, value] of themePaintUpdates(themeName)) {
+    const layer = layers.get(layerId);
+    if (layer) layer.paint = { ...(layer.paint ?? {}), [property]: value };
+  }
+  return style;
+}
+
+export function applyThemePaint(map, themeName) {
+  if (!map) return;
+
+  // MapLibre's isStyleLoaded() also becomes false while source tiles are
+  // loading. Theme changes are still safe at that point, so checking it makes
+  // a toggle silently affect the page chrome but not the map during a pan or
+  // raster refresh. Layer existence is the actual precondition we need.
+  for (const [layerId, property, value] of themePaintUpdates(themeName)) {
+    if (map.getLayer(layerId)) map.setPaintProperty(layerId, property, value);
+  }
+  if (map.getLayer("openaip-chart")) {
+    map.setPaintProperty(
+      "openaip-chart",
+      "raster-opacity",
+      themeName === "dark" ? 0.76 : 0.62,
+    );
+  }
+  if (map.getLayer("forecast-track-casing")) {
+    map.setPaintProperty(
+      "forecast-track-casing",
+      "line-color",
+      themeName === "dark" ? "#ffffff" : "#11151c",
+    );
+  }
+}

--- a/apps/planner/planner-theme.test.mjs
+++ b/apps/planner/planner-theme.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyThemePaint, themeStyle } from "./planner-theme.mjs";
+
+test("applies a theme while map sources are still loading", () => {
+  const layers = new Set([
+    "background",
+    "water",
+    "road-label",
+    "openaip-chart",
+    "forecast-track-casing",
+  ]);
+  const updates = [];
+  const map = {
+    isStyleLoaded: () => false,
+    getLayer: (id) => layers.has(id),
+    setPaintProperty: (id, property, value) => updates.push([id, property, value]),
+  };
+
+  applyThemePaint(map, "dark");
+
+  assert.deepEqual(updates, [
+    ["background", "background-color", "#14111b"],
+    ["water", "fill-color", "#1b2436"],
+    ["road-label", "text-color", "#8d84a0"],
+    ["road-label", "text-halo-color", "#14111b"],
+    ["openaip-chart", "raster-opacity", 0.76],
+    ["forecast-track-casing", "line-color", "#ffffff"],
+  ]);
+});
+
+test("prepares the initial style with the selected light palette", () => {
+  const style = {
+    layers: [
+      { id: "background", paint: { "background-color": "old" } },
+      { id: "water", paint: { "fill-color": "old", "fill-opacity": 0.8 } },
+    ],
+  };
+
+  assert.equal(
+    themeStyle(style, "light").layers[0].paint["background-color"],
+    "#f1eee7",
+  );
+  assert.deepEqual(style.layers[1].paint, {
+    "fill-color": "#b9dced",
+    "fill-opacity": 0.8,
+  });
+});


### PR DESCRIPTION
## What changed
- apply map palette updates even while MapLibre sources are loading
- keep OpenAIP opacity and forecast-track contrast aligned with the selected theme
- add regression coverage for toggling while the map is still loading tiles

## Verification
- `node --test *.test.mjs` (35 passed)
- `node --check apps/planner/app.js`
- `node --check apps/planner/planner-theme.mjs`