### PR TITLE
fix: isolate TestFlight build number lookup

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -147,12 +147,15 @@ jobs:
           printf '%s' "$APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64" | base64 -D \
             > "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
           chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
-          python3 -m pip install --quiet --disable-pip-version-check cryptography
+          build_number_venv="$RUNNER_TEMP/testflight-build-number-venv"
+          python3 -m venv "$build_number_venv"
+          "$build_number_venv/bin/python" -m pip install \
+            --quiet --disable-pip-version-check "cryptography==50.0.0"
           # The same script a local build uses, so a number cannot be spent twice
           # by uploading from a laptop and from CI. Deliberately not the run
           # number: that is monotonic per repository, not per app record, and it
           # knows nothing about builds uploaded by hand.
-          number="$(python3 tools/testflight/next_build_number.py "$BUNDLE_ID")"
+          number="$("$build_number_venv/bin/python" tools/testflight/next_build_number.py "$BUNDLE_ID")"
           echo "BUILD_NUMBER=$number" >> "$GITHUB_ENV"
           echo "App Store Connect's next free build number is $number."
 


### PR DESCRIPTION
## Summary\n- resolve App Store Connect build numbers inside a temporary Python virtual environment\n- pin the same tested cryptography version used by signing normalization\n- avoid Homebrew PEP 668 failures on GitHub-hosted macOS runners\n\n## Verification\n- workflow YAML parses successfully\n- git diff --check passes\n- failure matched runner log from TestFlight run 32603923535