### PR TITLE
fix: set team for TestFlight archive

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -209,6 +209,7 @@ jobs:
             -archivePath "$PWD/build/ios/archive/Runner.xcarchive" \
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Apple Distribution" \
+            DEVELOPMENT_TEAM=UY4624PH6X \
             PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
             archive
 


### PR DESCRIPTION
## Summary\n- pass the Balloon Crumbs Apple team ID to the manual Xcode archive\n- allow Swift Package resource-bundle targets to inherit the signing team\n\n## Evidence\n- TestFlight run 32604796067 compiled the app but Xcode 26 rejected Swift Package resource targets because no development team was set\n- the team ID matches every Runner build configuration and the App Store export configuration\n\n## Verification\n- workflow YAML parses successfully\n- git diff --check passes