### PR TITLE
feat: add role-specific live balloon operations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -7,6 +7,12 @@ Working title: **Balloon Crumbs**
 Platforms: iOS and Android
 Initial users: UK hot-air-balloon pilots, ground crew, and chase drivers
 
+Active implementation specification:
+[role-specific live flight experience](docs/role-specific-live-flight-experience.md).
+This defines the production role/craft assignment, four distinct live views,
+planner-to-app contract, shared tracks and per-vehicle chase guidance that must
+land before the next broad live-flight UI implementation.
+
 ## Problem statement
 
 Balloon chase teams need a shared, rapidly changing picture of an aircraft that

--- a/apps/mobile/lib/app/balloon_crumbs_app.dart
+++ b/apps/mobile/lib/app/balloon_crumbs_app.dart
@@ -21,6 +21,7 @@ import '../features/home/home_screen.dart';
 import 'ride_invitation_link_gate.dart';
 import '../features/onboarding/onboarding_screen.dart';
 import '../features/ride/active_ride_shell.dart';
+import '../features/ride/flight_assignment_screen.dart';
 import '../internet/plan_directory.dart';
 import '../services/test_control_registry.dart';
 
@@ -165,6 +166,9 @@ class BalloonCrumbsApp extends StatelessWidget {
         // An ended ride the user has stepped away from stays on the phone and
         // stays archived; it just stops owning the whole screen (#207).
         if (controller.hasActiveRide && !controller.rideSetAside) {
+          if (controller.session!.requiresFlightAssignment) {
+            return FlightAssignmentScreen(controller: controller);
+          }
           return ActiveRideShell(
             key: ValueKey(controller.session!.rideId),
             rideController: controller,

--- a/apps/mobile/lib/app/ride_invitation_link_gate.dart
+++ b/apps/mobile/lib/app/ride_invitation_link_gate.dart
@@ -6,6 +6,17 @@ import '../controllers/ride_code_preference_controller.dart';
 import '../controllers/ride_controller.dart';
 import '../controllers/ride_invitation_link_controller.dart';
 import '../controllers/rider_profile_controller.dart';
+import '../domain/flight_role.dart';
+
+class _InvitationJoinDecision {
+  const _InvitationJoinDecision({
+    required this.role,
+    required this.vehicleLabel,
+  });
+
+  final FlightRole role;
+  final String vehicleLabel;
+}
 
 /// Presents one native App/Universal Link as a deliberate join action.
 ///
@@ -120,32 +131,88 @@ class _RideInvitationLinkGateState extends State<RideInvitationLinkGate> {
         return;
       }
 
-      final shouldJoin = await showDialog<bool>(
+      var selectedRole = FlightRole.chaseCrew;
+      final vehicleLabelController = TextEditingController(text: 'Land Rover');
+      final decision = await showDialog<_InvitationJoinDecision>(
         context: context,
         barrierDismissible: false,
-        builder: (context) => AlertDialog(
-          key: const Key('ride-invitation-link-dialog'),
-          icon: const Icon(Icons.group_add_outlined),
-          title: Text('Join flight ${invitation.rideCode}?'),
-          content: const Text(
-            'This private invitation will connect you to the group. Only join '
-            'if you recognise the person who shared it.',
+        builder: (context) => StatefulBuilder(
+          builder: (context, setDialogState) => AlertDialog(
+            key: const Key('ride-invitation-link-dialog'),
+            icon: const Icon(Icons.group_add_outlined),
+            title: Text('Join flight ${invitation.rideCode}?'),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'This private invitation will connect you to the group. Only join if you recognise the person who shared it.',
+                  ),
+                  const SizedBox(height: 18),
+                  Text(
+                    'Your role',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final role in const [
+                        FlightRole.balloonCrew,
+                        FlightRole.chaseDriver,
+                        FlightRole.chaseCrew,
+                      ])
+                        ChoiceChip(
+                          key: Key('invitation-role-${role.name}'),
+                          selected: selectedRole == role,
+                          label: Text(role.label),
+                          onSelected: (_) =>
+                              setDialogState(() => selectedRole = role),
+                        ),
+                    ],
+                  ),
+                  if (selectedRole.isChasing) ...[
+                    const SizedBox(height: 14),
+                    TextField(
+                      key: const Key('invitation-vehicle-label'),
+                      controller: vehicleLabelController,
+                      maxLength: 32,
+                      textCapitalization: TextCapitalization.words,
+                      decoration: const InputDecoration(
+                        labelText: 'Chase vehicle',
+                        helperText:
+                            'Use the same name as crewmates in this vehicle.',
+                        counterText: '',
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                key: const Key('decline-ride-invitation-link'),
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Not now'),
+              ),
+              FilledButton(
+                key: const Key('accept-ride-invitation-link'),
+                onPressed: () => Navigator.of(context).pop(
+                  _InvitationJoinDecision(
+                    role: selectedRole,
+                    vehicleLabel: vehicleLabelController.text,
+                  ),
+                ),
+                child: const Text('Join flight'),
+              ),
+            ],
           ),
-          actions: [
-            TextButton(
-              key: const Key('decline-ride-invitation-link'),
-              onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('Not now'),
-            ),
-            FilledButton(
-              key: const Key('accept-ride-invitation-link'),
-              onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Join flight'),
-            ),
-          ],
         ),
       );
-      if (shouldJoin != true || !mounted) {
+      vehicleLabelController.dispose();
+      if (decision == null || !mounted) {
         widget.links.clear();
         return;
       }
@@ -154,6 +221,8 @@ class _RideInvitationLinkGateState extends State<RideInvitationLinkGate> {
       await widget.rideController.joinRide(
         invitation.rideCode,
         profile.displayName,
+        flightRole: decision.role,
+        vehicleLabel: decision.vehicleLabel,
         joinToken: invitation.joinToken,
         motorcycleStyle: profile.motorcycleStyle,
         riderSymbol: profile.riderSymbol,
@@ -180,7 +249,7 @@ class _RideInvitationLinkGateState extends State<RideInvitationLinkGate> {
           title: const Text('Could not join this flight'),
           content: Text(
             widget.rideController.errorMessage ??
-                'That invitation could not be checked. Ask the coordinator to '
+                'That invitation could not be checked. Ask the pilot to '
                     'share a new one.',
           ),
           actions: [

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -9,6 +9,7 @@ import 'package:uuid/uuid.dart';
 
 import '../domain/craft.dart';
 import '../services/craft_roster.dart';
+import '../services/chase_guidance_target.dart';
 import '../domain/event_store.dart';
 import '../domain/flight_replay.dart';
 import '../domain/flight_role.dart';
@@ -1266,6 +1267,35 @@ class RideController extends ChangeNotifier {
           'targetLabel': targetCraftId == null
               ? null
               : roster.byId(targetCraftId)?.craft.label,
+        },
+      );
+    });
+    return _errorMessage == null;
+  }
+
+  /// The road-guidance target shared by the devices aboard this vehicle.
+  ChaseGuidanceSelection? get localChaseGuidanceSelection {
+    final session = _session;
+    if (session == null) return null;
+    final local = resolveCraftRoster().forDevice(session.localRiderId);
+    if (local == null || local.isBalloon) return null;
+    return const ChaseGuidanceSelectionReducer().fromEvents(_events)[local.id];
+  }
+
+  /// Changes this vehicle's shared road-guidance target.
+  Future<bool> setLocalChaseGuidanceTarget(ChaseGuidanceTarget target) async {
+    final session = _session;
+    if (session == null || !session.flightRole.isChasing) return false;
+    final local = resolveCraftRoster().forDevice(session.localRiderId);
+    if (local == null || local.isBalloon) return false;
+    await _run(() async {
+      await _record(
+        type: RideEventType.chaseGuidanceTargetSelected,
+        priority: EventPriority.important,
+        payload: {
+          'craftId': local.id,
+          'vehicleLabel': local.craft.label,
+          'target': target.name,
         },
       );
     });

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -1022,6 +1022,80 @@ class RideController extends ChangeNotifier {
     });
   }
 
+  /// Completes the one-time assignment for a session written before explicit
+  /// flight roles and crafts existed.
+  ///
+  /// The legacy creator may restore as pilot. Other participants must choose a
+  /// non-authority role; a legacy `lead` flag is never accepted from them as a
+  /// shortcut to pilot authority.
+  Future<void> repairFlightAssignment({
+    required FlightRole role,
+    String vehicleLabel = 'Land Rover',
+  }) async {
+    await _run(() async {
+      final activeSession = _requireSession();
+      if (!activeSession.requiresFlightAssignment) return;
+      if (role == FlightRole.observer ||
+          (role == FlightRole.pilot && activeSession.role != RideRole.lead)) {
+        throw const FormatException('Choose a valid role for this flight.');
+      }
+      final craftKind = role.isAboardBalloon
+          ? CraftKind.balloon
+          : CraftKind.vehicle;
+      final craftLabel = craftKind == CraftKind.balloon
+          ? 'Balloon'
+          : _normaliseVehicleLabel(vehicleLabel);
+      final craftId = _craftIdFor(
+        rideId: activeSession.rideId,
+        kind: craftKind,
+        label: craftLabel,
+      );
+      final updated = activeSession.copyWith(
+        flightRole: role,
+        localCraftId: craftId,
+        requiresFlightAssignment: false,
+      );
+
+      await _record(
+        type: RideEventType.roleChanged,
+        priority: EventPriority.important,
+        payload: {'role': updated.role.name, 'flightRole': role.name},
+      );
+      await _record(
+        type: RideEventType.craftRegistered,
+        priority: EventPriority.important,
+        payload: {
+          'craftId': craftId,
+          'kind': craftKind.name,
+          'label': craftLabel,
+        },
+      );
+      await _record(
+        type: RideEventType.deviceAttachedToCraft,
+        priority: EventPriority.important,
+        payload: {
+          'deviceId': activeSession.localRiderId,
+          'craftId': craftId,
+          'craftLabel': craftLabel,
+        },
+      );
+      if (role == FlightRole.pilot) {
+        await _record(
+          type: RideEventType.craftPrimaryDeviceNominated,
+          priority: EventPriority.important,
+          payload: {
+            'craftId': craftId,
+            'deviceId': activeSession.localRiderId,
+            'craftLabel': craftLabel,
+          },
+        );
+      }
+      _session = updated;
+      await _sessionStore.save(updated);
+      _invalidateMembershipProjection();
+    });
+  }
+
   /// The rider currently holding [RideRole.lead] in the reconciled roster.
   ///
   /// Used to address a leader-only event. Null when the leader has left or is

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -1996,7 +1996,7 @@ class RideController extends ChangeNotifier {
       _errorMessage = 'That action could not be saved. Please try again.';
       _errorIsRetryable = true;
       if (kDebugMode) {
-        debugPrint('Ride action failed: $error\n$stackTrace');
+        debugPrint('Flight action failed: $error\n$stackTrace');
       }
     } finally {
       _busy = false;
@@ -2156,7 +2156,9 @@ class RideController extends ChangeNotifier {
     } on Object catch (error, stackTrace) {
       _rideArchiveError = rideArchiveFailedMessage;
       if (kDebugMode) {
-        debugPrint('Could not archive the completed ride: $error\n$stackTrace');
+        debugPrint(
+          'Could not archive the completed flight: $error\n$stackTrace',
+        );
       }
     }
   }

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -11,6 +11,7 @@ import '../domain/craft.dart';
 import '../services/craft_roster.dart';
 import '../domain/event_store.dart';
 import '../domain/flight_replay.dart';
+import '../domain/flight_role.dart';
 import '../domain/geo_point.dart' as awareness_geo;
 import '../domain/ice_share.dart';
 import '../domain/imported_route.dart';
@@ -206,7 +207,12 @@ class RideController extends ChangeNotifier {
 
   bool get rideStarted => _lifecycle.started;
   DateTime? get rideStartedAt => _lifecycle.startedAt;
-  bool get isLocalRideLeader => _session?.role == RideRole.lead;
+  FlightRole? get localFlightRole => _session?.flightRole;
+  String? get localCraftId => _session?.localCraftId;
+
+  /// Legacy compatibility name retained while inherited surfaces are migrated.
+  /// Flight authority now comes only from the explicit pilot assignment.
+  bool get isLocalRideLeader => hasFlightAuthority;
   RidePhase get ridePhase => rideEnded
       ? RidePhase.ended
       : rideStarted
@@ -279,6 +285,7 @@ class RideController extends ChangeNotifier {
       localRiderId: activeSession.localRiderId,
       localDisplayName: activeSession.displayName,
       localRole: activeSession.role,
+      localFlightRole: activeSession.flightRole,
       localJoinedAt: activeSession.joinedAt,
       localMotorcycleStyle: activeSession.motorcycleStyle,
       localRiderColor: activeSession.riderColor,
@@ -775,7 +782,7 @@ class RideController extends ChangeNotifier {
     final activeSession = _requireSession();
     if (activeSession.isSimulation ||
         activeSession.coordinationMode == RideCoordinationMode.solo ||
-        activeSession.role != RideRole.lead) {
+        !hasFlightAuthority) {
       return;
     }
     var session = activeSession;
@@ -807,6 +814,8 @@ class RideController extends ChangeNotifier {
   Future<void> joinRideFromInvitation(
     RideJoinPayload invitation,
     String displayName, {
+    FlightRole flightRole = FlightRole.chaseCrew,
+    String vehicleLabel = 'Land Rover',
     CraftIconStyle motorcycleStyle = craftIconStyleDefault,
     RiderSymbol riderSymbol = riderSymbolDefault,
     RiderColor riderColor = riderColorDefault,
@@ -818,6 +827,8 @@ class RideController extends ChangeNotifier {
         inviteSecret: invitation.inviteSecret,
         joinToken: invitation.joinToken,
         displayName: displayName,
+        flightRole: flightRole,
+        vehicleLabel: vehicleLabel,
         motorcycleStyle: motorcycleStyle,
         riderSymbol: riderSymbol,
         riderColor: riderColor,
@@ -828,6 +839,8 @@ class RideController extends ChangeNotifier {
   Future<void> joinRide(
     String rideCode,
     String displayName, {
+    FlightRole flightRole = FlightRole.chaseCrew,
+    String vehicleLabel = 'Land Rover',
     CraftIconStyle motorcycleStyle = craftIconStyleDefault,
     RiderSymbol riderSymbol = riderSymbolDefault,
     RiderColor riderColor = riderColorDefault,
@@ -848,6 +861,8 @@ class RideController extends ChangeNotifier {
         inviteSecret: credentials.inviteSecret,
         joinToken: credentials.joinToken,
         displayName: displayName,
+        flightRole: flightRole,
+        vehicleLabel: vehicleLabel,
         motorcycleStyle: motorcycleStyle,
         riderSymbol: riderSymbol,
         riderColor: riderColor,
@@ -862,6 +877,8 @@ class RideController extends ChangeNotifier {
     required String inviteSecret,
     required String joinToken,
     required String displayName,
+    required FlightRole flightRole,
+    required String vehicleLabel,
     required CraftIconStyle motorcycleStyle,
     required RiderSymbol riderSymbol,
     required RiderColor riderColor,
@@ -887,6 +904,22 @@ class RideController extends ChangeNotifier {
         joinToken: joinToken,
       );
       final now = _clock();
+      if (flightRole == FlightRole.pilot || flightRole == FlightRole.observer) {
+        throw const FormatException(
+          'Join as balloon crew, a chase driver, or chase crew.',
+        );
+      }
+      final craftKind = flightRole.isAboardBalloon
+          ? CraftKind.balloon
+          : CraftKind.vehicle;
+      final craftLabel = craftKind == CraftKind.balloon
+          ? 'Balloon'
+          : _normaliseVehicleLabel(vehicleLabel);
+      final craftId = _craftIdFor(
+        rideId: credentials.rideId,
+        kind: craftKind,
+        label: craftLabel,
+      );
       final session = RideSession(
         rideId: credentials.rideId,
         rideCode: credentials.rideCode,
@@ -895,6 +928,8 @@ class RideController extends ChangeNotifier {
         localRiderId: _localRiderIdForRide(credentials.rideId),
         displayName: _normaliseName(displayName),
         role: RideRole.rider,
+        flightRole: flightRole,
+        localCraftId: craftId,
         joinedAt: now,
         motorcycleStyle: motorcycleStyle,
         riderSymbol: riderSymbol,
@@ -910,10 +945,29 @@ class RideController extends ChangeNotifier {
         payload: {
           'displayName': session.displayName,
           'role': session.role.name,
+          'flightRole': session.flightRole.name,
           'motorcycleStyle': session.riderSymbol.wireValue(
             session.motorcycleStyle,
           ),
           'riderColor': session.riderColor.name,
+        },
+      );
+      await _record(
+        type: RideEventType.craftRegistered,
+        priority: EventPriority.important,
+        payload: {
+          'craftId': craftId,
+          'kind': craftKind.name,
+          'label': craftLabel,
+        },
+      );
+      await _record(
+        type: RideEventType.deviceAttachedToCraft,
+        priority: EventPriority.important,
+        payload: {
+          'deviceId': session.localRiderId,
+          'craftId': craftId,
+          'craftLabel': craftLabel,
         },
       );
     }
@@ -928,6 +982,42 @@ class RideController extends ChangeNotifier {
       await _record(
         type: RideEventType.roleChanged,
         payload: {'role': role.name},
+      );
+    });
+  }
+
+  /// Changes this device's non-authority role without moving it to another
+  /// craft. Pilot handover is deliberately a separate accepted protocol.
+  Future<void> setFlightRole(FlightRole role) async {
+    await _run(() async {
+      final activeSession = _requireSession();
+      if (role == FlightRole.pilot ||
+          activeSession.flightRole == FlightRole.pilot) {
+        throw const FormatException(
+          'Use pilot handover to transfer authority.',
+        );
+      }
+      final craft = localCraft;
+      final compatible = switch (role) {
+        FlightRole.balloonCrew => craft?.isBalloon == true,
+        FlightRole.chaseDriver ||
+        FlightRole.chaseCrew => craft != null && !craft.isBalloon,
+        FlightRole.observer => true,
+        FlightRole.pilot => false,
+      };
+      if (!compatible) {
+        throw const FormatException('That role does not match this craft.');
+      }
+      final updated = activeSession.copyWith(
+        flightRole: role,
+        requiresFlightAssignment: false,
+      );
+      _session = updated;
+      await _sessionStore.save(updated);
+      await _record(
+        type: RideEventType.roleChanged,
+        priority: EventPriority.important,
+        payload: {'role': updated.role.name, 'flightRole': role.name},
       );
     });
   }
@@ -991,11 +1081,15 @@ class RideController extends ChangeNotifier {
   /// Whether this device may start or end the ride, nominate a craft's
   /// reporting device, or declare a landing.
   ///
-  /// Transitional: authority still comes from the inherited leader role. WP4
-  /// replaces this with [FlightRole.hasFlightAuthority] once the session carries
-  /// a ride role rather than a ride role. The seam is here so every caller
-  /// changes in one place.
-  bool get hasFlightAuthority => isLocalRideLeader;
+  /// The inherited leader flag remains on the wire for older builds, but it no
+  /// longer grants authority. A restored legacy session is deliberately denied
+  /// authority until its explicit flight assignment has been repaired.
+  bool get hasFlightAuthority {
+    final session = _session;
+    return session != null &&
+        !session.requiresFlightAssignment &&
+        session.flightRole.hasFlightAuthority;
+  }
 
   /// Registers a balloon or vehicle in this ride.
   ///
@@ -1336,10 +1430,8 @@ class RideController extends ChangeNotifier {
     if (rideStarted || rideEnded) return;
     await _run(() async {
       final session = _requireSession();
-      if (session.role != RideRole.lead) {
-        throw const FormatException(
-          'Only the coordinator can start the flight.',
-        );
+      if (!hasFlightAuthority) {
+        throw const FormatException('Only the pilot can start the flight.');
       }
       await _record(
         type: RideEventType.rideStarted,
@@ -1355,9 +1447,9 @@ class RideController extends ChangeNotifier {
   Future<void> publishRoute(ImportedRoute route) async {
     await _run(() async {
       final session = _requireSession();
-      if (!isLocalRideLeader) {
+      if (!hasFlightAuthority) {
         throw const FormatException(
-          'Only the coordinator can change the group route.',
+          'Only the pilot can change the forecast plan.',
         );
       }
       final encoded = const RideRouteEncoder().encode(route);
@@ -1395,7 +1487,7 @@ class RideController extends ChangeNotifier {
   Future<void> setLandingZone(LandingZoneTarget target) async {
     await _run(() async {
       final session = _requireSession();
-      if (!isLocalRideLeader) {
+      if (!hasFlightAuthority) {
         throw const FormatException(
           'Only the pilot can change the intended landing area.',
         );
@@ -1414,7 +1506,7 @@ class RideController extends ChangeNotifier {
   Future<void> noteWindContext(FlightReplayWindContext context) async {
     await _run(() async {
       _requireSession();
-      if (!isLocalRideLeader) return;
+      if (!hasFlightAuthority) return;
       final source = context.source.trim();
       if (source.isEmpty ||
           source.length > 120 ||
@@ -1449,7 +1541,7 @@ class RideController extends ChangeNotifier {
   Future<void> upsertOperationalBoundary(OperationalBoundary boundary) async {
     await _run(() async {
       final session = _requireSession();
-      if (!isLocalRideLeader) {
+      if (!hasFlightAuthority) {
         throw const FormatException(
           'Only the pilot can change operational boundaries.',
         );
@@ -1470,7 +1562,7 @@ class RideController extends ChangeNotifier {
   Future<void> removeOperationalBoundary(String boundaryId) async {
     await _run(() async {
       final session = _requireSession();
-      if (!isLocalRideLeader) {
+      if (!hasFlightAuthority) {
         throw const FormatException(
           'Only the pilot can change operational boundaries.',
         );
@@ -1492,9 +1584,9 @@ class RideController extends ChangeNotifier {
   Future<void> clearRoute() async {
     await _run(() async {
       final session = _requireSession();
-      if (!isLocalRideLeader) {
+      if (!hasFlightAuthority) {
         throw const FormatException(
-          'Only the coordinator can clear the group route.',
+          'Only the pilot can clear the forecast plan.',
         );
       }
       await _record(
@@ -1512,14 +1604,12 @@ class RideController extends ChangeNotifier {
   Future<void> _setRidePaused(bool paused) async {
     if (ridePaused == paused) return;
     await _run(() async {
-      final session = _requireSession();
+      _requireSession();
       if (!rideStarted) {
         throw const FormatException('Start the flight before pausing it.');
       }
-      if (session.role != RideRole.lead) {
-        throw const FormatException(
-          'Only the coordinator can pause the group.',
-        );
+      if (!hasFlightAuthority) {
+        throw const FormatException('Only the pilot can pause the flight.');
       }
       await _record(
         type: paused ? RideEventType.ridePaused : RideEventType.rideResumed,
@@ -1533,8 +1623,8 @@ class RideController extends ChangeNotifier {
     if (rideEnded) return;
     await _run(() async {
       _requireSession();
-      if (!isLocalRideLeader) {
-        throw const FormatException('Only the coordinator can end the flight.');
+      if (!hasFlightAuthority) {
+        throw const FormatException('Only the pilot can end the flight.');
       }
       await _record(
         type: RideEventType.rideEnded,
@@ -1699,6 +1789,11 @@ class RideController extends ChangeNotifier {
     final now = _clock();
     final normalisedRideName = rideName?.trim();
     final rideId = _idFactory();
+    final balloonCraftId = _craftIdFor(
+      rideId: rideId,
+      kind: CraftKind.balloon,
+      label: 'Balloon',
+    );
     final session = RideSession(
       rideId: rideId,
       rideCode: _generateCode(),
@@ -1707,6 +1802,8 @@ class RideController extends ChangeNotifier {
       localRiderId: _localRiderIdForRide(rideId),
       displayName: normalisedDisplayName,
       role: RideRole.lead,
+      flightRole: FlightRole.pilot,
+      localCraftId: balloonCraftId,
       joinedAt: now,
       isSimulation: isSimulation,
       simulationRiderCount: simulationRiderCount,
@@ -1725,6 +1822,7 @@ class RideController extends ChangeNotifier {
       payload: {
         'displayName': session.displayName,
         'role': session.role.name,
+        'flightRole': session.flightRole.name,
         if (isSimulation) 'simulation': true,
         'motorcycleStyle': session.riderSymbol.wireValue(
           session.motorcycleStyle,
@@ -1732,6 +1830,33 @@ class RideController extends ChangeNotifier {
         'riderColor': session.riderColor.name,
         'coordinationMode': session.coordinationMode.name,
         if (session.rideName != null) 'rideName': session.rideName,
+      },
+    );
+    await _record(
+      type: RideEventType.craftRegistered,
+      priority: EventPriority.important,
+      payload: {
+        'craftId': balloonCraftId,
+        'kind': CraftKind.balloon.name,
+        'label': 'Balloon',
+      },
+    );
+    await _record(
+      type: RideEventType.deviceAttachedToCraft,
+      priority: EventPriority.important,
+      payload: {
+        'deviceId': session.localRiderId,
+        'craftId': balloonCraftId,
+        'craftLabel': 'Balloon',
+      },
+    );
+    await _record(
+      type: RideEventType.craftPrimaryDeviceNominated,
+      priority: EventPriority.important,
+      payload: {
+        'craftId': balloonCraftId,
+        'deviceId': session.localRiderId,
+        'craftLabel': 'Balloon',
       },
     );
   }
@@ -1789,6 +1914,31 @@ class RideController extends ChangeNotifier {
       throw const FormatException('Enter a crew name.');
     }
     return name.length <= 24 ? name : name.substring(0, 24);
+  }
+
+  String _normaliseVehicleLabel(String value) {
+    final label = value.trim().replaceAll(RegExp(r'\s+'), ' ');
+    if (label.isEmpty) {
+      throw const FormatException('Name the chase vehicle.');
+    }
+    return label.length <= 32 ? label : label.substring(0, 32);
+  }
+
+  String _craftIdFor({
+    required String rideId,
+    required CraftKind kind,
+    required String label,
+  }) {
+    if (kind == CraftKind.balloon) return 'balloon-$rideId';
+    final canonicalLabel = label
+        .trim()
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .toLowerCase();
+    final digest = sha256.convert(
+      utf8.encode('balloon-crumbs-vehicle-v1\n$rideId\n$canonicalLabel'),
+    );
+    final suffix = base64Url.encode(digest.bytes).replaceAll('=', '');
+    return 'vehicle-${suffix.substring(0, 20)}';
   }
 
   String _generateCode() => List.generate(6, (_) => _random.nextInt(10)).join();

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -31,6 +31,7 @@ import '../domain/session_store.dart';
 import '../features/map/craft_icon.dart';
 import '../relay/live_presence.dart';
 import '../services/nearby_bridge.dart';
+import '../services/pilot_handover.dart';
 import '../services/completed_ride_archiver.dart';
 import '../services/ride_event_authenticator.dart';
 import '../services/ride_lifecycle.dart';
@@ -209,6 +210,15 @@ class RideController extends ChangeNotifier {
   bool get rideStarted => _lifecycle.started;
   DateTime? get rideStartedAt => _lifecycle.startedAt;
   FlightRole? get localFlightRole => _session?.flightRole;
+
+  PilotAuthorityState get pilotAuthority =>
+      const PilotAuthorityReducer().fromEvents(events: _events, now: _clock());
+
+  PilotHandoverOffer? get pendingLocalPilotHandover {
+    final localId = _session?.localRiderId;
+    return localId == null ? null : pilotAuthority.pendingFor(localId);
+  }
+
   String? get localCraftId => _session?.localCraftId;
 
   /// Legacy compatibility name retained while inherited surfaces are migrated.
@@ -684,6 +694,9 @@ class RideController extends ChangeNotifier {
     if (_affectsLifecycleOrRoute(event.type)) {
       _rebuildLifecycle();
     }
+    if (event.type == RideEventType.pilotHandoverAccepted) {
+      _applyLocalPilotAuthorityFromEvents();
+    }
     if (notify) notifyListeners();
     return true;
   }
@@ -1019,6 +1032,62 @@ class RideController extends ChangeNotifier {
         type: RideEventType.roleChanged,
         priority: EventPriority.important,
         payload: {'role': updated.role.name, 'flightRole': role.name},
+      );
+    });
+  }
+
+  Future<void> offerPilotHandover(String targetDeviceId) async {
+    await _run(() async {
+      final session = _requireSession();
+      if (!hasFlightAuthority ||
+          pilotAuthority.pilotDeviceId != session.localRiderId) {
+        throw const FormatException(
+          'Only the current pilot can offer handover.',
+        );
+      }
+      final balloon = resolveCraftRoster().balloon;
+      final target = participantFor(targetDeviceId);
+      if (balloon == null ||
+          !balloon.deviceIds.contains(targetDeviceId) ||
+          target == null ||
+          target.flightRole != FlightRole.balloonCrew ||
+          !target.isIncludedInLiveCount) {
+        throw const FormatException(
+          'Choose an active balloon crew member for pilot handover.',
+        );
+      }
+      final now = _clock();
+      final expiresAt = now.add(const Duration(minutes: 10));
+      await _record(
+        type: RideEventType.pilotHandoverOffered,
+        priority: EventPriority.important,
+        payload: {
+          'transferId': _idFactory(),
+          'fromDeviceId': session.localRiderId,
+          'toDeviceId': targetDeviceId,
+          'expiresAt': expiresAt.toUtc().toIso8601String(),
+        },
+      );
+    });
+  }
+
+  Future<void> acceptPilotHandover() async {
+    await _run(() async {
+      final session = _requireSession();
+      final offer = pendingLocalPilotHandover;
+      if (offer == null || offer.toDeviceId != session.localRiderId) {
+        throw const FormatException(
+          'No current pilot handover offer is available for this device.',
+        );
+      }
+      await _record(
+        type: RideEventType.pilotHandoverAccepted,
+        priority: EventPriority.important,
+        payload: {
+          'transferId': offer.transferId,
+          'fromDeviceId': offer.fromDeviceId,
+          'toDeviceId': offer.toDeviceId,
+        },
       );
     });
   }
@@ -2224,6 +2293,35 @@ class RideController extends ChangeNotifier {
     _invalidateMembershipProjection();
     _landingZoneDirty = true;
     _operationalBoundaryDirty = true;
+    _applyLocalPilotAuthorityFromEvents();
+  }
+
+  void _applyLocalPilotAuthorityFromEvents() {
+    final session = _session;
+    if (session == null) return;
+    final authority = const PilotAuthorityReducer().fromEvents(
+      events: _events,
+      now: _clock(),
+    );
+    // Existing TEC-derived builds transferred the legacy lead role with a
+    // roleChanged event. Preserve that replay until this journal contains the
+    // new two-party handover protocol; otherwise merely upgrading the app
+    // would silently give authority back to the original creator.
+    if (!authority.hasAcceptedHandover) return;
+    final pilotDeviceId = authority.pilotDeviceId;
+    if (pilotDeviceId == null) return;
+    final isPilot = pilotDeviceId == session.localRiderId;
+    final flightRole = isPilot
+        ? FlightRole.pilot
+        : session.flightRole == FlightRole.pilot
+        ? FlightRole.balloonCrew
+        : session.flightRole;
+    final legacyRole = isPilot ? RideRole.lead : RideRole.rider;
+    if (session.flightRole == flightRole && session.role == legacyRole) return;
+    final updated = session.copyWith(role: legacyRole, flightRole: flightRole);
+    _session = updated;
+    _invalidateMembershipProjection();
+    unawaited(_sessionStore.save(updated));
   }
 
   void _rebuildLifecycle() {

--- a/apps/mobile/lib/controllers/shared_route_controller.dart
+++ b/apps/mobile/lib/controllers/shared_route_controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import '../internet/plan_directory.dart';
 import '../domain/imported_route.dart';
 import '../services/gpx_import_source.dart';
+import '../services/forecast_plan_importer.dart';
 import '../services/planner_link_channel.dart';
 import '../services/shared_gpx_channel.dart';
 
@@ -151,10 +152,23 @@ class SharedRouteController extends ChangeNotifier with WidgetsBindingObserver {
     notifyListeners();
     try {
       final plan = await _planDirectory.fetch(code);
-      _pending = PickedGpxFile(
-        name: _plannerFileName(plan.name),
-        bytes: Uint8List.fromList(utf8.encode(plan.gpx)),
-      );
+      final structured = plan.forecastPlan;
+      if (structured == null) {
+        _pending = PickedGpxFile(
+          name: _plannerFileName(plan.name),
+          bytes: Uint8List.fromList(utf8.encode(plan.gpx)),
+        );
+        _pendingInAppRoute = null;
+      } else {
+        _pending = null;
+        _pendingInAppRoute = PendingInAppRoute(
+          route: const ForecastPlanImporter().import(
+            structured,
+            importedAt: DateTime.now(),
+            sourceFileName: _plannerFileName(plan.name),
+          ),
+        );
+      }
       _plannerLinkStatus = PlannerLinkStatus.idle;
       _plannerLinkMessage = null;
       _plannerLinkRetryable = false;

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -420,6 +420,7 @@ class SituationalAwarenessController extends ChangeNotifier {
       case RideEventType.windContextNoted:
       case RideEventType.operationalBoundaryUpserted:
       case RideEventType.operationalBoundaryRemoved:
+      case RideEventType.chaseGuidanceTargetSelected:
         break;
     }
     if (!replaying) {

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -423,6 +423,8 @@ class SituationalAwarenessController extends ChangeNotifier {
       case RideEventType.operationalBoundaryUpserted:
       case RideEventType.operationalBoundaryRemoved:
       case RideEventType.chaseGuidanceTargetSelected:
+      case RideEventType.pilotHandoverOffered:
+      case RideEventType.pilotHandoverAccepted:
         break;
     }
     if (!replaying) {

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -149,7 +149,9 @@ class SituationalAwarenessController extends ChangeNotifier {
   void updateLocalSession(RideSession session) {
     if (session.rideId != _session.rideId ||
         session.localRiderId != _session.localRiderId) {
-      throw ArgumentError('Cannot replace awareness with another ride session');
+      throw ArgumentError(
+        'Cannot replace awareness with another flight session',
+      );
     }
     _session = session;
     _eventFactory = SituationEventFactory(
@@ -274,7 +276,7 @@ class SituationalAwarenessController extends ChangeNotifier {
     if (_disposed) return;
     if (event.rideId != _session.rideId ||
         !_supportedSituationalEventTypes.contains(event.type)) {
-      throw const FormatException('Event is not valid for this ride.');
+      throw const FormatException('Event is not valid for this flight.');
     }
     if (!SituationEventFactory.verify(event, _session.inviteSecret)) {
       throw const FormatException('Event signature is invalid.');

--- a/apps/mobile/lib/domain/completed_ride.dart
+++ b/apps/mobile/lib/domain/completed_ride.dart
@@ -83,7 +83,7 @@ class CompletedRide {
     final version = json['schemaVersion'];
     if (version != 1 && version != schemaVersion) {
       throw FormatException(
-        'Unsupported completed ride schema: ${json['schemaVersion']}',
+        'Unsupported completed flight schema: ${json['schemaVersion']}',
       );
     }
     return CompletedRide(

--- a/apps/mobile/lib/domain/forecast_plan.dart
+++ b/apps/mobile/lib/domain/forecast_plan.dart
@@ -1,0 +1,640 @@
+import 'dart:convert';
+
+import 'geo_point.dart';
+import 'operational_boundary.dart';
+
+class ForecastPlanConstraints {
+  const ForecastPlanConstraints({
+    required this.altitudeCeilingMetersMsl,
+    required this.maximumAscentRateMetersPerSecond,
+    required this.maximumDescentRateMetersPerSecond,
+    required this.minimumDurationMinutes,
+    required this.maximumDurationMinutes,
+  });
+
+  final double altitudeCeilingMetersMsl;
+  final double maximumAscentRateMetersPerSecond;
+  final double maximumDescentRateMetersPerSecond;
+  final double minimumDurationMinutes;
+  final double maximumDurationMinutes;
+
+  Map<String, Object?> toJson() => {
+    'altitudeCeilingMsl': altitudeCeilingMetersMsl,
+    'maximumAscentRateMps': maximumAscentRateMetersPerSecond,
+    'maximumDescentRateMps': maximumDescentRateMetersPerSecond,
+    'minimumDurationMinutes': minimumDurationMinutes,
+    'maximumDurationMinutes': maximumDurationMinutes,
+  };
+}
+
+class ForecastPlanStage {
+  const ForecastPlanStage({
+    required this.fraction,
+    required this.plannedAt,
+    required this.altitudeMetersMsl,
+    required this.changeRateMetersPerSecond,
+  });
+
+  final double fraction;
+  final DateTime plannedAt;
+  final double altitudeMetersMsl;
+  final double changeRateMetersPerSecond;
+
+  Map<String, Object?> toJson() => {
+    'fraction': fraction,
+    'plannedAt': plannedAt.toUtc().toIso8601String(),
+    'altitudeMsl': altitudeMetersMsl,
+    'changeRateMps': changeRateMetersPerSecond,
+  };
+}
+
+class ForecastPlanTrackPoint {
+  const ForecastPlanTrackPoint({
+    required this.point,
+    required this.altitudeMetersMsl,
+    required this.elapsedSeconds,
+  });
+
+  final GeoPoint point;
+  final double altitudeMetersMsl;
+  final double elapsedSeconds;
+
+  Map<String, Object?> toJson() => {
+    ...point.toJson(),
+    'altitudeMsl': altitudeMetersMsl,
+    'elapsedSeconds': elapsedSeconds,
+  };
+}
+
+class ForecastPlanDeparture {
+  const ForecastPlanDeparture({
+    required this.selectedAt,
+    this.matchingWindowStart,
+    this.matchingWindowEnd,
+  });
+
+  final DateTime selectedAt;
+  final DateTime? matchingWindowStart;
+  final DateTime? matchingWindowEnd;
+
+  Map<String, Object?> toJson() => {
+    'selectedAt': selectedAt.toUtc().toIso8601String(),
+    if (matchingWindowStart != null)
+      'matchingWindowStart': matchingWindowStart!.toUtc().toIso8601String(),
+    if (matchingWindowEnd != null)
+      'matchingWindowEnd': matchingWindowEnd!.toUtc().toIso8601String(),
+  };
+}
+
+class ForecastPlanLandingArea {
+  const ForecastPlanLandingArea({
+    required this.center,
+    required this.updatedAt,
+    this.radiusMeters,
+    this.polygon = const [],
+  });
+
+  final GeoPoint center;
+  final double? radiusMeters;
+  final List<GeoPoint> polygon;
+  final DateTime updatedAt;
+
+  Map<String, Object?> toJson() => {
+    'centre': center.toJson(),
+    if (radiusMeters != null) 'radiusMetres': radiusMeters,
+    if (polygon.isNotEmpty)
+      'polygon': polygon.map((point) => point.toJson()).toList(growable: false),
+    'updatedAt': updatedAt.toUtc().toIso8601String(),
+  };
+}
+
+class ForecastPlanDestination {
+  const ForecastPlanDestination({
+    required this.point,
+    required this.toleranceMeters,
+  });
+
+  final GeoPoint point;
+  final double toleranceMeters;
+
+  Map<String, Object?> toJson() => {
+    'point': point.toJson(),
+    'toleranceMetres': toleranceMeters,
+  };
+}
+
+class ForecastPlanWind {
+  const ForecastPlanWind({
+    required this.provider,
+    required this.model,
+    required this.requestedAt,
+    required this.validFrom,
+    required this.validTo,
+    required this.attribution,
+    required this.licence,
+    required this.fieldDigest,
+  });
+
+  final String provider;
+  final String model;
+  final DateTime requestedAt;
+  final DateTime validFrom;
+  final DateTime validTo;
+  final String attribution;
+  final String licence;
+  final String fieldDigest;
+
+  Map<String, Object?> toJson() => {
+    'provider': provider,
+    'model': model,
+    'requestedAt': requestedAt.toUtc().toIso8601String(),
+    'validFrom': validFrom.toUtc().toIso8601String(),
+    'validTo': validTo.toUtc().toIso8601String(),
+    'attribution': attribution,
+    'licence': licence,
+    'forecastOnly': true,
+    'fieldDigest': fieldDigest,
+  };
+}
+
+class ForecastPlanResult {
+  const ForecastPlanResult({
+    required this.kind,
+    this.reachesDestination,
+    this.missDistanceMeters,
+  });
+
+  final String kind;
+  final bool? reachesDestination;
+  final double? missDistanceMeters;
+
+  Map<String, Object?> toJson() => {
+    'kind': kind,
+    if (reachesDestination != null) 'reachesDestination': reachesDestination,
+    if (missDistanceMeters != null) 'missDistanceMetres': missDistanceMeters,
+  };
+}
+
+/// Versioned, bounded planner evidence retained beside its GPX fallback.
+///
+/// Unknown additive fields are discarded while decoding. An unknown schema
+/// version rejects the complete document so partial geometry can never become
+/// an active flight forecast.
+class ForecastPlanDocument {
+  const ForecastPlanDocument._({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.source,
+    required this.launch,
+    required this.launchElevationMetersMsl,
+    required this.launchAltitudeDatum,
+    required this.intendedLandingArea,
+    required this.forecastLanding,
+    required this.departure,
+    required this.constraints,
+    required this.altitudeStages,
+    required this.plannedTrack,
+    required this.landingEnvelope,
+    required this.wind,
+    required this.operationalBoundaries,
+    required this.result,
+    required this.gpxFallback,
+    this.expiresAt,
+    this.destination,
+  });
+
+  static const schemaVersion = 1;
+  static const maximumDocumentBytes = 11 * 1024 * 1024;
+  static const maximumTrackPoints = 20000;
+  static const maximumEnvelopePoints = 512;
+  static const maximumStages = 32;
+  static const maximumBoundaries = 64;
+  static const maximumBoundaryPoints = 512;
+
+  final String id;
+  final String name;
+  final DateTime createdAt;
+  final DateTime? expiresAt;
+  final String source;
+  final GeoPoint launch;
+  final double launchElevationMetersMsl;
+  final String launchAltitudeDatum;
+  final ForecastPlanDestination? destination;
+  final ForecastPlanLandingArea intendedLandingArea;
+  final GeoPoint forecastLanding;
+  final ForecastPlanDeparture departure;
+  final ForecastPlanConstraints constraints;
+  final List<ForecastPlanStage> altitudeStages;
+  final List<ForecastPlanTrackPoint> plannedTrack;
+  final List<GeoPoint> landingEnvelope;
+  final ForecastPlanWind wind;
+  final List<OperationalBoundary> operationalBoundaries;
+  final ForecastPlanResult result;
+  final String gpxFallback;
+
+  Duration get plannedDuration =>
+      Duration(milliseconds: (plannedTrack.last.elapsedSeconds * 1000).round());
+
+  factory ForecastPlanDocument.fromJson(Map<String, Object?> json) {
+    final encodedBytes = utf8.encode(jsonEncode(json)).length;
+    if (encodedBytes > maximumDocumentBytes) {
+      throw const FormatException('Structured forecast plan is too large.');
+    }
+    if (json['schemaVersion'] != schemaVersion) {
+      throw FormatException(
+        'Unsupported forecast plan schema version: ${json['schemaVersion']}.',
+      );
+    }
+    final source = _string(json['source'], 'source', maximum: 120);
+    if (source != 'Balloon Crumbs web planner') {
+      throw const FormatException('Forecast plan source is not supported.');
+    }
+    final launch = _map(json['launch'], 'launch');
+    final launchPoint = _point(launch['point'], 'launch point');
+    final launchElevation = _number(
+      launch['elevationMsl'],
+      'launch elevation',
+      minimum: -500,
+      maximum: 20000,
+    );
+    final intended = _map(json['intendedLandingArea'], 'intended landing area');
+    final polygon = _points(
+      intended['polygon'] ?? const [],
+      'intended landing polygon',
+      maximum: maximumEnvelopePoints,
+    );
+    final radius = _optionalNumber(
+      intended['radiusMetres'],
+      'intended landing radius',
+      minimumExclusive: 0,
+      maximum: 100000,
+    );
+    if (radius == null && polygon.length < 3) {
+      throw const FormatException(
+        'Intended landing area needs a radius or polygon.',
+      );
+    }
+    final departure = _map(json['departure'], 'departure');
+    final windowStart = _optionalDate(
+      departure['matchingWindowStart'],
+      'matching window start',
+    );
+    final windowEnd = _optionalDate(
+      departure['matchingWindowEnd'],
+      'matching window end',
+    );
+    if (windowStart != null &&
+        windowEnd != null &&
+        windowEnd.isBefore(windowStart)) {
+      throw const FormatException('Matching departure window is reversed.');
+    }
+    final constraintsJson = _map(json['constraints'], 'constraints');
+    final minimumDuration = _number(
+      constraintsJson['minimumDurationMinutes'],
+      'minimum duration',
+      minimumExclusive: 0,
+      maximum: 1440,
+    );
+    final maximumDuration = _number(
+      constraintsJson['maximumDurationMinutes'],
+      'maximum duration',
+      minimumExclusive: 0,
+      maximum: 1440,
+    );
+    if (maximumDuration < minimumDuration) {
+      throw const FormatException('Forecast duration limits are reversed.');
+    }
+    final rawStages = _list(
+      json['altitudeStages'],
+      'altitude stages',
+      minimum: 2,
+      maximum: maximumStages,
+    );
+    final stages = [
+      for (final (index, value) in rawStages.indexed)
+        _stage(_map(value, 'altitude stage ${index + 1}')),
+    ];
+    for (var index = 1; index < stages.length; index += 1) {
+      if (stages[index].fraction <= stages[index - 1].fraction ||
+          stages[index].plannedAt.isBefore(stages[index - 1].plannedAt)) {
+        throw const FormatException('Forecast stages are not ordered.');
+      }
+    }
+    final rawTrack = _list(
+      json['plannedTrack'],
+      'planned track',
+      minimum: 2,
+      maximum: maximumTrackPoints,
+    );
+    final track = [
+      for (final (index, value) in rawTrack.indexed)
+        _trackPoint(_map(value, 'planned track point ${index + 1}')),
+    ];
+    for (var index = 1; index < track.length; index += 1) {
+      if (track[index].elapsedSeconds <= track[index - 1].elapsedSeconds) {
+        throw const FormatException('Forecast track times are not ordered.');
+      }
+    }
+    final windJson = _map(json['wind'], 'wind');
+    if (windJson['forecastOnly'] != true) {
+      throw const FormatException('Wind context must be marked forecast-only.');
+    }
+    final validFrom = _date(windJson['validFrom'], 'wind validity start');
+    final validTo = _date(windJson['validTo'], 'wind validity end');
+    if (validTo.isBefore(validFrom)) {
+      throw const FormatException('Wind validity window is reversed.');
+    }
+    final rawBoundaries = _list(
+      json['operationalBoundaries'] ?? const [],
+      'operational boundaries',
+      maximum: maximumBoundaries,
+    );
+    final boundaries = <OperationalBoundary>[];
+    for (final (index, value) in rawBoundaries.indexed) {
+      final boundaryJson = _map(value, 'operational boundary ${index + 1}');
+      final points = _list(
+        boundaryJson['points'] ?? const [],
+        'operational boundary points',
+        maximum: maximumBoundaryPoints,
+      );
+      boundaries.add(
+        OperationalBoundary.fromJson({...boundaryJson, 'points': points}),
+      );
+    }
+    final destinationJson = json['destination'];
+    final resultJson = _map(json['result'], 'result');
+    final reaches = resultJson['reachesDestination'];
+    if (reaches != null && reaches is! bool) {
+      throw const FormatException('Destination result must be true or false.');
+    }
+    final fallback = _string(
+      json['gpxFallback'],
+      'GPX fallback',
+      maximum: maximumDocumentBytes,
+    );
+    return ForecastPlanDocument._(
+      id: _string(json['id'], 'id', maximum: 128),
+      name: _string(json['name'], 'name', maximum: 200),
+      createdAt: _date(json['createdAt'], 'creation time'),
+      expiresAt: _optionalDate(json['expiresAt'], 'expiry time'),
+      source: source,
+      launch: launchPoint,
+      launchElevationMetersMsl: launchElevation,
+      launchAltitudeDatum: _string(
+        launch['datum'],
+        'launch altitude datum',
+        maximum: 64,
+      ),
+      destination: destinationJson == null
+          ? null
+          : _destination(_map(destinationJson, 'destination')),
+      intendedLandingArea: ForecastPlanLandingArea(
+        center: _point(intended['centre'], 'intended landing centre'),
+        radiusMeters: radius,
+        polygon: List.unmodifiable(polygon),
+        updatedAt: _date(intended['updatedAt'], 'landing area update time'),
+      ),
+      forecastLanding: _point(json['forecastLanding'], 'forecast landing'),
+      departure: ForecastPlanDeparture(
+        selectedAt: _date(departure['selectedAt'], 'selected departure'),
+        matchingWindowStart: windowStart,
+        matchingWindowEnd: windowEnd,
+      ),
+      constraints: ForecastPlanConstraints(
+        altitudeCeilingMetersMsl: _number(
+          constraintsJson['altitudeCeilingMsl'],
+          'altitude ceiling',
+          minimum: -500,
+          maximum: 20000,
+        ),
+        maximumAscentRateMetersPerSecond: _number(
+          constraintsJson['maximumAscentRateMps'],
+          'maximum ascent rate',
+          minimumExclusive: 0,
+          maximum: 30,
+        ),
+        maximumDescentRateMetersPerSecond: _number(
+          constraintsJson['maximumDescentRateMps'],
+          'maximum descent rate',
+          minimumExclusive: 0,
+          maximum: 30,
+        ),
+        minimumDurationMinutes: minimumDuration,
+        maximumDurationMinutes: maximumDuration,
+      ),
+      altitudeStages: List.unmodifiable(stages),
+      plannedTrack: List.unmodifiable(track),
+      landingEnvelope: List.unmodifiable(
+        _points(
+          json['landingEnvelope'] ?? const [],
+          'landing envelope',
+          maximum: maximumEnvelopePoints,
+        ),
+      ),
+      wind: ForecastPlanWind(
+        provider: _string(windJson['provider'], 'wind provider', maximum: 120),
+        model: _string(windJson['model'], 'wind model', maximum: 120),
+        requestedAt: _date(windJson['requestedAt'], 'wind request time'),
+        validFrom: validFrom,
+        validTo: validTo,
+        attribution: _string(
+          windJson['attribution'],
+          'wind attribution',
+          maximum: 500,
+        ),
+        licence: _string(windJson['licence'], 'wind licence', maximum: 500),
+        fieldDigest: _string(
+          windJson['fieldDigest'],
+          'wind field digest',
+          maximum: 128,
+        ),
+      ),
+      operationalBoundaries: List.unmodifiable(boundaries),
+      result: ForecastPlanResult(
+        kind: _string(resultJson['kind'], 'result kind', maximum: 80),
+        reachesDestination: reaches as bool?,
+        missDistanceMeters: _optionalNumber(
+          resultJson['missDistanceMetres'],
+          'miss distance',
+          minimum: 0,
+          maximum: 50000000,
+        ),
+      ),
+      gpxFallback: fallback,
+    );
+  }
+
+  Map<String, Object?> toJson() => {
+    'schemaVersion': schemaVersion,
+    'id': id,
+    'name': name,
+    'createdAt': createdAt.toUtc().toIso8601String(),
+    if (expiresAt != null) 'expiresAt': expiresAt!.toUtc().toIso8601String(),
+    'source': source,
+    'launch': {
+      'point': launch.toJson(),
+      'elevationMsl': launchElevationMetersMsl,
+      'datum': launchAltitudeDatum,
+    },
+    if (destination != null) 'destination': destination!.toJson(),
+    'intendedLandingArea': intendedLandingArea.toJson(),
+    'forecastLanding': forecastLanding.toJson(),
+    'departure': departure.toJson(),
+    'constraints': constraints.toJson(),
+    'altitudeStages': altitudeStages
+        .map((stage) => stage.toJson())
+        .toList(growable: false),
+    'plannedTrack': plannedTrack
+        .map((point) => point.toJson())
+        .toList(growable: false),
+    'landingEnvelope': landingEnvelope
+        .map((point) => point.toJson())
+        .toList(growable: false),
+    'wind': wind.toJson(),
+    'operationalBoundaries': operationalBoundaries
+        .map((boundary) => boundary.toJson())
+        .toList(growable: false),
+    'result': result.toJson(),
+    'gpxFallback': gpxFallback,
+  };
+}
+
+ForecastPlanDestination _destination(Map<String, Object?> json) =>
+    ForecastPlanDestination(
+      point: _point(json['point'], 'destination point'),
+      toleranceMeters: _number(
+        json['toleranceMetres'],
+        'destination tolerance',
+        minimumExclusive: 0,
+        maximum: 100000,
+      ),
+    );
+
+ForecastPlanStage _stage(Map<String, Object?> json) => ForecastPlanStage(
+  fraction: _number(json['fraction'], 'stage fraction', minimum: 0, maximum: 1),
+  plannedAt: _date(json['plannedAt'], 'stage time'),
+  altitudeMetersMsl: _number(
+    json['altitudeMsl'],
+    'stage altitude',
+    minimum: -500,
+    maximum: 20000,
+  ),
+  changeRateMetersPerSecond: _number(
+    json['changeRateMps'],
+    'stage change rate',
+    minimum: -30,
+    maximum: 30,
+  ),
+);
+
+ForecastPlanTrackPoint _trackPoint(Map<String, Object?> json) =>
+    ForecastPlanTrackPoint(
+      point: _point(json, 'track point'),
+      altitudeMetersMsl: _number(
+        json['altitudeMsl'],
+        'track altitude',
+        minimum: -500,
+        maximum: 20000,
+      ),
+      elapsedSeconds: _number(
+        json['elapsedSeconds'],
+        'track elapsed time',
+        minimum: 0,
+        maximum: 86400,
+      ),
+    );
+
+GeoPoint _point(Object? value, String label) {
+  final json = _map(value, label);
+  return GeoPoint(
+    latitude: _number(
+      json['latitude'],
+      '$label latitude',
+      minimum: -90,
+      maximum: 90,
+    ),
+    longitude: _number(
+      json['longitude'],
+      '$label longitude',
+      minimum: -180,
+      maximum: 180,
+    ),
+  );
+}
+
+List<GeoPoint> _points(Object? value, String label, {required int maximum}) => [
+  for (final (index, point) in _list(value, label, maximum: maximum).indexed)
+    _point(point, '$label ${index + 1}'),
+];
+
+Map<String, Object?> _map(Object? value, String label) {
+  if (value is! Map) throw FormatException('$label must be an object.');
+  return Map<String, Object?>.from(value);
+}
+
+List<Object?> _list(
+  Object? value,
+  String label, {
+  int minimum = 0,
+  required int maximum,
+}) {
+  if (value is! List || value.length < minimum || value.length > maximum) {
+    throw FormatException('$label has an invalid number of entries.');
+  }
+  return List<Object?>.from(value);
+}
+
+String _string(Object? value, String label, {required int maximum}) {
+  if (value is! String) throw FormatException('$label must be text.');
+  final result = value.trim();
+  if (result.isEmpty || result.length > maximum) {
+    throw FormatException('$label has an invalid length.');
+  }
+  return result;
+}
+
+double _number(
+  Object? value,
+  String label, {
+  double? minimum,
+  double? minimumExclusive,
+  double? maximum,
+}) {
+  if (value is! num || !value.isFinite) {
+    throw FormatException('$label must be a finite number.');
+  }
+  final result = value.toDouble();
+  if ((minimum != null && result < minimum) ||
+      (minimumExclusive != null && result <= minimumExclusive) ||
+      (maximum != null && result > maximum)) {
+    throw FormatException('$label is outside its supported range.');
+  }
+  return result;
+}
+
+double? _optionalNumber(
+  Object? value,
+  String label, {
+  double? minimum,
+  double? minimumExclusive,
+  double? maximum,
+}) => value == null
+    ? null
+    : _number(
+        value,
+        label,
+        minimum: minimum,
+        minimumExclusive: minimumExclusive,
+        maximum: maximum,
+      );
+
+DateTime _date(Object? value, String label) {
+  if (value is! String) throw FormatException('$label must be a timestamp.');
+  final result = DateTime.tryParse(value)?.toUtc();
+  if (result == null) throw FormatException('$label is invalid.');
+  return result;
+}
+
+DateTime? _optionalDate(Object? value, String label) =>
+    value == null ? null : _date(value, label);

--- a/apps/mobile/lib/domain/imported_route.dart
+++ b/apps/mobile/lib/domain/imported_route.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'altitude.dart';
+import 'forecast_plan.dart';
 import 'route_preferences.dart';
 
 export 'route_preferences.dart';
@@ -348,6 +349,7 @@ class ImportedRoute {
     this.purpose = ImportedRoutePurpose.unspecified,
     this.preferences,
     this.plannedDuration,
+    this.forecastPlan,
   });
 
   static const schemaVersion = 1;
@@ -369,6 +371,10 @@ class ImportedRoute {
   /// timing. Keeping this on the persisted route lets ETA exist before the
   /// first moving GPS fix and after an app restart (#413).
   final Duration? plannedDuration;
+
+  /// Structured planner evidence retained beside the renderable route.
+  /// Null for ordinary GPX and for plans created by older planner builds.
+  final ForecastPlanDocument? forecastPlan;
 
   /// The route character this route was planned for, when it was planned rather
   /// than recorded or imported from a tool that records none.
@@ -408,6 +414,7 @@ class ImportedRoute {
         maneuvers: maneuvers,
         preferences: preferences,
         plannedDuration: plannedDuration,
+        forecastPlan: forecastPlan,
       );
 
   Map<String, Object?> toJson() => {
@@ -428,6 +435,7 @@ class ImportedRoute {
       'preferences': routePreferences.toJson(),
     if (plannedDuration case final duration?)
       'plannedDurationSeconds': duration.inSeconds,
+    if (forecastPlan case final plan?) 'forecastPlan': plan.toJson(),
   };
 
   String toJsonString() => jsonEncode(toJson());
@@ -488,6 +496,7 @@ class ImportedRoute {
       throw const FormatException('A route must contain geometry.');
     }
     final rawPreferences = json['preferences'];
+    final rawForecastPlan = json['forecastPlan'];
     final sourceFileName = _requiredString(json, 'sourceFileName');
     final description = _optionalString(json['description']);
     return ImportedRoute(
@@ -514,6 +523,11 @@ class ImportedRoute {
             sourceFileName: sourceFileName,
             description: description,
           ),
+      forecastPlan: rawForecastPlan is Map
+          ? ForecastPlanDocument.fromJson(
+              Map<String, Object?>.from(rawForecastPlan),
+            )
+          : null,
     );
   }
 

--- a/apps/mobile/lib/domain/imported_route.dart
+++ b/apps/mobile/lib/domain/imported_route.dart
@@ -7,6 +7,15 @@ export 'route_preferences.dart';
 
 enum RoutePathKind { track, route }
 
+/// What an imported line represents, when its source states that explicitly.
+///
+/// Most GPX files do not carry enough semantics to distinguish a recorded road
+/// track from any other line, so [unspecified] preserves the existing import
+/// and optional road-matching flow. The web planner does state that its output
+/// is a forecast balloon flight; retaining that distinction prevents it from
+/// being offered as turn-by-turn road navigation.
+enum ImportedRoutePurpose { unspecified, balloonForecast }
+
 class GeoPoint {
   const GeoPoint({
     required this.latitude,
@@ -336,6 +345,7 @@ class ImportedRoute {
     this.shapingPoints = const [],
     this.maneuvers = const [],
     this.description,
+    this.purpose = ImportedRoutePurpose.unspecified,
     this.preferences,
     this.plannedDuration,
   });
@@ -345,6 +355,7 @@ class ImportedRoute {
   final String id;
   final String name;
   final String? description;
+  final ImportedRoutePurpose purpose;
   final DateTime importedAt;
   final String sourceFileName;
   final List<RoutePath> paths;
@@ -369,6 +380,8 @@ class ImportedRoute {
   /// defaults.
   final RoutePreferences? preferences;
 
+  bool get isBalloonForecast => purpose == ImportedRoutePurpose.balloonForecast;
+
   Iterable<GeoPoint> get allPoints sync* {
     for (final path in paths) {
       yield* path.points;
@@ -386,6 +399,7 @@ class ImportedRoute {
         id: id,
         name: name,
         description: description,
+        purpose: purpose,
         importedAt: importedAt,
         sourceFileName: sourceFileName,
         paths: paths,
@@ -401,6 +415,7 @@ class ImportedRoute {
     'id': id,
     'name': name,
     if (description != null) 'description': description,
+    if (purpose != ImportedRoutePurpose.unspecified) 'purpose': purpose.name,
     'importedAt': importedAt.toUtc().toIso8601String(),
     'sourceFileName': sourceFileName,
     'paths': paths.map((path) => path.toJson()).toList(),
@@ -479,6 +494,11 @@ class ImportedRoute {
       id: _requiredString(json, 'id'),
       name: _requiredString(json, 'name'),
       description: description,
+      purpose: _enumByName(
+        ImportedRoutePurpose.values,
+        json['purpose'],
+        ImportedRoutePurpose.unspecified,
+      ),
       importedAt: DateTime.parse(_requiredString(json, 'importedAt')).toUtc(),
       sourceFileName: sourceFileName,
       paths: paths,

--- a/apps/mobile/lib/domain/landing_zone.dart
+++ b/apps/mobile/lib/domain/landing_zone.dart
@@ -143,6 +143,8 @@ class LandingZoneReducer {
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
         case RideEventType.chaseGuidanceTargetSelected:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/domain/landing_zone.dart
+++ b/apps/mobile/lib/domain/landing_zone.dart
@@ -142,6 +142,7 @@ class LandingZoneReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.chaseGuidanceTargetSelected:
           break;
       }
     }

--- a/apps/mobile/lib/domain/live_route_state.dart
+++ b/apps/mobile/lib/domain/live_route_state.dart
@@ -1,0 +1,28 @@
+import 'flight_role.dart';
+import 'imported_route.dart';
+
+/// Keeps the shared airborne forecast separate from one vehicle's road route.
+///
+/// They may share geometry near the landing area, but they have different
+/// owners and meanings. A pilot publishing a new forecast must never replace a
+/// driver's turn-by-turn route, and a driver's dynamic reroute must never be
+/// broadcast as the aircraft plan.
+class LiveRouteState {
+  const LiveRouteState({this.sharedFlightPlan, this.vehicleRoadRoute});
+
+  final ImportedRoute? sharedFlightPlan;
+  final ImportedRoute? vehicleRoadRoute;
+
+  ImportedRoute? activeFor(FlightRole role) =>
+      role.isChasing ? vehicleRoadRoute : sharedFlightPlan;
+
+  LiveRouteState withSharedFlightPlan(ImportedRoute? route) => LiveRouteState(
+    sharedFlightPlan: route,
+    vehicleRoadRoute: vehicleRoadRoute,
+  );
+
+  LiveRouteState withVehicleRoadRoute(ImportedRoute? route) => LiveRouteState(
+    sharedFlightPlan: sharedFlightPlan,
+    vehicleRoadRoute: route,
+  );
+}

--- a/apps/mobile/lib/domain/operational_boundary.dart
+++ b/apps/mobile/lib/domain/operational_boundary.dart
@@ -191,6 +191,8 @@ class OperationalBoundaryReducer {
         case RideEventType.landingAreaNoted:
         case RideEventType.windContextNoted:
         case RideEventType.chaseGuidanceTargetSelected:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/domain/operational_boundary.dart
+++ b/apps/mobile/lib/domain/operational_boundary.dart
@@ -190,6 +190,7 @@ class OperationalBoundaryReducer {
         case RideEventType.craftChaseAssigned:
         case RideEventType.landingAreaNoted:
         case RideEventType.windContextNoted:
+        case RideEventType.chaseGuidanceTargetSelected:
           break;
       }
     }

--- a/apps/mobile/lib/domain/ride_event.dart
+++ b/apps/mobile/lib/domain/ride_event.dart
@@ -85,6 +85,13 @@ enum RideEventType {
 
   /// Removes one pilot-authored operational boundary by its stable ID.
   operationalBoundaryRemoved,
+
+  /// Which shared target a chase vehicle wants road guidance towards.
+  ///
+  /// This is a vehicle fact, not a phone preference: the driver and chase crew
+  /// attached to the same vehicle therefore converge on the same choice while
+  /// separate vehicles can make independent decisions.
+  chaseGuidanceTargetSelected,
 }
 
 enum EventPriority { routine, important, critical }

--- a/apps/mobile/lib/domain/ride_event.dart
+++ b/apps/mobile/lib/domain/ride_event.dart
@@ -92,6 +92,14 @@ enum RideEventType {
   /// attached to the same vehicle therefore converge on the same choice while
   /// separate vehicles can make independent decisions.
   chaseGuidanceTargetSelected,
+
+  /// The current pilot offers authority to a named balloon-crew device.
+  /// The offer expires and does not change authority by itself.
+  pilotHandoverOffered,
+
+  /// The named recipient accepts a still-valid handover offer. Reducers apply
+  /// the demotion and promotion atomically from this one shared journal fact.
+  pilotHandoverAccepted,
 }
 
 enum EventPriority { routine, important, critical }

--- a/apps/mobile/lib/domain/ride_session.dart
+++ b/apps/mobile/lib/domain/ride_session.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import '../features/map/craft_icon.dart';
+import 'flight_role.dart';
 import 'ride_coordination_mode.dart';
 import 'ride_role.dart';
 import 'rider_color.dart';
@@ -20,6 +21,9 @@ class RideSession {
     required this.displayName,
     required this.role,
     required this.joinedAt,
+    FlightRole? flightRole,
+    this.localCraftId,
+    this.requiresFlightAssignment = false,
     this.isSimulation = false,
     this.simulationRiderCount = defaultSimulationRiderCount,
     this.motorcycleStyle = craftIconStyleDefault,
@@ -27,7 +31,10 @@ class RideSession {
     this.riderColor = riderColorDefault,
     this.coordinationMode = RideCoordinationMode.keepTogether,
     this.rideName,
-  }) : assert(
+  }) : flightRole =
+           flightRole ??
+           (role == RideRole.lead ? FlightRole.pilot : FlightRole.chaseCrew),
+       assert(
          !isSimulation ||
              (simulationRiderCount >= minimumSimulationRiderCount &&
                  simulationRiderCount <= maximumSimulationRiderCount),
@@ -46,6 +53,20 @@ class RideSession {
   final String localRiderId;
   final String displayName;
   final RideRole role;
+
+  /// The person's balloon-specific job. [role] remains only for mixed-version
+  /// relay compatibility and must not drive the live experience or authority.
+  final FlightRole flightRole;
+
+  /// The stable craft this device is aboard. The journal attachment is the
+  /// shared source of truth; retaining the id here lets a restored device reach
+  /// the correct assignment/recovery flow before relay replay completes.
+  final String? localCraftId;
+
+  /// True only for a session written by a build that did not persist a flight
+  /// role. Such a session is least-privileged until the assignment repair flow
+  /// has run; it must never inherit pilot authority merely from `lead`.
+  final bool requiresFlightAssignment;
   final DateTime joinedAt;
   final bool isSimulation;
   final int simulationRiderCount;
@@ -60,6 +81,9 @@ class RideSession {
 
   RideSession copyWith({
     RideRole? role,
+    FlightRole? flightRole,
+    String? localCraftId,
+    bool? requiresFlightAssignment,
     String? rideCode,
     int? simulationRiderCount,
     RideCoordinationMode? coordinationMode,
@@ -71,6 +95,10 @@ class RideSession {
     localRiderId: localRiderId,
     displayName: displayName,
     role: role ?? this.role,
+    flightRole: flightRole ?? this.flightRole,
+    localCraftId: localCraftId ?? this.localCraftId,
+    requiresFlightAssignment:
+        requiresFlightAssignment ?? this.requiresFlightAssignment,
     joinedAt: joinedAt,
     isSimulation: isSimulation,
     simulationRiderCount: simulationRiderCount ?? this.simulationRiderCount,
@@ -89,6 +117,9 @@ class RideSession {
     'localRiderId': localRiderId,
     'displayName': displayName,
     'role': role.name,
+    'flightRole': flightRole.name,
+    if (localCraftId != null) 'localCraftId': localCraftId,
+    if (requiresFlightAssignment) 'requiresFlightAssignment': true,
     'joinedAt': joinedAt.toUtc().toIso8601String(),
     if (isSimulation) 'isSimulation': true,
     if (isSimulation) 'simulationRiderCount': simulationRiderCount,
@@ -99,25 +130,39 @@ class RideSession {
     if (rideName != null) 'rideName': rideName,
   };
 
-  factory RideSession.fromJson(Map<String, Object?> json) => RideSession(
-    rideId: json['rideId']! as String,
-    rideCode: json['rideCode']! as String,
-    inviteSecret: json['inviteSecret']! as String,
-    joinToken: _joinTokenOrFallback(json['joinToken']),
-    localRiderId: json['localRiderId']! as String,
-    displayName: json['displayName']! as String,
-    role: rideRoleFromName(json['role']),
-    joinedAt: DateTime.parse(json['joinedAt']! as String).toLocal(),
-    isSimulation: json['isSimulation'] as bool? ?? false,
-    simulationRiderCount: _simulationRiderCount(json['simulationRiderCount']),
-    motorcycleStyle: craftIconStyleFromName(json['motorcycleStyle'] as String?),
-    riderSymbol: RiderSymbol.fromStorageValue(json['riderSymbol'] as String?),
-    riderColor: riderColorFromName(json['riderColor'] as String?),
-    coordinationMode: RideCoordinationMode.fromName(
-      json['coordinationMode'] as String?,
-    ),
-    rideName: json['rideName'] as String?,
-  );
+  factory RideSession.fromJson(Map<String, Object?> json) {
+    final storedFlightRole = json['flightRole'];
+    final hasFlightRole =
+        storedFlightRole is String &&
+        FlightRole.values.any((role) => role.name == storedFlightRole);
+    return RideSession(
+      rideId: json['rideId']! as String,
+      rideCode: json['rideCode']! as String,
+      inviteSecret: json['inviteSecret']! as String,
+      joinToken: _joinTokenOrFallback(json['joinToken']),
+      localRiderId: json['localRiderId']! as String,
+      displayName: json['displayName']! as String,
+      role: rideRoleFromName(json['role']),
+      flightRole: hasFlightRole
+          ? flightRoleFromName(storedFlightRole)
+          : FlightRole.observer,
+      localCraftId: json['localCraftId'] as String?,
+      requiresFlightAssignment:
+          json['requiresFlightAssignment'] as bool? ?? !hasFlightRole,
+      joinedAt: DateTime.parse(json['joinedAt']! as String).toLocal(),
+      isSimulation: json['isSimulation'] as bool? ?? false,
+      simulationRiderCount: _simulationRiderCount(json['simulationRiderCount']),
+      motorcycleStyle: craftIconStyleFromName(
+        json['motorcycleStyle'] as String?,
+      ),
+      riderSymbol: RiderSymbol.fromStorageValue(json['riderSymbol'] as String?),
+      riderColor: riderColorFromName(json['riderColor'] as String?),
+      coordinationMode: RideCoordinationMode.fromName(
+        json['coordinationMode'] as String?,
+      ),
+      rideName: json['rideName'] as String?,
+    );
+  }
 
   static int _simulationRiderCount(Object? value) {
     if (value is! int) return defaultSimulationRiderCount;

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -1208,7 +1208,7 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
                     LengthLimitingTextInputFormatter(16),
                   ],
                   decoration: InputDecoration(
-                    labelText: 'Planned route code (optional)',
+                    labelText: 'Forecast plan code (optional)',
                     hintText: 'e.g. 7F3K9QRT',
                     helperText:
                         'From the web planner. The forecast opens for review after the flight is created.',
@@ -1459,7 +1459,7 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
           if (mounted) {
             setState(
               () => _planCodeError =
-                  'The planned route could not be loaded. Check your connection and try again.',
+                  'The forecast plan could not be loaded. Check your connection and try again.',
             );
           }
           return;

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -22,6 +22,7 @@ import '../../domain/imported_route.dart' show GeoPoint;
 import '../../domain/geo_point.dart' as awareness_geo;
 import '../../domain/landing_zone.dart';
 import '../../domain/map_style_mode.dart';
+import '../../domain/flight_role.dart';
 import '../../services/road_routing.dart';
 import 'home_destination_search.dart';
 import 'home_map_backdrop.dart';
@@ -1070,10 +1071,12 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
   );
   final _rideNameController = TextEditingController();
   final _planCodeController = TextEditingController();
+  final _vehicleLabelController = TextEditingController(text: 'Land Rover');
   final _codeFocusNode = FocusNode();
   final _codeFieldKey = GlobalKey();
   RideCoordinationMode _selectedCoordinationMode =
       RideCoordinationMode.keepTogether;
+  FlightRole _selectedJoinRole = FlightRole.chaseCrew;
 
   /// Set once a created ride's code needs sharing before handing off to the
   /// map - the moment a leader most needs it, with people waiting nearby.
@@ -1103,6 +1106,7 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
     _codeController.dispose();
     _rideNameController.dispose();
     _planCodeController.dispose();
+    _vehicleLabelController.dispose();
     super.dispose();
   }
 
@@ -1140,8 +1144,8 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
               const SizedBox(height: 8),
               Text(
                 widget.creating
-                    ? 'You will become the pilot/coordinator and get a six-digit code to share.'
-                    : 'Enter the six-digit code shared by the pilot or coordinator. You need a connection once to join, then the app keeps using the secure relay.',
+                    ? 'You will become the pilot and get a six-digit code to share.'
+                    : 'Choose your job, then enter the six-digit code shared by the pilot. You need a connection once to join, then the app keeps using the secure relay.',
                 style: const TextStyle(color: Color(0xFFABB5C1)),
               ),
               const SizedBox(height: 24),
@@ -1213,6 +1217,63 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
                     suffixIcon: const Icon(Icons.qr_code),
                   ),
                 ),
+                const SizedBox(height: 12),
+              ],
+              if (!widget.creating) ...[
+                Text(
+                  'Your role in this flight',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    ChoiceChip(
+                      key: const Key('join-role-balloon-crew'),
+                      selected: _selectedJoinRole == FlightRole.balloonCrew,
+                      avatar: const Icon(Icons.air, size: 18),
+                      label: const Text('Balloon crew'),
+                      onSelected: (_) => setState(
+                        () => _selectedJoinRole = FlightRole.balloonCrew,
+                      ),
+                    ),
+                    ChoiceChip(
+                      key: const Key('join-role-chase-driver'),
+                      selected: _selectedJoinRole == FlightRole.chaseDriver,
+                      avatar: const Icon(Icons.directions_car, size: 18),
+                      label: const Text('Driver'),
+                      onSelected: (_) => setState(
+                        () => _selectedJoinRole = FlightRole.chaseDriver,
+                      ),
+                    ),
+                    ChoiceChip(
+                      key: const Key('join-role-chase-crew'),
+                      selected: _selectedJoinRole == FlightRole.chaseCrew,
+                      avatar: const Icon(Icons.groups_2_outlined, size: 18),
+                      label: const Text('Chase crew'),
+                      onSelected: (_) => setState(
+                        () => _selectedJoinRole = FlightRole.chaseCrew,
+                      ),
+                    ),
+                  ],
+                ),
+                if (_selectedJoinRole.isChasing) ...[
+                  const SizedBox(height: 12),
+                  TextField(
+                    key: const Key('join-vehicle-label-field'),
+                    controller: _vehicleLabelController,
+                    maxLength: 32,
+                    textCapitalization: TextCapitalization.words,
+                    decoration: const InputDecoration(
+                      labelText: 'Chase vehicle',
+                      helperText:
+                          'Use the same name as crewmates in this vehicle.',
+                      hintText: 'e.g. Land Rover',
+                      counterText: '',
+                    ),
+                  ),
+                ],
                 const SizedBox(height: 12),
               ],
               TextField(
@@ -1424,6 +1485,8 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
       await widget.controller.joinRide(
         code,
         name,
+        flightRole: _selectedJoinRole,
+        vehicleLabel: _vehicleLabelController.text,
         motorcycleStyle: widget.riderProfile.motorcycleStyle,
         riderSymbol: widget.riderProfile.riderSymbol,
         riderColor: widget.riderProfile.riderColor,
@@ -1519,6 +1582,8 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
     await widget.controller.joinRideFromInvitation(
       invitation,
       name,
+      flightRole: _selectedJoinRole,
+      vehicleLabel: _vehicleLabelController.text,
       motorcycleStyle: widget.riderProfile.motorcycleStyle,
       riderSymbol: widget.riderProfile.riderSymbol,
       riderColor: widget.riderProfile.riderColor,

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -18,7 +18,7 @@ import '../../controllers/shared_route_controller.dart';
 import '../../controllers/speed_limit_display_controller.dart';
 import '../../controllers/ride_diagnostics_controller.dart';
 import '../../controllers/spoken_guidance_controller.dart';
-import '../../domain/imported_route.dart' show GeoPoint;
+import '../../domain/imported_route.dart' show GeoPoint, ImportedRoute;
 import '../../domain/geo_point.dart' as awareness_geo;
 import '../../domain/landing_zone.dart';
 import '../../domain/map_style_mode.dart';
@@ -37,6 +37,7 @@ import '../../services/build_identity.dart';
 import '../../services/basemap_configuration.dart';
 import '../../services/carplay_bridge.dart';
 import '../../services/gpx_import_source.dart';
+import '../../services/forecast_plan_importer.dart';
 import '../../services/flight_planner_launcher.dart';
 import '../../services/stored_route_library.dart';
 import '../../services/landing_zone_library.dart';
@@ -1084,6 +1085,7 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
   bool _checkingPlanCode = false;
   String? _planCodeError;
   PickedGpxFile? _pendingPlanFile;
+  ImportedRoute? _pendingStructuredPlan;
 
   /// Captured when pasted text includes a join token alongside the six
   /// digits - see [parseJoinInvite]. Typing the code by hand leaves this
@@ -1436,6 +1438,7 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
     if (widget.creating) {
       final code = _planCodeController.text.trim();
       _pendingPlanFile = null;
+      _pendingStructuredPlan = null;
       if (code.isNotEmpty) {
         setState(() {
           _checkingPlanCode = true;
@@ -1448,10 +1451,19 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
           final plan = await (widget.planDirectory ?? ownedDirectory!).fetch(
             code,
           );
-          _pendingPlanFile = PickedGpxFile(
-            name: '${plan.name ?? 'planned-route'}.gpx',
-            bytes: Uint8List.fromList(utf8.encode(plan.gpx)),
-          );
+          final structured = plan.forecastPlan;
+          if (structured == null) {
+            _pendingPlanFile = PickedGpxFile(
+              name: '${plan.name ?? 'planned-route'}.gpx',
+              bytes: Uint8List.fromList(utf8.encode(plan.gpx)),
+            );
+          } else {
+            _pendingStructuredPlan = const ForecastPlanImporter().import(
+              structured,
+              importedAt: DateTime.now(),
+              sourceFileName: '${plan.name ?? 'planned-route'}.forecast-plan',
+            );
+          }
         } on PlanDirectoryException catch (error) {
           if (mounted) setState(() => _planCodeError = error.message);
           return;
@@ -1521,7 +1533,10 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
   }
 
   void _finishCreating() {
-    if (_pendingPlanFile case final file?) {
+    if (_pendingStructuredPlan case final route?) {
+      widget.sharedRoutes.stagePendingInAppRoute(route);
+      _pendingStructuredPlan = null;
+    } else if (_pendingPlanFile case final file?) {
       widget.sharedRoutes.stagePending(file);
       _pendingPlanFile = null;
     } else if (widget.pendingInAppRoute case final route?) {

--- a/apps/mobile/lib/features/home/scan_invitation_screen.dart
+++ b/apps/mobile/lib/features/home/scan_invitation_screen.dart
@@ -156,7 +156,7 @@ class _CameraUnavailable extends StatelessWidget {
             const SizedBox(height: 10),
             const Text(
               'You can still join with the six-digit flight code, or by pasting '
-              'the invitation the leader shared. Scanning is the only way that '
+              'the invitation the coordinator shared. Scanning is the only way that '
               'works with no signal at all.',
               textAlign: TextAlign.center,
               style: TextStyle(color: Color(0xFFABB5C1), height: 1.45),

--- a/apps/mobile/lib/features/map/navigation_export_sheet.dart
+++ b/apps/mobile/lib/features/map/navigation_export_sheet.dart
@@ -53,7 +53,7 @@ class NavigationExportSheet extends StatelessWidget {
             const SizedBox(height: 5),
             const Text(
               'Direct links cannot transfer an exact GPX route. Use GPX sharing '
-              'for motorcycle navigation apps and connected bike devices.',
+              'for road-navigation apps and connected vehicle devices.',
               style: TextStyle(color: Color(0xFF98A3B1)),
             ),
             const SizedBox(height: 18),

--- a/apps/mobile/lib/features/map/ride_map.dart
+++ b/apps/mobile/lib/features/map/ride_map.dart
@@ -17,6 +17,7 @@ export 'ride_map_feature.dart'
         portraitRideMenuTopOffset,
         portraitBottomChromeKey,
         rideMapPrimaryPanelFill,
+        rideMapShowsForecastContext,
         quickMessageIcon;
 export 'route_trail_style.dart'
     show RouteLineStyle, RouteTrailStyle, contrastRatio, relativeLuminance;

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -2932,7 +2932,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
               commanded.target,
             );
       debugPrint(
-        'Ride map camera: centre=${camera.target.latitude.toStringAsFixed(6)},'
+        'Flight map camera: centre=${camera.target.latitude.toStringAsFixed(6)},'
         '${camera.target.longitude.toStringAsFixed(6)} '
         'zoom=${camera.zoom.toStringAsFixed(2)} '
         'follow=$_navigationMode '
@@ -3557,7 +3557,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
     _mapPointerOrigins[event.pointer] = event.localPosition;
     if (_mapPointerOrigins.length > 1) {
       if (kDebugMode) {
-        debugPrint('Ride map gesture: pinch started; handing camera to rider.');
+        debugPrint(
+          'Flight map gesture: pinch started; handing camera to crew.',
+        );
       }
       _suppressFollowForMapGesture();
     }
@@ -3568,7 +3570,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     if (origin != null && (event.localPosition - origin).distance >= 8) {
       if (kDebugMode) {
         debugPrint(
-          'Ride map gesture: pan threshold crossed; handing camera to rider.',
+          'Flight map gesture: pan threshold crossed; handing camera to crew.',
         );
       }
       _suppressFollowForMapGesture();
@@ -4489,7 +4491,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     } on Object catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint(
-          'Could not prepare MapLibre ride layers: $error\n$stackTrace',
+          'Could not prepare MapLibre flight layers: $error\n$stackTrace',
         );
       }
     }
@@ -4572,7 +4574,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       await controller.setGeoJsonSource(_overlaySource, _overlayGeoJson());
     } on Object catch (error) {
       if (kDebugMode) {
-        debugPrint('Could not refresh MapLibre ride layers: $error');
+        debugPrint('Could not refresh MapLibre flight layers: $error');
       }
     }
   }

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -2649,10 +2649,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
           PolylineLayer(
             polylines: [
               ..._trailPolylines(dashed: false),
-              if (_displayedRoutePaths.isNotEmpty)
-                ..._displayedRoutePaths.map(
-                  (path) => _routePolyline(path, RouteTrailStyle.routeAhead),
-                ),
+              ..._displayedRoutePolylines,
               ..._trailPolylines(dashed: true),
             ],
           ),
@@ -4312,13 +4309,16 @@ class _RideMapScreenState extends State<RideMapScreen> {
         _remainingRouteSource,
         _remainingRouteGeoJson(),
       );
+      final displayedRouteStyle = _route?.isBalloonForecast == true
+          ? RouteTrailStyle.forecastTrack
+          : RouteTrailStyle.routeAhead;
       await controller.addLineLayer(
         _remainingRouteSource,
         'balloon-crumbs-route-remaining-border',
         ml.LineLayerProperties(
           lineColor: _casingHex,
-          lineWidth: RouteTrailStyle.routeAhead.casingWidthPixels,
-          lineDasharray: RouteTrailStyle.routeAhead.maplibreCasingDashArray,
+          lineWidth: displayedRouteStyle.casingWidthPixels,
+          lineDasharray: displayedRouteStyle.maplibreCasingDashArray,
           lineCap: 'round',
           lineJoin: 'round',
         ),
@@ -4328,9 +4328,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
         _remainingRouteSource,
         'balloon-crumbs-route-remaining',
         ml.LineLayerProperties(
-          lineColor: _hexColor(RouteTrailStyle.routeAhead.color),
-          lineWidth: RouteTrailStyle.routeAhead.widthPixels,
-          lineDasharray: RouteTrailStyle.routeAhead.maplibreDashArray,
+          lineColor: _route?.isBalloonForecast == true
+              ? const ['get', 'color']
+              : _hexColor(displayedRouteStyle.color),
+          lineWidth: displayedRouteStyle.widthPixels,
+          lineDasharray: displayedRouteStyle.maplibreDashArray,
           lineCap: 'round',
           lineJoin: 'round',
         ),
@@ -4623,8 +4625,67 @@ class _RideMapScreenState extends State<RideMapScreen> {
     }
   }
 
-  Map<String, dynamic> _remainingRouteGeoJson() =>
-      MapGeoJson.lines(_displayedRoutePaths, idPrefix: 'remaining-route');
+  Map<String, dynamic> _remainingRouteGeoJson() {
+    if (_route?.isBalloonForecast != true) {
+      return MapGeoJson.lines(
+        _displayedRoutePaths,
+        idPrefix: 'remaining-route',
+      );
+    }
+    return {
+      'type': 'FeatureCollection',
+      'features': [
+        for (final part in _displayedRouteParts)
+          {
+            'type': 'Feature',
+            'id': part.id,
+            'properties': {'color': _hexColor(part.color)},
+            'geometry': {
+              'type': 'LineString',
+              'coordinates': [
+                for (final point in part.points)
+                  [point.longitude, point.latitude],
+              ],
+            },
+          },
+      ],
+    };
+  }
+
+  Iterable<Polyline> get _displayedRoutePolylines => _displayedRouteParts.map(
+    (part) => _routePolyline(
+      part.points,
+      (_route?.isBalloonForecast == true
+              ? RouteTrailStyle.forecastTrack
+              : RouteTrailStyle.routeAhead)
+          .withColor(part.color),
+    ),
+  );
+
+  Iterable<({String id, List<GeoPoint> points, Color color})>
+  get _displayedRouteParts sync* {
+    if (_route?.isBalloonForecast != true) {
+      for (final (index, path) in _displayedRoutePaths.indexed) {
+        yield (
+          id: 'remaining-route-$index',
+          points: path,
+          color: RouteTrailStyle.routeAhead.color,
+        );
+      }
+      return;
+    }
+    for (final (pathIndex, path) in _route!.paths.indexed) {
+      for (final (segmentIndex, segment) in BalloonAltitudeStyle.segments(
+        path.points,
+      ).indexed) {
+        yield (
+          id: 'forecast-$pathIndex-altitude-$segmentIndex',
+          points: segment.points,
+          color: segment.color,
+        );
+      }
+    }
+  }
 
   List<List<GeoPoint>> get _displayedRoutePaths {
     if (_route?.isBalloonForecast == true) {
@@ -4740,9 +4801,15 @@ class _RideMapScreenState extends State<RideMapScreen> {
             paths: _displayedRoutePaths,
             reserve: _plannedRouteArrowReserve,
             style: _TrailArrowStyle(
-              color: RouteTrailStyle.routeAhead.color,
-              idPrefix: 'route-ahead',
-              semanticLabel: 'Route direction',
+              color: _route?.isBalloonForecast == true
+                  ? RouteTrailStyle.forecastTrack.color
+                  : RouteTrailStyle.routeAhead.color,
+              idPrefix: _route?.isBalloonForecast == true
+                  ? 'flight-forecast'
+                  : 'route-ahead',
+              semanticLabel: _route?.isBalloonForecast == true
+                  ? 'Flight forecast direction'
+                  : 'Route direction',
             ),
           ),
         for (final trace in byImportance)

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -116,6 +116,12 @@ enum _ImportedTrackChoice { cancel, followOriginal, generateNavigable }
 /// aviation presentation.
 enum RideMapPerspective { chase, balloon }
 
+@visibleForTesting
+bool rideMapShowsForecastContext({
+  required RideMapPerspective perspective,
+  bool? explicitPreference,
+}) => explicitPreference ?? perspective == RideMapPerspective.balloon;
+
 /// A deliberately approximate area where the balloon intends or is expected
 /// to land.
 ///
@@ -272,6 +278,7 @@ class RideMapFeature extends StatefulWidget {
     this.localDisplayName = 'You',
     this.localBadgeColor = const Color(0xFF2F80ED),
     this.perspective = RideMapPerspective.chase,
+    this.showForecastContext,
     this.aeronauticalChartConfiguration =
         const AeronauticalChartConfiguration(),
     this.windForecastController,
@@ -337,6 +344,7 @@ class RideMapFeature extends StatefulWidget {
     String localDisplayName = 'You',
     Color localBadgeColor = const Color(0xFF2F80ED),
     RideMapPerspective perspective = RideMapPerspective.chase,
+    bool? showForecastContext,
     AeronauticalChartConfiguration? aeronauticalChartConfiguration,
     WindForecastController? windForecastController,
   }) => RideMapFeature(
@@ -400,6 +408,7 @@ class RideMapFeature extends StatefulWidget {
     localDisplayName: localDisplayName,
     localBadgeColor: localBadgeColor,
     perspective: perspective,
+    showForecastContext: showForecastContext,
     aeronauticalChartConfiguration:
         aeronauticalChartConfiguration ??
         AeronauticalChartConfiguration.fromEnvironment(),
@@ -503,6 +512,7 @@ class RideMapFeature extends StatefulWidget {
   final String localDisplayName;
   final Color localBadgeColor;
   final RideMapPerspective perspective;
+  final bool? showForecastContext;
   final AeronauticalChartConfiguration aeronauticalChartConfiguration;
   final WindForecastController? windForecastController;
 
@@ -665,6 +675,7 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         localDisplayName: widget.localDisplayName,
         localBadgeColor: widget.localBadgeColor,
         perspective: widget.perspective,
+        showForecastContext: widget.showForecastContext,
         aeronauticalChartConfiguration: widget.aeronauticalChartConfiguration,
         windForecastController: widget.windForecastController,
       );
@@ -765,6 +776,7 @@ class RideMapScreen extends StatefulWidget {
     this.localDisplayName = 'You',
     this.localBadgeColor = const Color(0xFF2F80ED),
     this.perspective = RideMapPerspective.chase,
+    this.showForecastContext,
     this.aeronauticalChartConfiguration =
         const AeronauticalChartConfiguration(),
     this.windForecastController,
@@ -889,6 +901,7 @@ class RideMapScreen extends StatefulWidget {
   final String localDisplayName;
   final Color localBadgeColor;
   final RideMapPerspective perspective;
+  final bool? showForecastContext;
   final AeronauticalChartConfiguration aeronauticalChartConfiguration;
   final WindForecastController? windForecastController;
 
@@ -917,16 +930,21 @@ class _RideMapScreenState extends State<RideMapScreen> {
 
   bool get _isBalloonView => widget.perspective == RideMapPerspective.balloon;
 
+  bool get _showsForecastContext => rideMapShowsForecastContext(
+    perspective: widget.perspective,
+    explicitPreference: widget.showForecastContext,
+  );
+
   CraftIconStyle get _localCraftStyle =>
       _isBalloonView ? CraftIconStyle.balloon : widget.localMotorcycleStyle;
 
   bool get _showAeronauticalChart =>
-      _isBalloonView &&
+      _showsForecastContext &&
       widget.aeronauticalChartConfiguration.isCurrentAt(DateTime.now());
 
   bool get _showWindForecast {
     final controller = widget.windForecastController;
-    return _isBalloonView &&
+    return _showsForecastContext &&
         controller != null &&
         controller.enabled &&
         controller.field != null;
@@ -1622,8 +1640,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
                     child: _buildMap(),
                   ),
                 ),
-                if (_isBalloonView &&
-                    (widget.navigationPosition != null ||
+                if (_showsForecastContext &&
+                    ((_isBalloonView && widget.navigationPosition != null) ||
                         widget.windForecastController != null))
                   Positioned(
                     key: const Key('balloon-altitude-position'),
@@ -1643,17 +1661,19 @@ class _RideMapScreenState extends State<RideMapScreen> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
-                          if (widget.navigationPosition case final position?)
-                            ValueListenableBuilder<MapNavigationPosition?>(
-                              valueListenable: position,
-                              builder: (context, fix, _) =>
-                                  _BalloonAltitudeCard(
-                                    fix: fix,
-                                    onShowMapInformation:
-                                        _showBalloonMapInformation,
-                                  ),
-                            ),
-                          if (widget.navigationPosition != null &&
+                          if (_isBalloonView)
+                            if (widget.navigationPosition case final position?)
+                              ValueListenableBuilder<MapNavigationPosition?>(
+                                valueListenable: position,
+                                builder: (context, fix, _) =>
+                                    _BalloonAltitudeCard(
+                                      fix: fix,
+                                      onShowMapInformation:
+                                          _showBalloonMapInformation,
+                                    ),
+                              ),
+                          if (_isBalloonView &&
+                              widget.navigationPosition != null &&
                               widget.windForecastController != null)
                             const SizedBox(height: 6),
                           if (widget.windForecastController
@@ -4306,6 +4326,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
       await _addTrailLayers(controller, RiderTrailKind.rider);
       await _addTrailLayers(controller, RiderTrailKind.operationalBoundary);
       await _addTrailLayers(controller, RiderTrailKind.originalLandingEnvelope);
+      await _addTrailLayers(controller, RiderTrailKind.liveProjectionTrack);
+      await _addTrailLayers(controller, RiderTrailKind.liveLandingEnvelope);
       await controller.addGeoJsonSource(
         _remainingRouteSource,
         _remainingRouteGeoJson(),
@@ -4755,7 +4777,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
   Iterable<({String id, List<GeoPoint> points, Color color})>
   _renderedTrailParts(MapOverlayTrace trace) sync* {
     if (trace.kind != RiderTrailKind.balloonGroundTrack &&
-        trace.kind != RiderTrailKind.forecastTrack) {
+        trace.kind != RiderTrailKind.forecastTrack &&
+        trace.kind != RiderTrailKind.liveProjectionTrack) {
       yield (id: trace.id, points: trace.points, color: trace.effectiveColor);
       return;
     }
@@ -4789,7 +4812,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
             .where(
               (trace) =>
                   trace.kind != RiderTrailKind.operationalBoundary &&
-                  trace.kind != RiderTrailKind.originalLandingEnvelope,
+                  trace.kind != RiderTrailKind.originalLandingEnvelope &&
+                  trace.kind != RiderTrailKind.liveProjectionTrack &&
+                  trace.kind != RiderTrailKind.liveLandingEnvelope,
             )
             .toList()
           ..sort(
@@ -4848,6 +4873,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
     RiderTrailKind.rider => 3,
     RiderTrailKind.operationalBoundary => 4,
     RiderTrailKind.originalLandingEnvelope => 4,
+    RiderTrailKind.liveProjectionTrack => 4,
+    RiderTrailKind.liveLandingEnvelope => 4,
   };
 
   Map<String, dynamic> _trailDirectionArrowGeoJson() => MapGeoJson.points(

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -4305,6 +4305,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       await _addTrailLayers(controller, RiderTrailKind.forecastTrack);
       await _addTrailLayers(controller, RiderTrailKind.rider);
       await _addTrailLayers(controller, RiderTrailKind.operationalBoundary);
+      await _addTrailLayers(controller, RiderTrailKind.originalLandingEnvelope);
       await controller.addGeoJsonSource(
         _remainingRouteSource,
         _remainingRouteGeoJson(),
@@ -4785,7 +4786,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
     // ordinary ones.
     final byImportance =
         _visibleRiderTrails
-            .where((trace) => trace.kind != RiderTrailKind.operationalBoundary)
+            .where(
+              (trace) =>
+                  trace.kind != RiderTrailKind.operationalBoundary &&
+                  trace.kind != RiderTrailKind.originalLandingEnvelope,
+            )
             .toList()
           ..sort(
             (first, second) => _arrowPriority(
@@ -4842,6 +4847,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     RiderTrailKind.leader => 1,
     RiderTrailKind.rider => 3,
     RiderTrailKind.operationalBoundary => 4,
+    RiderTrailKind.originalLandingEnvelope => 4,
   };
 
   Map<String, dynamic> _trailDirectionArrowGeoJson() => MapGeoJson.points(

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -4505,11 +4505,10 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _riderTrailSource,
       'balloon-crumbs-trail-${kind.name}-line',
       ml.LineLayerProperties(
-        lineColor:
-            kind == RiderTrailKind.balloonGroundTrack ||
-                kind == RiderTrailKind.forecastTrack
-            ? const ['get', 'color']
-            : _hexColor(style.color),
+        // Every feature carries its resolved colour. Balloon and forecast
+        // segments use altitude colours; chase craft retain the identity
+        // colour of their elected reporter across both map renderers.
+        lineColor: const ['get', 'color'],
         lineWidth: style.widthPixels,
         lineDasharray: style.maplibreDashArray,
         lineCap: 'round',
@@ -4756,7 +4755,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
   _renderedTrailParts(MapOverlayTrace trace) sync* {
     if (trace.kind != RiderTrailKind.balloonGroundTrack &&
         trace.kind != RiderTrailKind.forecastTrack) {
-      yield (id: trace.id, points: trace.points, color: trace.style.color);
+      yield (id: trace.id, points: trace.points, color: trace.effectiveColor);
       return;
     }
     for (final (index, segment) in BalloonAltitudeStyle.segments(
@@ -4816,7 +4815,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
           TrailDirectionArrowSource(
             paths: [trace.points],
             style: _TrailArrowStyle(
-              color: trace.style.color,
+              color: trace.effectiveColor,
               idPrefix: trace.id,
               semanticLabel: '${trace.label} direction',
             ),
@@ -6238,14 +6237,17 @@ class MapOverlayTrace {
     required this.points,
     required this.label,
     this.kind = RiderTrailKind.rider,
+    this.color,
   });
 
   final String id;
   final List<GeoPoint> points;
   final String label;
   final RiderTrailKind kind;
+  final Color? color;
 
   RouteLineStyle get style => RouteTrailStyle.forTrail(kind);
+  Color get effectiveColor => color ?? style.color;
 }
 
 /// How one source's arrows are drawn. Carried through the selection untouched.
@@ -8684,6 +8686,16 @@ class _WindForecastControl extends StatelessWidget {
                 ],
               ),
               if (controller.enabled) ...[
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: FilterChip(
+                    key: const Key('wind-follow-balloon-altitude'),
+                    avatar: const Icon(Icons.air_outlined, size: 16),
+                    label: const Text('Follow balloon altitude'),
+                    selected: controller.followBalloonAltitude,
+                    onSelected: controller.setFollowBalloonAltitude,
+                  ),
+                ),
                 Row(
                   children: [
                     const Text('20', style: TextStyle(fontSize: 9)),

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -4293,6 +4293,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       );
       await _addTrailLayers(controller, RiderTrailKind.leader);
       await _addTrailLayers(controller, RiderTrailKind.balloonGroundTrack);
+      await _addTrailLayers(controller, RiderTrailKind.forecastTrack);
       await _addTrailLayers(controller, RiderTrailKind.rider);
       await _addTrailLayers(controller, RiderTrailKind.operationalBoundary);
       await controller.addGeoJsonSource(
@@ -4490,7 +4491,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _riderTrailSource,
       'balloon-crumbs-trail-${kind.name}-line',
       ml.LineLayerProperties(
-        lineColor: kind == RiderTrailKind.balloonGroundTrack
+        lineColor:
+            kind == RiderTrailKind.balloonGroundTrack ||
+                kind == RiderTrailKind.forecastTrack
             ? const ['get', 'color']
             : _hexColor(style.color),
         lineWidth: style.widthPixels,
@@ -4673,7 +4676,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
 
   Iterable<({String id, List<GeoPoint> points, Color color})>
   _renderedTrailParts(MapOverlayTrace trace) sync* {
-    if (trace.kind != RiderTrailKind.balloonGroundTrack) {
+    if (trace.kind != RiderTrailKind.balloonGroundTrack &&
+        trace.kind != RiderTrailKind.forecastTrack) {
       yield (id: trace.id, points: trace.points, color: trace.style.color);
       return;
     }
@@ -4751,6 +4755,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     // direction arrows are the last thing the budget may drop.
     RiderTrailKind.routeStartConnector => 0,
     RiderTrailKind.balloonGroundTrack => 1,
+    RiderTrailKind.forecastTrack => 2,
     RiderTrailKind.leader => 1,
     RiderTrailKind.rider => 3,
     RiderTrailKind.operationalBoundary => 4,

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -1169,6 +1169,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     final start = _plannedRouteStart;
     final route = _route;
     if (position == null || start == null || route == null) return null;
+    if (route.isBalloonForecast) return null;
     if (_progressGeometry.progressMeters > 50 ||
         distanceToRouteMeters(route, position) <= 250) {
       return null;
@@ -1490,7 +1491,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   ),
                 // Route-derived: there is nothing to hand to another
                 // navigation app or write to a GPX without one.
-                if (!_isBalloonView && _route != null)
+                if (!_isBalloonView &&
+                    _route != null &&
+                    !_route!.isBalloonForecast)
                   IconButton(
                     tooltip: 'Navigate or export route',
                     visualDensity: compactDensity,
@@ -1503,11 +1506,15 @@ class _RideMapScreenState extends State<RideMapScreen> {
                         : const Icon(Icons.alt_route),
                   ),
                 IconButton(
-                  tooltip: 'Fit route',
+                  tooltip: _route?.isBalloonForecast == true
+                      ? 'Fit forecast plan'
+                      : 'Fit route',
                   visualDensity: compactDensity,
                   // Route-derived: fitting the whole plan needs a plan. The
                   // rider's own framing is the follow camera's job.
-                  onPressed: _isBalloonView || _route == null
+                  onPressed:
+                      (_isBalloonView && _route?.isBalloonForecast != true) ||
+                          _route == null
                       ? null
                       : _showWholeRoute,
                   icon: const Icon(Icons.fit_screen),
@@ -1930,6 +1937,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
           : null;
       final routeProgressPanel =
           _isBalloonView ||
+              _route?.isBalloonForecast == true ||
               !widget.showRouteProgress ||
               _route == null ||
               _progressGeometry.totalMeters <= 0
@@ -2537,10 +2545,13 @@ class _RideMapScreenState extends State<RideMapScreen> {
   Widget _buildMap() {
     if (_basemap.usesMapLibre) return _buildMapLibreMap();
 
-    final route = _isBalloonView ? null : _route;
+    final route = _isBalloonView && _route?.isBalloonForecast != true
+        ? null
+        : _route;
     final framingPoints = <GeoPoint>[
       ...(_isBalloonView
-          ? _balloonGroundTrackPoints
+          ? route?.allPoints.toList(growable: false) ??
+                _balloonGroundTrackPoints
           : route?.allPoints.toList(growable: false) ?? const <GeoPoint>[]),
       ...?_landingZone?.boundary,
     ];
@@ -2638,8 +2649,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
           PolylineLayer(
             polylines: [
               ..._trailPolylines(dashed: false),
-              if (!_isBalloonView)
-                ..._progressGeometry.remainingPaths.map(
+              if (_displayedRoutePaths.isNotEmpty)
+                ..._displayedRoutePaths.map(
                   (path) => _routePolyline(path, RouteTrailStyle.routeAhead),
                 ),
               ..._trailPolylines(dashed: true),
@@ -3429,14 +3440,15 @@ class _RideMapScreenState extends State<RideMapScreen> {
     _speedLimitDisplay.observe(location);
     _speedLimitDisplay.prefetchAhead(
       current: location,
-      routeAhead:
-          _navigationProgressGeometry.remainingPaths.firstOrNull ??
-          const <GeoPoint>[],
+      routeAhead: _route?.isBalloonForecast == true
+          ? const <GeoPoint>[]
+          : _navigationProgressGeometry.remainingPaths.firstOrNull ??
+                const <GeoPoint>[],
     );
   }
 
   void _updateNavigationGuidance(GeoPoint? position) {
-    if (_isBalloonView) {
+    if (_isBalloonView || _route?.isBalloonForecast == true) {
       final current = _navigationGuidance.value;
       if (current.state != NavigationGuidanceState.noRoute) {
         _navigationGuidance.value =
@@ -4611,12 +4623,17 @@ class _RideMapScreenState extends State<RideMapScreen> {
     }
   }
 
-  Map<String, dynamic> _remainingRouteGeoJson() => MapGeoJson.lines(
-    _isBalloonView
+  Map<String, dynamic> _remainingRouteGeoJson() =>
+      MapGeoJson.lines(_displayedRoutePaths, idPrefix: 'remaining-route');
+
+  List<List<GeoPoint>> get _displayedRoutePaths {
+    if (_route?.isBalloonForecast == true) {
+      return _route!.paths.map((path) => path.points).toList(growable: false);
+    }
+    return _isBalloonView
         ? const <List<GeoPoint>>[]
-        : _progressGeometry.remainingPaths,
-    idPrefix: 'remaining-route',
-  );
+        : _progressGeometry.remainingPaths;
+  }
 
   /// Every rider's travelled trail with enough geometry to draw. Rendering is
   /// deliberately independent of whether a route is loaded or matched (#100).
@@ -4718,9 +4735,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
     final selected = selectTrailDirectionArrows<_TrailArrowStyle>(
       sampler: _trailDirectionArrowSampler,
       sources: [
-        if (!_isBalloonView)
+        if (_displayedRoutePaths.isNotEmpty)
           TrailDirectionArrowSource(
-            paths: _progressGeometry.remainingPaths,
+            paths: _displayedRoutePaths,
             reserve: _plannedRouteArrowReserve,
             style: _TrailArrowStyle(
               color: RouteTrailStyle.routeAhead.color,
@@ -5020,7 +5037,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     } on FormatException catch (error) {
       _showMessage(error.message);
     } on Object catch (error) {
-      _showMessage('Could not load planned route: $error');
+      _showMessage('Could not load forecast plan: $error');
     } finally {
       if (mounted) setState(() => _importing = false);
     }
@@ -5031,7 +5048,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     return showDialog<String>(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: const Text('Load a planned route'),
+        title: const Text('Load a forecast flight plan'),
         content: TextField(
           controller: controller,
           autofocus: true,
@@ -5180,7 +5197,13 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }) async {
     if (!widget.canEditRoute) {
       throw const FormatException(
-        'Only the pilot or coordinator can replace the crew route.',
+        'Only the pilot or coordinator can replace the shared flight plan or chase route.',
+      );
+    }
+    if (_isBalloonView && !route.isBalloonForecast) {
+      throw const FormatException(
+        'The balloon view accepts forecast flight plans, not road routes. '
+        'Open the chase view to import or plan road guidance.',
       );
     }
     ImportedRoute? comparisonRoute;
@@ -5232,10 +5255,16 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }) async {
     if (!widget.canEditRoute) {
       throw const FormatException(
-        'Only the pilot or coordinator can replace the crew route.',
+        'Only the pilot or coordinator can replace the shared flight plan or chase route.',
       );
     }
-    final enrichment = await _routeGeometryEnricher.enrich(route);
+    final enrichment = route.isBalloonForecast
+        ? RouteGeometryEnrichment(
+            route: route,
+            attempted: false,
+            snappedPathCount: 0,
+          )
+        : await _routeGeometryEnricher.enrich(route);
     final activeRoute = enrichment.route;
     if (!mounted) return null;
     final confirmationWarnings = [
@@ -5261,7 +5290,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
 
   bool _canGenerateNavigableRoute(ImportedRoute route) {
     final drawablePaths = route.paths.where((path) => path.points.length >= 2);
-    return route.maneuvers.isEmpty &&
+    return !route.isBalloonForecast &&
+        route.maneuvers.isEmpty &&
         drawablePaths.isNotEmpty &&
         drawablePaths.every((path) => path.kind == RoutePathKind.track);
   }
@@ -5333,7 +5363,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
     widget.onRouteChanged?.call(activeRoute);
     widget.onRouteCommitted?.call(activeRoute);
     _showMessage(
-      '${activeRoute.name}: confirmed and stored offline '
+      '${activeRoute.name}: '
+      '${activeRoute.isBalloonForecast ? 'forecast plan' : 'route'} confirmed '
+      'and stored offline '
       '(${activeRoute.pathPointCount} points).',
     );
     return activeRoute;
@@ -5488,9 +5520,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
   /// until the bike moved fast enough to arm the follow camera (#124).
   void _fitRoute() {
     final planned = <GeoPoint>[
-      ...(_isBalloonView
-          ? _balloonGroundTrackPoints
-          : _route?.allPoints.toList(growable: false) ?? const []),
+      if (_isBalloonView) ..._balloonGroundTrackPoints,
+      if (!_isBalloonView || _route?.isBalloonForecast == true)
+        ...?_route?.allPoints,
       ...?_landingZone?.boundary,
     ];
     final routePoints = planned.isNotEmpty ? planned : [?_effectivePosition];
@@ -5862,7 +5894,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       if (!mounted) return;
       if (!widget.canEditRoute) {
         _showMessage(
-          'Only the pilot or coordinator can replace the crew route.',
+          'Only the pilot or coordinator can replace the shared flight plan or chase route.',
         );
         return;
       }
@@ -5897,7 +5929,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
 
   Future<void> _showChangeRouteSheet() async {
     if (!widget.canEditRoute) {
-      _showMessage('Only the pilot or coordinator can replace the crew route.');
+      _showMessage(
+        'Only the pilot or coordinator can replace the shared flight plan or chase route.',
+      );
       return;
     }
     await showModalBottomSheet<void>(
@@ -5913,7 +5947,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
                 leading: const Icon(Icons.map_outlined),
                 title: Text(
                   _route == null
-                      ? 'Continue without a route'
+                      ? _isBalloonView
+                            ? 'Continue without a forecast plan'
+                            : 'Continue without a route'
+                      : _route!.isBalloonForecast
+                      ? 'Keep current forecast plan'
                       : 'Keep current route',
                 ),
                 subtitle: _route == null
@@ -5925,31 +5963,39 @@ class _RideMapScreenState extends State<RideMapScreen> {
                 },
               ),
               const Divider(height: 1),
-              ListTile(
-                leading: const Icon(Icons.add_road),
-                title: const Text('Plan a destination'),
-                onTap: () {
-                  Navigator.of(sheetContext).pop();
-                  _planDestination();
-                },
-              ),
+              if (!_isBalloonView)
+                ListTile(
+                  leading: const Icon(Icons.add_road),
+                  title: const Text('Plan a destination'),
+                  onTap: () {
+                    Navigator.of(sheetContext).pop();
+                    _planDestination();
+                  },
+                ),
               // Stored geometry sits beside "choose a file", not behind it: a
               // rider picking a route should not have to know which one the
               // app wants (#155).
-              ListTile(
-                key: const Key('use-stored-route-sheet-item'),
-                leading: const Icon(Icons.history),
-                title: const Text('Use a saved route'),
-                subtitle: const Text('A recorded route or a previous flight'),
-                onTap: () {
-                  Navigator.of(sheetContext).pop();
-                  _useStoredRoute();
-                },
-              ),
+              if (!_isBalloonView)
+                ListTile(
+                  key: const Key('use-stored-route-sheet-item'),
+                  leading: const Icon(Icons.history),
+                  title: const Text('Use a saved route'),
+                  subtitle: const Text('A recorded route or a previous flight'),
+                  onTap: () {
+                    Navigator.of(sheetContext).pop();
+                    _useStoredRoute();
+                  },
+                ),
               ListTile(
                 leading: const Icon(Icons.upload_file),
                 title: Text(
-                  _route == null ? 'Import GPX route' : 'Replace GPX route',
+                  _isBalloonView
+                      ? _route == null
+                            ? 'Import GPX forecast plan'
+                            : 'Replace GPX forecast plan'
+                      : _route == null
+                      ? 'Import GPX route'
+                      : 'Replace GPX route',
                 ),
                 onTap: () {
                   Navigator.of(sheetContext).pop();
@@ -5958,20 +6004,21 @@ class _RideMapScreenState extends State<RideMapScreen> {
               ),
               ListTile(
                 leading: const Icon(Icons.qr_code),
-                title: const Text('Load a planned route'),
+                title: const Text('Load a forecast flight plan'),
                 onTap: () {
                   Navigator.of(sheetContext).pop();
                   _loadPlannedRoute();
                 },
               ),
-              ListTile(
-                leading: const Icon(Icons.route_outlined),
-                title: const Text('Load demo route'),
-                onTap: () {
-                  Navigator.of(sheetContext).pop();
-                  _loadDemoRoute();
-                },
-              ),
+              if (!_isBalloonView)
+                ListTile(
+                  leading: const Icon(Icons.route_outlined),
+                  title: const Text('Load demo route'),
+                  onTap: () {
+                    Navigator.of(sheetContext).pop();
+                    _loadDemoRoute();
+                  },
+                ),
               // Route-derived: nothing to remove without one.
               if (_route != null)
                 ListTile(
@@ -6104,14 +6151,14 @@ class MapEmergencyContact {
   bool get hasPhoneNumber => (phoneNumber ?? '').isNotEmpty;
 
   String get shortRoleLabel => switch (role) {
-    RideRole.lead => 'the leader',
+    RideRole.lead => 'the flight coordinator',
     _ => displayName,
   };
 
-  /// "Oliver (leader)". Used at the point of dialling, where the rider needs to
+  /// "Oliver (coordinator)". Used at the point of dialling, where the crew needs to
   /// know both who and which role.
   String get roleQualifiedName => switch (role) {
-    RideRole.lead => '$displayName (leader)',
+    RideRole.lead => '$displayName (coordinator)',
     _ => displayName,
   };
 }
@@ -6425,14 +6472,14 @@ class _WaitingForLeaderRoutePrompt extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const Text(
-                'Waiting for the leader’s route',
+                'Waiting for the coordinator’s plan',
                 style: TextStyle(fontSize: 22, fontWeight: FontWeight.w700),
               ),
               const SizedBox(height: 8),
               const Text(
-                'This flight has no crew route yet. It will appear here when '
-                'the leader shares one. The leader can also start without a '
-                'route.',
+                'This flight has no forecast plan or chase route yet. It will '
+                'appear here when the coordinator shares one. The coordinator '
+                'can also start without one.',
                 style: TextStyle(color: Color(0xFF98A3B1)),
               ),
               const SizedBox(height: 16),
@@ -9189,7 +9236,7 @@ class _PostedSpeedLimitBadge extends StatelessWidget {
           };
     final riderSpeedLabel = riderMilesPerHour == null
         ? 'Your speed is unavailable.'
-        : 'You are riding at $riderMilesPerHour miles per hour by GPS.';
+        : 'You are travelling at $riderMilesPerHour miles per hour by GPS.';
     // Carries what the deleted caption used to say (#125): which number is the
     // sign and which is the rider, that the limit is mapped rather than live,
     // and how stale it is. Removing the caption moved this wording, it did not

--- a/apps/mobile/lib/features/map/rider_symbol_picker.dart
+++ b/apps/mobile/lib/features/map/rider_symbol_picker.dart
@@ -101,7 +101,7 @@ class RiderSymbolPicker extends StatelessWidget {
               return Semantics(
                 button: true,
                 selected: selected,
-                label: '${style.label} motorcycle icon',
+                label: '${style.label} craft icon',
                 child: InkWell(
                   key: Key('$bikeKeyPrefix-${style.name}'),
                   borderRadius: BorderRadius.circular(12),

--- a/apps/mobile/lib/features/map/route_confirmation_sheet.dart
+++ b/apps/mobile/lib/features/map/route_confirmation_sheet.dart
@@ -74,14 +74,22 @@ class RouteConfirmationSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isForecast = route.isBalloonForecast;
     final formatter = MeasurementFormatter(distanceUnit);
     final effectiveDistance = distanceMeters ?? routeLengthMeters(route);
+    final forecastDuration = isForecast ? _forecastDuration(route) : null;
+    final effectiveDuration = duration ?? forecastDuration;
     final maneuverCount = const NavigationGuidancePlanner()
         .instructions(route)
         .length;
     final visibleWarnings = [
       ...warnings.where((warning) => warning.trim().isNotEmpty),
-      ?materialRouteChangeWarning(previousRoute, route, distanceUnit),
+      if (isForecast)
+        'Forecast only: the balloon cannot follow this line. Wind, airspace '
+            'and landing conditions can change; check current aviation '
+            'information and landing suitability before launch.',
+      if (!isForecast)
+        ?materialRouteChangeWarning(previousRoute, route, distanceUnit),
     ];
 
     return SafeArea(
@@ -92,7 +100,7 @@ class RouteConfirmationSheet extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
-              'Use this route?',
+              isForecast ? 'Use this forecast plan?' : 'Use this route?',
               style: Theme.of(context).textTheme.titleLarge,
             ),
             const SizedBox(height: 6),
@@ -110,14 +118,47 @@ class RouteConfirmationSheet extends StatelessWidget {
                   icon: Icons.straighten,
                   label: formatter.distance(effectiveDistance),
                 ),
-                if (duration case final duration?)
+                if (effectiveDuration case final duration?)
                   _Fact(icon: Icons.schedule, label: _durationLabel(duration)),
-                _Fact(
-                  icon: Icons.turn_right,
-                  label: maneuverCount == 1 ? '1 turn' : '$maneuverCount turns',
-                ),
+                if (isForecast)
+                  if (_maximumAltitude(route) case final altitude?)
+                    _Fact(
+                      icon: Icons.height,
+                      label: 'Max ${altitude.round()} m MSL',
+                    )
+                  else
+                    const _Fact(
+                      icon: Icons.height,
+                      label: 'Altitude unavailable',
+                    )
+                else
+                  _Fact(
+                    icon: Icons.turn_right,
+                    label: maneuverCount == 1
+                        ? '1 turn'
+                        : '$maneuverCount turns',
+                  ),
               ],
             ),
+            if (isForecast) ...[
+              const SizedBox(height: 12),
+              Text(
+                _forecastWindow(context, route) ??
+                    'The forecast time is not included in this file.',
+                key: const Key('forecast-plan-time'),
+                style: const TextStyle(color: Color(0xFFB9C4D1)),
+              ),
+              if (route.description case final description?) ...[
+                const SizedBox(height: 6),
+                Text(
+                  description,
+                  style: const TextStyle(
+                    color: Color(0xFF9CA7B5),
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ],
             if (visibleWarnings.isNotEmpty) ...[
               const SizedBox(height: 16),
               // Scrolls rather than truncates: a matched import can produce
@@ -176,7 +217,9 @@ class RouteConfirmationSheet extends StatelessWidget {
                     onPressed: () => Navigator.of(
                       context,
                     ).pop(RouteConfirmationAction.confirm),
-                    child: const Text('Use this route'),
+                    child: Text(
+                      isForecast ? 'Use forecast plan' : 'Use this route',
+                    ),
                   ),
                 ),
               ],
@@ -191,6 +234,44 @@ class RouteConfirmationSheet extends StatelessWidget {
     final hours = duration.inHours;
     final minutes = duration.inMinutes.remainder(60);
     return hours > 0 ? '${hours}h ${minutes}m' : '${minutes}m';
+  }
+
+  static List<GeoPoint> _forecastPoints(ImportedRoute route) => route.paths
+      .expand((path) => path.points)
+      .where((point) => point.recordedAt != null)
+      .toList(growable: false);
+
+  static Duration? _forecastDuration(ImportedRoute route) {
+    final points = _forecastPoints(route);
+    if (points.length < 2) return null;
+    final duration = points.last.recordedAt!.difference(
+      points.first.recordedAt!,
+    );
+    return duration.isNegative ? null : duration;
+  }
+
+  static double? _maximumAltitude(ImportedRoute route) => route.paths
+      .expand((path) => path.points)
+      .map((point) => point.elevationMeters)
+      .nonNulls
+      .fold<double?>(null, (highest, value) {
+        if (highest == null || value > highest) return value;
+        return highest;
+      });
+
+  static String? _forecastWindow(BuildContext context, ImportedRoute route) {
+    final points = _forecastPoints(route);
+    if (points.isEmpty) return null;
+    final localizations = MaterialLocalizations.of(context);
+    final use24Hour = MediaQuery.alwaysUse24HourFormatOf(context);
+    String time(DateTime value) => localizations.formatTimeOfDay(
+      TimeOfDay.fromDateTime(value.toLocal()),
+      alwaysUse24HourFormat: use24Hour,
+    );
+    final start = points.first.recordedAt!.toLocal();
+    final end = points.last.recordedAt!.toLocal();
+    return 'Forecast ${localizations.formatMediumDate(start)} · '
+        '${time(start)}–${time(end)} local';
   }
 }
 

--- a/apps/mobile/lib/features/map/route_trail_style.dart
+++ b/apps/mobile/lib/features/map/route_trail_style.dart
@@ -76,6 +76,8 @@ class RouteLineStyle {
 /// | leader trail  | #D3B8FF |      4.22  |        9.78  |    10.53  |
 /// | flight forecast | #00E5FF |    4.77  |       11.06  |    11.91  |
 /// | original envelope | #C69CFF |  3.36  |        7.78  |     8.38  |
+/// | live projection | #64D8FF |      4.48  |       10.38  |    11.18  |
+/// | live envelope | #FFC857 |        4.77  |       11.06  |    11.91  |
 /// | connector     | #00E5FF |      4.77  |       11.06  |    11.91  |
 /// | boundary      | #FF8FA3 |      3.39  |        7.87  |     8.47  |
 ///
@@ -195,6 +197,24 @@ class RouteTrailStyle {
     dashPixels: [18, 10],
   );
 
+  /// A current forecast line. The short dotted pattern makes it visibly less
+  /// certain than the original dashed plan and the solid measured track.
+  static const liveProjectionTrack = RouteLineStyle(
+    color: Color(0xFF64D8FF),
+    widthPixels: 4.25,
+    casingWidthPixels: 8.25,
+    dashPixels: [3, 7],
+  );
+
+  /// Current forecast endpoints. Amber distinguishes it from the immutable
+  /// purple planner envelope and the pilot's green intended area.
+  static const liveLandingEnvelope = RouteLineStyle(
+    color: Color(0xFFFFC857),
+    widthPixels: 2.75,
+    casingWidthPixels: 6.75,
+    dashPixels: [4, 9],
+  );
+
   /// The road route to the start of the planned route (#133), which claimed this
   /// cyan and renders it dashed. Declared here so the palette stays one table and
   /// the widths and dash runs stay distinct from every other line.
@@ -225,6 +245,8 @@ class RouteTrailStyle {
     RiderTrailKind.forecastTrack => forecastTrack,
     RiderTrailKind.operationalBoundary => operationalBoundary,
     RiderTrailKind.originalLandingEnvelope => originalLandingEnvelope,
+    RiderTrailKind.liveProjectionTrack => liveProjectionTrack,
+    RiderTrailKind.liveLandingEnvelope => liveLandingEnvelope,
     RiderTrailKind.routeStartConnector => routeStartConnectorLine,
   };
 
@@ -283,6 +305,8 @@ class RouteTrailStyle {
     'flight forecast': forecastTrack,
     'operational boundary': operationalBoundary,
     'original landing envelope': originalLandingEnvelope,
+    'live projection': liveProjectionTrack,
+    'live landing envelope': liveLandingEnvelope,
     'route start connector': routeStartConnectorLine,
   };
 

--- a/apps/mobile/lib/features/map/route_trail_style.dart
+++ b/apps/mobile/lib/features/map/route_trail_style.dart
@@ -75,6 +75,7 @@ class RouteLineStyle {
 /// | travelled     | #FF7A1A |      2.81  |        6.52  |     7.02  |
 /// | leader trail  | #D3B8FF |      4.22  |        9.78  |    10.53  |
 /// | flight forecast | #00E5FF |    4.77  |       11.06  |    11.91  |
+/// | original envelope | #C69CFF |  3.36  |        7.78  |     8.38  |
 /// | connector     | #00E5FF |      4.77  |       11.06  |    11.91  |
 /// | boundary      | #FF8FA3 |      3.39  |        7.87  |     8.47  |
 ///
@@ -184,6 +185,16 @@ class RouteTrailStyle {
     dashPixels: [10, 7],
   );
 
+  /// Feasible landing endpoints retained from the original planner run.
+  /// Purple and a longer dash distinguish historical forecast evidence from
+  /// the pilot's current green intent and the pink advisory boundaries.
+  static const originalLandingEnvelope = RouteLineStyle(
+    color: Color(0xFFC69CFF),
+    widthPixels: 3.5,
+    casingWidthPixels: 7.5,
+    dashPixels: [18, 10],
+  );
+
   /// The road route to the start of the planned route (#133), which claimed this
   /// cyan and renders it dashed. Declared here so the palette stays one table and
   /// the widths and dash runs stay distinct from every other line.
@@ -213,6 +224,7 @@ class RouteTrailStyle {
     RiderTrailKind.balloonGroundTrack => balloonGroundTrack,
     RiderTrailKind.forecastTrack => forecastTrack,
     RiderTrailKind.operationalBoundary => operationalBoundary,
+    RiderTrailKind.originalLandingEnvelope => originalLandingEnvelope,
     RiderTrailKind.routeStartConnector => routeStartConnectorLine,
   };
 
@@ -270,6 +282,7 @@ class RouteTrailStyle {
     'balloon ground track': balloonGroundTrack,
     'flight forecast': forecastTrack,
     'operational boundary': operationalBoundary,
+    'original landing envelope': originalLandingEnvelope,
     'route start connector': routeStartConnectorLine,
   };
 

--- a/apps/mobile/lib/features/map/route_trail_style.dart
+++ b/apps/mobile/lib/features/map/route_trail_style.dart
@@ -74,6 +74,7 @@ class RouteLineStyle {
 /// | route ahead   | #3DDC84 |      4.11  |        9.54  |    10.27  |
 /// | travelled     | #FF7A1A |      2.81  |        6.52  |     7.02  |
 /// | leader trail  | #D3B8FF |      4.22  |        9.78  |    10.53  |
+/// | flight forecast | #00E5FF |    4.77  |       11.06  |    11.91  |
 /// | connector     | #00E5FF |      4.77  |       11.06  |    11.91  |
 /// | boundary      | #FF8FA3 |      3.39  |        7.87  |     8.47  |
 ///
@@ -165,6 +166,15 @@ class RouteTrailStyle {
     casingWidthPixels: 11,
   );
 
+  /// Pilot-published predicted flight geometry. The dash is the non-colour cue
+  /// that it is a forecast rather than the aircraft's observed ground track.
+  static const forecastTrack = RouteLineStyle(
+    color: Color(0xFF00E5FF),
+    widthPixels: 5.5,
+    casingWidthPixels: 9.5,
+    dashPixels: [14, 8],
+  );
+
   /// Advisory operational geometry. Magenta and a short dash keep it distinct
   /// from road guidance and all recorded tracks.
   static const operationalBoundary = RouteLineStyle(
@@ -201,6 +211,7 @@ class RouteTrailStyle {
     RiderTrailKind.rider => travelled,
     RiderTrailKind.leader => leaderTrail,
     RiderTrailKind.balloonGroundTrack => balloonGroundTrack,
+    RiderTrailKind.forecastTrack => forecastTrack,
     RiderTrailKind.operationalBoundary => operationalBoundary,
     RiderTrailKind.routeStartConnector => routeStartConnectorLine,
   };
@@ -257,6 +268,7 @@ class RouteTrailStyle {
     'travelled': travelled,
     'leader trail': leaderTrail,
     'balloon ground track': balloonGroundTrack,
+    'flight forecast': forecastTrack,
     'operational boundary': operationalBoundary,
     'route start connector': routeStartConnectorLine,
   };

--- a/apps/mobile/lib/features/map/stored_route_picker.dart
+++ b/apps/mobile/lib/features/map/stored_route_picker.dart
@@ -329,7 +329,7 @@ class _StoredRouteOptionsSheetState extends State<StoredRouteOptionsSheet> {
               Text(
                 _variant == StoredRouteVariant.tidied
                     ? 'Tidied: a recording, not a planned route. Stops and GPS '
-                          'wander are removed. Every road the bike actually '
+                          'wander are removed. Every road the vehicle actually '
                           'took is kept, including any wrong turns and car '
                           'park loops.'
                     : 'Raw track: every fix exactly as recorded, including '
@@ -337,26 +337,30 @@ class _StoredRouteOptionsSheetState extends State<StoredRouteOptionsSheet> {
                 style: const TextStyle(color: Color(0xFF98A3B1), height: 1.4),
               ),
             ] else
-              const Text(
-                'This is the route that flight was planned with, so it is used '
-                'exactly as it was planned.',
-                style: TextStyle(color: Color(0xFF98A3B1), height: 1.4),
+              Text(
+                candidate.geometry.isBalloonForecast
+                    ? 'This is an advisory, time-specific wind-drift forecast. '
+                          'It cannot be reversed or followed like a road route.'
+                    : 'This is the route that flight was planned with, so it '
+                          'is used exactly as it was planned.',
+                style: const TextStyle(color: Color(0xFF98A3B1), height: 1.4),
               ),
             const SizedBox(height: 6),
-            SwitchListTile(
-              key: const Key('stored-route-reverse'),
-              contentPadding: EdgeInsets.zero,
-              value: _reversed,
-              onChanged: (value) => setState(() => _reversed = value),
-              title: const Text('Use it in reverse'),
-              subtitle: Text(
-                _reversed
-                    ? 'Runs from the original finish to the original start. '
-                          'Turn instructions from the original direction are '
-                          'dropped.'
-                    : 'Runs in the direction it was ridden.',
+            if (candidate.canReverse)
+              SwitchListTile(
+                key: const Key('stored-route-reverse'),
+                contentPadding: EdgeInsets.zero,
+                value: _reversed,
+                onChanged: (value) => setState(() => _reversed = value),
+                title: const Text('Use it in reverse'),
+                subtitle: Text(
+                  _reversed
+                      ? 'Runs from the original finish to the original start. '
+                            'Turn instructions from the original direction are '
+                            'dropped.'
+                      : 'Runs in the direction it was travelled.',
+                ),
               ),
-            ),
             const SizedBox(height: 12),
             FilledButton.icon(
               key: const Key('use-stored-route'),
@@ -367,8 +371,16 @@ class _StoredRouteOptionsSheetState extends State<StoredRouteOptionsSheet> {
                   reversed: _reversed,
                 ),
               ),
-              icon: const Icon(Icons.route_outlined),
-              label: const Text('Use this route'),
+              icon: Icon(
+                candidate.geometry.isBalloonForecast
+                    ? Icons.air_outlined
+                    : Icons.route_outlined,
+              ),
+              label: Text(
+                candidate.geometry.isBalloonForecast
+                    ? 'Use forecast plan'
+                    : 'Use this route',
+              ),
             ),
           ],
         ),

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -480,6 +480,10 @@ class _RideActionsPanel extends StatelessWidget {
     required this.canChangeRoute,
     required this.onAlertsAndReports,
     required this.onShareSummary,
+    required this.canOfferPilotHandover,
+    required this.onOfferPilotHandover,
+    required this.pendingPilotHandoverFrom,
+    required this.onAcceptPilotHandover,
     required this.onOpenRoster,
     required this.onShareRoster,
     required this.onChangeRoute,
@@ -518,6 +522,10 @@ class _RideActionsPanel extends StatelessWidget {
   final bool canChangeRoute;
   final VoidCallback onAlertsAndReports;
   final VoidCallback onShareSummary;
+  final bool canOfferPilotHandover;
+  final VoidCallback onOfferPilotHandover;
+  final String? pendingPilotHandoverFrom;
+  final VoidCallback onAcceptPilotHandover;
   final VoidCallback onOpenRoster;
   final VoidCallback onShareRoster;
   final VoidCallback onChangeRoute;
@@ -606,6 +614,26 @@ class _RideActionsPanel extends StatelessWidget {
             subtitle: const Text('Current flight details and recorded route'),
             onTap: onShareSummary,
           ),
+          if (canOfferPilotHandover)
+            ListTile(
+              key: const Key('flight-offer-pilot-handover'),
+              leading: const Icon(Icons.swap_horiz_rounded),
+              title: const Text('Transfer pilot role'),
+              subtitle: const Text(
+                'Offer authority to an active crew member in the balloon',
+              ),
+              onTap: onOfferPilotHandover,
+            ),
+          if (pendingPilotHandoverFrom != null)
+            ListTile(
+              key: const Key('flight-accept-pilot-handover'),
+              leading: const Icon(Icons.how_to_reg_outlined),
+              title: const Text('Accept pilot handover'),
+              subtitle: Text(
+                '$pendingPilotHandoverFrom offered you flight authority. The transfer happens only after you accept.',
+              ),
+              onTap: onAcceptPilotHandover,
+            ),
           const Divider(height: 20),
           if (flightRole.isChasing && maneuverCount > 0)
             ListTile(
@@ -5459,6 +5487,115 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     );
   }
 
+  List<RideParticipant> get _pilotHandoverTargets {
+    final balloonDeviceIds =
+        widget.rideController.resolveCraftRoster().balloon?.deviceIds.toSet() ??
+        const <String>{};
+    return widget.rideController.liveParticipants
+        .where(
+          (participant) =>
+              !participant.isLocal &&
+              participant.flightRole == FlightRole.balloonCrew &&
+              balloonDeviceIds.contains(participant.riderId),
+        )
+        .toList(growable: false);
+  }
+
+  String? get _pendingPilotHandoverFrom {
+    final offer = widget.rideController.pendingLocalPilotHandover;
+    if (offer == null) return null;
+    return widget.rideController
+            .participantFor(offer.fromDeviceId)
+            ?.displayName ??
+        'The current pilot';
+  }
+
+  Future<void> _offerPilotHandover() async {
+    final targets = _pilotHandoverTargets;
+    if (targets.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'No active balloon crew member is available for pilot handover.',
+          ),
+        ),
+      );
+      return;
+    }
+    final target = await showModalBottomSheet<RideParticipant>(
+      context: context,
+      useSafeArea: true,
+      showDragHandle: true,
+      builder: (sheetContext) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const ListTile(
+            title: Text('Transfer pilot role'),
+            subtitle: Text(
+              'Choose someone in the balloon. They become pilot only after accepting the ten-minute offer; you remain pilot until then.',
+            ),
+          ),
+          for (final participant in targets)
+            ListTile(
+              key: Key('pilot-handover-target-${participant.riderId}'),
+              leading: const Icon(Icons.person_outline),
+              title: Text(participant.displayName),
+              subtitle: Text(participant.stateLabel),
+              onTap: () => Navigator.pop(sheetContext, participant),
+            ),
+          const SizedBox(height: 12),
+        ],
+      ),
+    );
+    if (target == null || !mounted) return;
+    await widget.rideController.offerPilotHandover(target.riderId);
+    if (!mounted) return;
+    final error = widget.rideController.errorMessage;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          error ??
+              'Pilot handover offered to ${target.displayName}. You retain authority until they accept.',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _acceptPilotHandover() async {
+    final offer = widget.rideController.pendingLocalPilotHandover;
+    if (offer == null) return;
+    final pilot = widget.rideController.participantFor(offer.fromDeviceId);
+    final accepted = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Accept pilot authority?'),
+        content: Text(
+          '${pilot?.displayName ?? 'The current pilot'} will become balloon crew and this device will gain authority to update landing intent and end the flight.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Not now'),
+          ),
+          FilledButton(
+            key: const Key('confirm-pilot-handover'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Accept handover'),
+          ),
+        ],
+      ),
+    );
+    if (accepted != true || !mounted) return;
+    await widget.rideController.acceptPilotHandover();
+    if (!mounted) return;
+    final error = widget.rideController.errorMessage;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(error ?? 'Pilot handover accepted. You are now pilot.'),
+      ),
+    );
+  }
+
   Widget _buildRideActions() => _RideActionsPanel(
     flightRole:
         widget.rideController.session?.flightRole ?? FlightRole.observer,
@@ -5466,6 +5603,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     canChangeRoute: _isSimulation || widget.rideController.hasFlightAuthority,
     onAlertsAndReports: _openAlertsAndReports,
     onShareSummary: _shareCurrentRideSummary,
+    canOfferPilotHandover:
+        widget.rideController.hasFlightAuthority &&
+        _pilotHandoverTargets.isNotEmpty,
+    onOfferPilotHandover: () => unawaited(_offerPilotHandover()),
+    pendingPilotHandoverFrom: _pendingPilotHandoverFrom,
+    onAcceptPilotHandover: () => unawaited(_acceptPilotHandover()),
     onOpenRoster: _openRoster,
     onShareRoster: _shareRoster,
     onChangeRoute: _requestRouteChange,

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -59,6 +59,7 @@ import '../../relay/sqlite_relay_queue.dart';
 import '../../services/carplay_bridge.dart';
 import '../../services/chase_guidance_target.dart';
 import '../../services/fiesta_flight_loader.dart';
+import '../../services/flight_plan_summary.dart';
 import '../../services/geo_calculations.dart';
 import '../../services/spoken_audio_mode.dart';
 import '../../services/spoken_guidance_schedule.dart';
@@ -425,6 +426,7 @@ presentableQuickMessageAlerts({
 /// discover, while the moving map keeps only its large riding-time controls.
 class _RideActionsPanel extends StatelessWidget {
   const _RideActionsPanel({
+    required this.flightRole,
     required this.canChangeRoute,
     required this.onAlertsAndReports,
     required this.onShareSummary,
@@ -462,6 +464,7 @@ class _RideActionsPanel extends StatelessWidget {
     required this.coordinationMode,
   });
 
+  final FlightRole flightRole;
   final bool canChangeRoute;
   final VoidCallback onAlertsAndReports;
   final VoidCallback onShareSummary;
@@ -508,30 +511,44 @@ class _RideActionsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final title = switch (flightRole) {
+      FlightRole.pilot => 'Pilot controls',
+      FlightRole.balloonCrew => 'Airborne crew controls',
+      FlightRole.chaseDriver => 'Driver controls',
+      FlightRole.chaseCrew => 'Chase controls',
+      FlightRole.observer => 'Observer controls',
+    };
+    final detail = switch (flightRole) {
+      FlightRole.pilot =>
+        'Flight plan, landing intent, boundaries and crew coordination.',
+      FlightRole.balloonCrew =>
+        'Shared flight information and crew coordination. Pilot decisions are read-only.',
+      FlightRole.chaseDriver =>
+        'Road navigation and essential flight controls for this vehicle.',
+      FlightRole.chaseCrew =>
+        'Chase target, shared flight information and crew coordination.',
+      FlightRole.observer =>
+        'Read-only flight information and personal settings.',
+    };
     return Padding(
       padding: const EdgeInsets.only(top: 22),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text(
-            'Flight actions',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
+          Text(title, style: Theme.of(context).textTheme.headlineSmall),
           const SizedBox(height: 4),
-          const Text(
-            'Route, crew, sharing and flight controls are all on this page.',
-            style: TextStyle(color: Color(0xFF98A3B1)),
-          ),
+          Text(detail, style: const TextStyle(color: Color(0xFF98A3B1))),
           const SizedBox(height: 8),
-          ListTile(
-            key: const Key('ride-actions-alerts'),
-            leading: const Icon(Icons.warning_amber_outlined),
-            title: const Text('Alerts and reports'),
-            subtitle: const Text('Road alerts and traffic alternatives'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: onAlertsAndReports,
-          ),
+          if (flightRole.isChasing)
+            ListTile(
+              key: const Key('ride-actions-alerts'),
+              leading: const Icon(Icons.warning_amber_outlined),
+              title: const Text('Road alerts and reports'),
+              subtitle: const Text('Road hazards and traffic alternatives'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: onAlertsAndReports,
+            ),
           ListTile(
             key: const Key('ride-actions-share-summary'),
             leading: const Icon(Icons.summarize_outlined),
@@ -540,7 +557,7 @@ class _RideActionsPanel extends StatelessWidget {
             onTap: onShareSummary,
           ),
           const Divider(height: 20),
-          if (maneuverCount > 0)
+          if (flightRole.isChasing && maneuverCount > 0)
             ListTile(
               key: const Key('ride-menu-maneuvers'),
               leading: const Icon(Icons.list_alt),
@@ -2077,6 +2094,21 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         await widget.rideController.clearRoute();
       } else {
         await widget.rideController.publishRoute(route);
+        final plan = FlightPlanSummary.fromRoute(route);
+        final intendedLanding = plan?.intendedLanding;
+        if (intendedLanding != null) {
+          await widget.rideController.setLandingZone(
+            LandingZoneTarget(
+              center: awareness_geo.GeoPoint(
+                latitude: intendedLanding.latitude,
+                longitude: intendedLanding.longitude,
+              ),
+              radiusMeters: _landingRadiusMeters,
+              label: 'Planner intended landing area',
+              updatedAt: DateTime.now(),
+            ),
+          );
+        }
       }
       _appliedAuthoritativeRouteRevision =
           widget.rideController.authoritativeRouteState.revisionId;
@@ -5163,8 +5195,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   Widget _buildRideActions() => _RideActionsPanel(
+    flightRole:
+        widget.rideController.session?.flightRole ?? FlightRole.observer,
     coordinationMode: widget.rideController.coordinationMode,
-    canChangeRoute: _isSimulation || widget.rideController.isLocalRideLeader,
+    canChangeRoute: _isSimulation || widget.rideController.hasFlightAuthority,
     onAlertsAndReports: _openAlertsAndReports,
     onShareSummary: _shareCurrentRideSummary,
     onOpenRoster: _openRoster,
@@ -5172,12 +5206,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     onChangeRoute: _requestRouteChange,
     activeRouteIsForecast: _activeRoute?.isBalloonForecast == true,
     canChangeLandingZone:
-        !_isSimulation && widget.rideController.isLocalRideLeader,
+        !_isSimulation && widget.rideController.hasFlightAuthority,
     landingZoneLabel: widget.rideController.landingZone?.label,
     onChangeLandingZone: () => unawaited(_chooseLandingZoneOnMap()),
     boundaryCount: widget.rideController.operationalBoundaries.length,
     canEditBoundaries:
-        !_isSimulation && widget.rideController.isLocalRideLeader,
+        !_isSimulation && widget.rideController.hasFlightAuthority,
     onOperationalBoundaries: () => unawaited(_openOperationalBoundaries()),
     canChooseChaseGuidance:
         !_isSimulation &&
@@ -5207,7 +5241,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     ownPhoneNumberShared: widget.rideController.hasSharedOwnContactNumber,
     ownPhoneNumberRecipientLabel: _ownContactRecipients.toRideGroup
         ? 'this flight'
-        : 'the coordinator',
+        : 'the pilot',
     onShareOwnPhoneNumber: () => unawaited(_shareOwnPhoneNumber()),
     ridePaused: widget.rideController.ridePaused,
     canToggleRidePause:
@@ -6020,6 +6054,16 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         _observerAccessController?.localAssistance != null,
     serviceWarning: _warnings.isEmpty ? null : _warnings.join('\n'),
     connectivity: _connectivitySummary,
+    sharedFlightPlan: _liveRoutes.sharedFlightPlan,
+    vehicleRoadRoute: _liveRoutes.vehicleRoadRoute,
+    navigationPosition: _mapNavigationPosition,
+    windForecast: _windForecastController,
+    chaseGuidanceLabel: _chaseGuidanceRouting
+        ? 'Calculating a road rendezvous…'
+        : _chaseGuidanceTarget?.label,
+    onUpdateFlightPlan: _requestRouteChange,
+    onUpdateLandingArea: () => unawaited(_chooseLandingZoneOnMap()),
+    onChooseChaseGuidance: () => unawaited(_chooseChaseGuidanceTarget()),
   );
 
   Widget _buildSettings() => SafeArea(

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -3112,7 +3112,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   List<MapOverlayTrace> get _sharedForecastTraces {
     final plan = _liveRoutes.sharedFlightPlan;
-    if (_isSimulation || plan == null) return const [];
+    if (_isSimulation || !_isChaserPerspective || plan == null) return const [];
     return [
       for (final (index, path) in plan.paths.indexed)
         if (path.points.length >= 2)

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -1253,6 +1253,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   _OperationalBoundaryDraft? _operationalBoundaryDraft;
   double _landingRadiusMeters = 500;
   ChaseGuidanceTarget? _chaseGuidanceTarget;
+  String? _observedLandingGuidanceRevision;
   bool _chaseGuidanceRouting = false;
   DateTime? _lastChaseGuidanceRouteAt;
   awareness_geo.GeoPoint? _lastChaseGuidanceTarget;
@@ -1580,9 +1581,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       _warnings.add('Traffic preferences could not be restored: $error');
     }
     try {
-      await _restoreChaseGuidanceTarget();
+      await _initializeChaseGuidanceTarget();
     } on Object catch (error) {
-      _warnings.add('Chase guidance preference could not be restored: $error');
+      _warnings.add('Chase vehicle guidance could not be restored: $error');
     }
     try {
       await _replaceAwarenessController(route);
@@ -1831,23 +1832,24 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       'traffic-reroute-suppression:'
       '${widget.rideController.session?.rideId ?? 'none'}';
 
-  String get _chaseGuidancePreferenceKey =>
-      'chase-guidance-target:'
-      '${widget.rideController.session?.rideId ?? 'none'}';
-
   bool get _isChaserPerspective =>
       widget.rideController.session?.flightRole.isChasing == true;
 
-  Future<void> _restoreChaseGuidanceTarget() async {
+  Future<void> _initializeChaseGuidanceTarget() async {
     if (!_isChaserPerspective) return;
-    final preferences = await SharedPreferences.getInstance();
-    final stored = preferences.getString(_chaseGuidancePreferenceKey);
-    _chaseGuidanceTarget = ChaseGuidanceTarget.values
-        .where((target) => target.name == stored)
-        .firstOrNull;
-    _chaseGuidanceTarget ??= widget.rideController.landingZone == null
-        ? ChaseGuidanceTarget.balloon
-        : ChaseGuidanceTarget.landingArea;
+    final shared = widget.rideController.localChaseGuidanceSelection;
+    final initial =
+        shared?.target ??
+        (widget.rideController.landingZone == null
+            ? ChaseGuidanceTarget.balloon
+            : ChaseGuidanceTarget.landingArea);
+    _chaseGuidanceTarget = initial;
+    _observedLandingGuidanceRevision = _landingGuidanceRevisionFingerprint(
+      widget.rideController.landingZone,
+    );
+    if (shared == null) {
+      await widget.rideController.setLocalChaseGuidanceTarget(initial);
+    }
   }
 
   /// Publishes a rider's own enforcement sighting to the group.
@@ -3378,6 +3380,18 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   };
 
   void _onRideControllerChanged() {
+    final sharedTarget = _isChaserPerspective
+        ? widget.rideController.localChaseGuidanceSelection?.target
+        : null;
+    final chaseTargetChanged =
+        sharedTarget != null && sharedTarget != _chaseGuidanceTarget;
+    if (sharedTarget != null) _chaseGuidanceTarget = sharedTarget;
+    final landingRevision = _landingGuidanceRevisionFingerprint(
+      widget.rideController.landingZone,
+    );
+    final landingTargetChanged =
+        landingRevision != _observedLandingGuidanceRevision;
+    _observedLandingGuidanceRevision = landingRevision;
     _syncSharedLandingZone();
     _syncOperationalBoundaries();
     if (_isChaserPerspective && _chaseGuidanceTarget == null) {
@@ -3409,13 +3423,27 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         unawaited(_pushNotificationController?.refreshRegistration());
       }
       _publishObserverSnapshot();
-      unawaited(_refreshChaseGuidanceIfNeeded());
+      unawaited(
+        _refreshChaseGuidanceIfNeeded(
+          force:
+              chaseTargetChanged ||
+              (landingTargetChanged &&
+                  _chaseGuidanceTarget == ChaseGuidanceTarget.landingArea),
+        ),
+      );
     }
     if (widget.rideController.rideEnded && !_rideEndHandled) {
       unawaited(_handleRideEnded());
     }
     _schedulePublish();
   }
+
+  static String? _landingGuidanceRevisionFingerprint(
+    LandingZoneTarget? target,
+  ) => target == null
+      ? null
+      : '${target.center.latitude}:${target.center.longitude}:'
+            '${target.radiusMeters}:${target.updatedAt.toUtc().toIso8601String()}';
 
   void _syncSharedLandingZone() {
     final target = widget.rideController.landingZone;
@@ -4303,7 +4331,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           const ListTile(
             title: Text('Directions for this chase vehicle'),
             subtitle: Text(
-              'This changes only this device. The route ends on a road near the target; it never directs a vehicle off-road.',
+              'Driver and crew in this vehicle share this choice. The route ends on a road near the target; it never directs a vehicle off-road.',
             ),
           ),
           ListTile(
@@ -4345,9 +4373,20 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       ),
     );
     if (selected == null || !mounted) return;
+    final saved = await widget.rideController.setLocalChaseGuidanceTarget(
+      selected,
+    );
+    if (!saved || !mounted) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('The shared chase target could not be updated.'),
+          ),
+        );
+      }
+      return;
+    }
     setState(() => _chaseGuidanceTarget = selected);
-    final preferences = await SharedPreferences.getInstance();
-    await preferences.setString(_chaseGuidancePreferenceKey, selected.name);
     await _refreshChaseGuidanceIfNeeded(force: true);
   }
 
@@ -4417,7 +4456,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         id: 'personal-chase-${_chaseGuidanceRouteSequence++}',
         name: selected.label,
         description:
-            'Device-local road guidance. The road endpoint is '
+            'Road guidance for this chase vehicle. The road endpoint is '
             '${MeasurementFormatter(widget.distanceUnits.value).distance(separation)} '
             'from ${selected == ChaseGuidanceTarget.balloon ? 'the latest balloon fix' : 'the centre of the intended area'}. Access and stopping suitability remain unverified.',
         importedAt: now,
@@ -5271,7 +5310,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         ? 'Calculating a road rendezvous…'
         : _chaseGuidanceTarget == null
         ? null
-        : '${_chaseGuidanceTarget!.label} · only on this device',
+        : '${_chaseGuidanceTarget!.label} · shared in this vehicle',
     onChooseChaseGuidance: () => unawaited(_chooseChaseGuidanceTarget()),
     maneuverCount: const NavigationGuidancePlanner()
         .instructions(_activeRoute)

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -1453,7 +1453,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             } else {
               await _rideRouteStore!.saveActiveRoute(route);
             }
-          } else if (session.role != RideRole.lead) {
+          } else if (!widget.rideController.hasFlightAuthority) {
             route = null;
             await _rideRouteStore!.clearActiveRoute();
           } else {
@@ -1520,7 +1520,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (widget.enableNativeServices && !_isSimulation) {
       final session = widget.rideController.session;
       final groupRide = widget.rideController.coordinationMode.isGroup;
-      if (groupRide && session?.role == RideRole.lead) {
+      if (groupRide && widget.rideController.hasFlightAuthority) {
         try {
           await widget.rideController.publishRideCode();
         } on RideCodeDirectoryException catch (error) {
@@ -1744,7 +1744,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       '${widget.rideController.session?.rideId ?? 'none'}';
 
   bool get _isChaserPerspective =>
-      widget.rideController.session?.role != RideRole.lead;
+      widget.rideController.session?.flightRole.isChasing == true;
 
   Future<void> _restoreChaseGuidanceTarget() async {
     if (!_isChaserPerspective) return;
@@ -1951,7 +1951,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     // adapter itself stays in the repository, where a closed investigation
     // belongs, and is exercised by its own test.
     final externalProviders = <ExternalHazardProvider>[
-      if (session.role == RideRole.lead && !_isSimulation)
+      if (session.flightRole == FlightRole.chaseDriver && !_isSimulation)
         RelayTrafficHazardProvider(
           configuration: InternetRelayConfiguration.fromEnvironment(),
         ),
@@ -1970,7 +1970,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       // same event once each. The ids are derived from the OpenStreetMap node
       // so they merge into one hazard either way, but there is no reason to pay
       // for it six times over.
-      if (session.role == RideRole.lead)
+      if (session.flightRole == FlightRole.chaseDriver)
         FixedSpeedCameraProvider(readCatalogue: _loadFixedSpeedCameras),
     ];
     final controller = SituationalAwarenessController(
@@ -2007,7 +2007,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     }
     _pushRiderTrails();
     controller.addListener(_onAwarenessChanged);
-    if (session.role == RideRole.lead &&
+    if (session.flightRole == FlightRole.chaseDriver &&
         !_isSimulation &&
         widget.enableNativeServices) {
       unawaited(controller.refreshExternalHazards());
@@ -2823,7 +2823,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     // A real ride remains leader-owned. Ride Lab drives the entire virtual
     // group locally, so completion must work from its leader, follower and TEC
     // perspectives alike.
-    if (session == null || (!_isSimulation && session.role != RideRole.lead)) {
+    if (session == null ||
+        (!_isSimulation && !widget.rideController.hasFlightAuthority)) {
       return;
     }
     final route = _activeRoute;
@@ -3676,7 +3677,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 // record in the ride roster instead (#144).
                 participants: widget.rideController.liveParticipants,
                 coordinationMode: widget.rideController.coordinationMode,
-                isLeader: session.role == RideRole.lead,
+                isLeader: widget.rideController.hasFlightAuthority,
                 busy: widget.rideController.busy || _loading,
                 routeName: _activeRoute?.name,
                 onStartRide: _confirmStartRide,
@@ -3705,6 +3706,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         // the map viewport until the rider deliberately leaves the map tab.
         final hideWhileMoving =
             widget.rideController.rideStarted &&
+            session.flightRole == FlightRole.chaseDriver &&
             _selectedIndex == 0 &&
             _activeRoute != null &&
             navigationPosition != null;
@@ -3830,7 +3832,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
     final session = widget.rideController.session;
+    final flightRole = session?.flightRole;
     final isBalloonView = session?.flightRole.isAboardBalloon == true;
+    final isDriverView = flightRole == FlightRole.chaseDriver;
     final landingZoneUpdates = _isSimulation
         ? _simulationLandingZone
         : _sharedLandingZone;
@@ -3856,7 +3860,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       onOpenRoster: _openRoster,
       // Deliberately not `onOpenRideMenu`. The control that reaches the other
       // tabs is rendered by this shell instead — see _openRideMenu and #404.
-      enforcementAlert: isBalloonView ? null : _enforcementAlert,
+      enforcementAlert: isDriverView ? _enforcementAlert : null,
       rideCompletionSuggestion: _rideCompletionSuggestion,
       onEndRideForEveryone: _endRideFromCompletionSuggestion,
       onDismissRideCompletion: _dismissRideCompletionSuggestion,
@@ -3871,9 +3875,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       initialRouteStartConnector: _routeStartConnector,
       onRouteStartConnectorChanged: (connector) =>
           _routeStartConnector = connector,
-      onReportHazard: isBalloonView || _awarenessController == null
-          ? null
-          : _reportHazardFromMap,
+      onReportHazard: isDriverView && _awarenessController != null
+          ? _reportHazardFromMap
+          : null,
       emergencyContacts: _emergencyContacts,
       onEmergencyAlert: _sendEmergencyMapAlert,
       onEmergencyIssue: _sendEmergencyMapIssue,
@@ -3883,10 +3887,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       rideStarted: widget.rideController.rideStarted,
       onLeaveRide: _confirmLeaveRideFromMap,
       onRouteCommitted: _onRouteChanged,
-      onNavigationGuidanceChanged: isBalloonView
-          ? null
-          : _onNavigationGuidanceChanged,
-      onNavigationViewportChanged: isBalloonView
+      onNavigationGuidanceChanged: isDriverView
+          ? _onNavigationGuidanceChanged
+          : null,
+      onNavigationViewportChanged: !isDriverView
           ? null
           : (viewport) {
               final bridge = _carPlayBridge;
@@ -3923,10 +3927,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           !isBalloonView &&
           (_isSimulation || widget.rideController.isLocalRideLeader),
       distanceUnit: widget.distanceUnits.value,
-      speedLimitDisplay: isBalloonView ? null : widget.speedLimitDisplay,
+      speedLimitDisplay: isDriverView ? widget.speedLimitDisplay : null,
       chaseVehicle: widget.chaseVehicle?.vehicle ?? ChaseVehicle.unspecified,
       showRouteProgress:
-          !isBalloonView && (widget.routeProgressDisplay?.enabled ?? true),
+          isDriverView && (widget.routeProgressDisplay?.enabled ?? true),
       darkMapStyle: widget.mapStyleMode.resolveDark(
         MediaQuery.platformBrightnessOf(context),
       ),
@@ -4694,7 +4698,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final contacts = <String, MapEmergencyContact>{};
     final sharedNumbers = widget.rideController.receivedRiderContacts;
     final session = widget.rideController.session;
-    if (session != null && session.role == RideRole.lead) {
+    if (session != null && session.flightRole == FlightRole.pilot) {
       contacts[session.localRiderId] = MapEmergencyContact(
         riderId: session.localRiderId,
         displayName: session.displayName,
@@ -4928,7 +4932,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   String? get _currentLeaderRiderId {
     final session = widget.rideController.session;
-    if (session?.role == RideRole.lead) return session!.localRiderId;
+    if (session?.flightRole == FlightRole.pilot) {
+      return session!.localRiderId;
+    }
     for (final rider in _awarenessController?.riderLocations ?? const []) {
       if (rider.role == RideRole.lead) return rider.riderId;
     }
@@ -4966,7 +4972,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     }
     _rideStartFlowInProgress = true;
     try {
-      if (controller.session?.role != RideRole.lead || controller.rideStarted) {
+      if (!controller.hasFlightAuthority || controller.rideStarted) {
         _diagnostics?.recordNote(
           'start ride refused before the dialog: not the leader, or already '
           'started',
@@ -5139,7 +5145,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     canToggleRidePause:
         !_isSimulation &&
         widget.rideController.rideStarted &&
-        widget.rideController.session?.role == RideRole.lead,
+        widget.rideController.hasFlightAuthority,
     onToggleRidePause: _toggleRidePause,
     onLeaveOrEndRide: _confirmLeaveRideFromMap,
   );
@@ -6074,7 +6080,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         controller.rideStarted ||
         controller.busy ||
         controller.coordinationMode != RideCoordinationMode.solo ||
-        controller.session?.role != RideRole.lead) {
+        !controller.hasFlightAuthority) {
       return;
     }
     await _leaveRide();

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -31,6 +31,7 @@ import '../../data/secure_observer_grant_store.dart';
 import '../../domain/event_store.dart';
 import '../../domain/completed_ride_store.dart';
 import '../../domain/flight_replay.dart';
+import '../../domain/flight_role.dart';
 import '../../domain/geo_point.dart' as awareness_geo;
 import '../../domain/hazard.dart';
 import '../../domain/imported_route.dart' as route_domain;
@@ -3829,9 +3830,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
     final session = widget.rideController.session;
-    final isBalloonView = _isSimulation
-        ? session?.role == RideRole.lead
-        : widget.rideController.localCraft?.isBalloon == true;
+    final isBalloonView = session?.flightRole.isAboardBalloon == true;
     final landingZoneUpdates = _isSimulation
         ? _simulationLandingZone
         : _sharedLandingZone;

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -36,6 +36,7 @@ import '../../domain/geo_point.dart' as awareness_geo;
 import '../../domain/hazard.dart';
 import '../../domain/imported_route.dart' as route_domain;
 import '../../domain/landing_zone.dart';
+import '../../domain/live_route_state.dart';
 import '../../domain/operational_boundary.dart';
 import '../../domain/map_style_mode.dart';
 import '../../domain/quick_message.dart';
@@ -1222,7 +1223,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   String? _trailLifecycleFingerprint;
   String? _appliedAuthoritativeRouteRevision;
   String? _simulationRouteFingerprint;
-  route_domain.ImportedRoute? _activeRoute;
+  LiveRouteState _liveRoutes = const LiveRouteState();
+  route_domain.ImportedRoute? _simulationChaseRoute;
   NavigationGuidance? _latestNavigationGuidance;
   TrafficRerouteSuppression? _trafficRerouteSuppression;
   String? _lastTrafficOfferFingerprint;
@@ -1255,6 +1257,27 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   RideRole? _lastPushRole;
 
   bool get _isSimulation => widget.rideController.session?.isSimulation == true;
+
+  /// The route this device actively follows. The shared aircraft forecast and
+  /// a chase vehicle's road route are deliberately separate sources of truth.
+  route_domain.ImportedRoute? get _activeRoute {
+    if (_isSimulation) return _simulationChaseRoute;
+    final role = widget.rideController.session?.flightRole;
+    return role == null ? null : _liveRoutes.activeFor(role);
+  }
+
+  set _activeRoute(route_domain.ImportedRoute? route) {
+    if (_isSimulation) {
+      _simulationChaseRoute = route;
+      return;
+    }
+    final role = widget.rideController.session?.flightRole;
+    if (role?.isChasing == true) {
+      _liveRoutes = _liveRoutes.withVehicleRoadRoute(route);
+    } else {
+      _liveRoutes = _liveRoutes.withSharedFlightPlan(route);
+    }
+  }
 
   @override
   void initState() {
@@ -1312,25 +1335,21 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     widget.sharedRoutes.addListener(_onSharedRoutesChanged);
     _capturePlannerLinkError();
     if (widget.sharedRoutes.pending case final file?) {
-      if (widget.rideController.isLocalRideLeader) {
+      if (widget.rideController.hasFlightAuthority) {
         _selectedIndex = 0;
         _changeRouteRequestToken = Object();
         _pendingSharedGpxFile = file;
       } else {
-        _warnings.add(
-          'Only the pilot or coordinator can replace the crew route.',
-        );
+        _warnings.add('Only the pilot can replace the shared flight forecast.');
       }
       _clearSharedRoutePending();
     } else if (widget.sharedRoutes.pendingInAppRoute case final route?) {
-      if (widget.rideController.isLocalRideLeader) {
+      if (widget.rideController.hasFlightAuthority) {
         _selectedIndex = 0;
         _changeRouteRequestToken = Object();
         _pendingInAppRoute = route;
       } else {
-        _warnings.add(
-          'Only the pilot or coordinator can replace the crew route.',
-        );
+        _warnings.add('Only the pilot can replace the shared flight forecast.');
       }
       _clearSharedRoutePending();
     }
@@ -1362,10 +1381,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       if (warningAdded) setState(() {});
       return;
     }
-    if (!widget.rideController.isLocalRideLeader) {
-      _warnings.add(
-        'Only the pilot or coordinator can replace the crew route.',
-      );
+    if (!widget.rideController.hasFlightAuthority) {
+      _warnings.add('Only the pilot can replace the shared flight forecast.');
       _clearSharedRoutePending();
       setState(() {});
       return;
@@ -1407,8 +1424,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     var publishStoredLeaderRoute = false;
     if (_isSimulation) {
       try {
-        // The chase crew's road route is the group route, because it is the
-        // one anybody drives. The balloon's air track is not a route at all.
+        // Ride Lab currently replays one local chase road route alongside the
+        // balloon track. Production keeps those route purposes separate.
         const loader = BundledFiestaFlightLoader();
         route = await loader.loadChaseRoute();
         _balloonFlight = await loader.load();
@@ -1441,24 +1458,39 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           _rideRouteStore = await JsonFileRouteStore.openForRide(
             session.rideId,
           ).timeout(_localRouteRestoreTimeout);
-          route = await _rideRouteStore!.loadActiveRoute().timeout(
+          final storedRoute = await _rideRouteStore!.loadActiveRoute().timeout(
             _localRouteRestoreTimeout,
           );
           final authoritative = widget.rideController.authoritativeRouteState;
           _appliedAuthoritativeRouteRevision = authoritative.revisionId;
-          if (authoritative.hasDecision) {
-            route = authoritative.route;
-            if (route == null) {
-              await _rideRouteStore!.clearActiveRoute();
-            } else {
-              await _rideRouteStore!.saveActiveRoute(route);
-            }
-          } else if (!widget.rideController.hasFlightAuthority) {
-            route = null;
-            await _rideRouteStore!.clearActiveRoute();
+          if (session.flightRole.isChasing) {
+            // This store belongs to this device, so on a chaser it contains
+            // road guidance. The relay's authoritative route is the shared
+            // aircraft forecast and must never replace it.
+            _liveRoutes = LiveRouteState(
+              sharedFlightPlan: authoritative.hasDecision
+                  ? authoritative.route
+                  : null,
+              vehicleRoadRoute: storedRoute,
+            );
           } else {
-            publishStoredLeaderRoute = route != null;
+            final sharedPlan = authoritative.hasDecision
+                ? authoritative.route
+                : storedRoute;
+            _liveRoutes = LiveRouteState(sharedFlightPlan: sharedPlan);
+            if (authoritative.hasDecision) {
+              if (sharedPlan == null) {
+                await _rideRouteStore!.clearActiveRoute();
+              } else {
+                await _rideRouteStore!.saveActiveRoute(sharedPlan);
+              }
+            } else {
+              publishStoredLeaderRoute =
+                  widget.rideController.hasFlightAuthority &&
+                  sharedPlan != null;
+            }
           }
+          route = _activeRoute;
         }
       } on Object catch (error) {
         // Never fall back to the legacy app-wide route file. A failed
@@ -1468,11 +1500,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         _warnings.add('Route storage could not be opened: $error');
         final authoritative = widget.rideController.authoritativeRouteState;
         _appliedAuthoritativeRouteRevision = authoritative.revisionId;
-        if (authoritative.hasDecision) route = authoritative.route;
+        if (authoritative.hasDecision) {
+          _liveRoutes = _liveRoutes.withSharedFlightPlan(authoritative.route);
+        }
+        route = _activeRoute;
       }
     }
 
-    _activeRoute = route;
+    if (_isSimulation) _activeRoute = route;
     if (!mounted) return;
 
     // The map depends only on its ride-scoped route store. It must not leave a
@@ -1512,7 +1547,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         _appliedAuthoritativeRouteRevision =
             widget.rideController.authoritativeRouteState.revisionId;
       } on Object catch (error) {
-        _warnings.add('The stored group route could not be published: $error');
+        _warnings.add(
+          'The stored flight forecast could not be published: $error',
+        );
       }
     }
     if (!mounted) return;
@@ -1772,7 +1809,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   List<HazardReport> get _trafficRerouteHazards {
-    if (!widget.rideController.isLocalRideLeader ||
+    if (widget.rideController.localFlightRole != FlightRole.chaseDriver ||
         !widget.rideController.rideStarted ||
         _activeRoute == null) {
       return const [];
@@ -1861,24 +1898,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           if (preview.trafficDelaySaved > Duration.zero)
             'Estimated live-traffic delay avoided: '
                 '${_trafficDurationLabel(preview.trafficDelaySaved)}.',
-          'The current group route remains authoritative until you confirm.',
+          'This vehicle keeps its current road route until you confirm.',
         ],
       );
       if (action != RouteConfirmationAction.confirm || !mounted) return;
-      final previousRevision =
-          widget.rideController.authoritativeRouteState.revisionNumber;
-      await _handleRouteChanged(preview.route);
-      final published = widget.rideController.authoritativeRouteState;
-      if (published.revisionNumber <= previousRevision ||
-          published.route?.id != preview.route.id) {
-        _activeRoute = route;
-        await _replaceAwarenessController(route);
-        await _rideRouteStore?.saveActiveRoute(route);
-        throw const FormatException(
-          'The traffic alternative could not be published. '
-          'The current route has been restored.',
-        );
-      }
+      _liveRoutes = _liveRoutes.withVehicleRoadRoute(preview.route);
+      await _rideRouteStore?.saveActiveRoute(preview.route);
+      await _replaceAwarenessController(preview.route);
       await _suppressTrafficIncidents(hazards);
       if (mounted) {
         setState(() {
@@ -2022,8 +2048,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   Future<void> _handleRouteChanged(route_domain.ImportedRoute? route) async {
-    if (!_isSimulation && !widget.rideController.isLocalRideLeader) {
-      _warnings.add('A chaser cannot replace the coordinator’s crew route.');
+    if (!_isSimulation && !widget.rideController.hasFlightAuthority) {
+      _warnings.add('Only the pilot can replace the shared flight forecast.');
       await _applyAuthoritativeRouteDecision();
       if (mounted) setState(() {});
       return;
@@ -2065,16 +2091,19 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     }
     _appliedAuthoritativeRouteRevision = state.revisionId;
     final route = state.route;
-    final store = _rideRouteStore;
-    if (store != null) {
-      if (route == null) {
-        await store.clearActiveRoute();
-      } else {
-        await store.saveActiveRoute(route);
+    _liveRoutes = _liveRoutes.withSharedFlightPlan(route);
+    if (!_isChaserPerspective) {
+      final store = _rideRouteStore;
+      if (store != null) {
+        if (route == null) {
+          await store.clearActiveRoute();
+        } else {
+          await store.saveActiveRoute(route);
+        }
       }
+      await _replaceAwarenessController(route);
     }
-    _activeRoute = route;
-    await _replaceAwarenessController(route);
+    _pushRiderTrails();
     if (mounted) setState(() {});
     if (_isChaserPerspective && _chaseGuidanceTarget != null) {
       unawaited(_refreshChaseGuidanceIfNeeded(force: true));
@@ -3039,6 +3068,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               RiderTrailKind.leader => '${trail.displayName} leader trail',
               RiderTrailKind.balloonGroundTrack =>
                 '${trail.displayName} balloon ground track',
+              RiderTrailKind.forecastTrack =>
+                '${trail.displayName} flight forecast',
               RiderTrailKind.rider => '${trail.displayName} trail',
               RiderTrailKind.operationalBoundary =>
                 '${trail.displayName} operational boundary',
@@ -3061,13 +3092,30 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   void _pushRiderTrails() {
     _riderTrails.value = List.unmodifiable([
       for (final trace in _recordedTrailTraces) _simplifiedForDisplay(trace),
+      ..._sharedForecastTraces,
       ..._operationalBoundaryTraces,
     ]);
   }
 
+  List<MapOverlayTrace> get _sharedForecastTraces {
+    final plan = _liveRoutes.sharedFlightPlan;
+    if (_isSimulation || plan == null) return const [];
+    return [
+      for (final (index, path) in plan.paths.indexed)
+        if (path.points.length >= 2)
+          MapOverlayTrace(
+            id: 'shared-flight-forecast-$index',
+            points: _trailSimplifier.simplify(path.points),
+            label: path.name ?? '${plan.name} shared flight forecast',
+            kind: RiderTrailKind.forecastTrack,
+          ),
+    ];
+  }
+
   MapOverlayTrace _simplifiedForDisplay(MapOverlayTrace trace) {
     final simplified =
-        (trace.kind == RiderTrailKind.balloonGroundTrack
+        (trace.kind == RiderTrailKind.balloonGroundTrack ||
+                    trace.kind == RiderTrailKind.forecastTrack
                 ? _balloonTrailSimplifier
                 : _trailSimplifier)
             .simplify(trace.points);
@@ -4305,9 +4353,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         maneuvers: result.maneuvers,
         plannedDuration: result.duration,
       );
-      _activeRoute = route;
+      _liveRoutes = _liveRoutes.withVehicleRoadRoute(route);
       _lastChaseGuidanceRouteAt = now;
       _lastChaseGuidanceTarget = destination.point;
+      await _rideRouteStore?.saveActiveRoute(route);
       await _replaceAwarenessController(route);
       if (mounted) setState(() {});
     } on Object catch (error) {

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -431,6 +431,7 @@ class _RideActionsPanel extends StatelessWidget {
     required this.onOpenRoster,
     required this.onShareRoster,
     required this.onChangeRoute,
+    required this.activeRouteIsForecast,
     required this.canChangeLandingZone,
     required this.landingZoneLabel,
     required this.onChangeLandingZone,
@@ -467,6 +468,7 @@ class _RideActionsPanel extends StatelessWidget {
   final VoidCallback onOpenRoster;
   final VoidCallback onShareRoster;
   final VoidCallback onChangeRoute;
+  final bool activeRouteIsForecast;
   final bool canChangeLandingZone;
   final String? landingZoneLabel;
   final VoidCallback onChangeLandingZone;
@@ -560,9 +562,13 @@ class _RideActionsPanel extends StatelessWidget {
             ListTile(
               key: const Key('ride-menu-change-route'),
               leading: const Icon(Icons.edit_road_outlined),
-              title: const Text('Change route'),
-              subtitle: const Text(
-                'Plan a destination, import a GPX file, or load the demo route',
+              title: Text(
+                activeRouteIsForecast ? 'Change flight plan' : 'Change route',
+              ),
+              subtitle: Text(
+                activeRouteIsForecast
+                    ? 'Replace the advisory forecast, or plan chase guidance'
+                    : 'Plan a destination, import a GPX file, or load a forecast plan',
               ),
               onTap: onChangeRoute,
             ),
@@ -733,6 +739,7 @@ class _PreStartRidePanel extends StatelessWidget {
     required this.isLeader,
     required this.busy,
     required this.routeName,
+    required this.routeIsForecast,
     required this.onStartRide,
     required this.onChooseRoute,
     this.onJoinGroup,
@@ -744,6 +751,7 @@ class _PreStartRidePanel extends StatelessWidget {
   final bool isLeader;
   final bool busy;
   final String? routeName;
+  final bool routeIsForecast;
   final VoidCallback onStartRide;
   final VoidCallback onChooseRoute;
   final VoidCallback? onJoinGroup;
@@ -775,7 +783,7 @@ class _PreStartRidePanel extends StatelessWidget {
                       Text(
                         coordinationMode == RideCoordinationMode.solo
                             ? 'Ready for solo flight'
-                            : 'Waiting to start',
+                            : 'Waiting for launch',
                         style: TextStyle(fontWeight: FontWeight.w800),
                       ),
                       Text(
@@ -792,7 +800,7 @@ class _PreStartRidePanel extends StatelessWidget {
                 ),
                 if (!isLeader)
                   const Text(
-                    'LEADER STARTS',
+                    'COORDINATOR STARTS',
                     style: TextStyle(
                       color: Color(0xFFFFC857),
                       fontWeight: FontWeight.w800,
@@ -844,8 +852,10 @@ class _PreStartRidePanel extends StatelessWidget {
                 Expanded(
                   child: Text(
                     routeName == null
-                        ? 'No route selected'
-                        : 'Route: $routeName',
+                        ? 'No flight plan or chase route selected'
+                        : routeIsForecast
+                        ? 'Forecast plan: $routeName'
+                        : 'Chase route: $routeName',
                     maxLines: 2,
                     style: const TextStyle(
                       color: Color(0xFFD4DCE6),
@@ -857,7 +867,7 @@ class _PreStartRidePanel extends StatelessWidget {
                   TextButton(
                     key: const Key('pre-start-choose-route'),
                     onPressed: busy ? null : onChooseRoute,
-                    child: Text(routeName == null ? 'Choose route' : 'Change'),
+                    child: Text(routeName == null ? 'Choose plan' : 'Change'),
                   ),
               ],
             ),
@@ -1405,7 +1415,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final code = widget.sharedRoutes.plannerLinkCode;
     return _warnings.add(
       'Shared route link: $message'
-      '${code == null ? '' : ' You can still enter code $code from Change route → Load a planned route.'}',
+      '${code == null ? '' : ' You can still enter code $code from Change route → Load a forecast flight plan.'}',
     );
   }
 
@@ -1811,7 +1821,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   List<HazardReport> get _trafficRerouteHazards {
     if (widget.rideController.localFlightRole != FlightRole.chaseDriver ||
         !widget.rideController.rideStarted ||
-        _activeRoute == null) {
+        _activeRoute == null ||
+        _activeRoute!.isBalloonForecast) {
       return const [];
     }
     final now = DateTime.now();
@@ -1951,7 +1962,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (session == null) return;
 
     final routeSegments =
-        route?.paths
+        (route?.isBalloonForecast == true ? null : route)?.paths
             .where((path) => path.points.length >= 2)
             .map(
               (path) => path.points
@@ -2662,7 +2673,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final bridge = _carPlayBridge;
     if (bridge == null) return;
     final session = widget.rideController.session;
-    final navigationRoute = _activeRoute;
+    final navigationRoute = _activeRoute?.isBalloonForecast == true
+        ? null
+        : _activeRoute;
     final routeProgress = _carPlayRouteProgressTracker.update(
       navigationRoute,
       _mapPosition.value,
@@ -2936,7 +2949,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   static route_domain.GeoPoint? _routeDestination(
     route_domain.ImportedRoute? route,
   ) {
-    if (route == null) return null;
+    if (route == null || route.isBalloonForecast) return null;
     for (final path in route.paths.reversed) {
       if (path.points.isNotEmpty) return path.points.last;
     }
@@ -3065,7 +3078,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 : 'trail-${trail.riderId}-$index',
             points: points,
             label: switch (trail.kind) {
-              RiderTrailKind.leader => '${trail.displayName} leader trail',
+              RiderTrailKind.leader => '${trail.displayName} pilot trail',
               RiderTrailKind.balloonGroundTrack =>
                 '${trail.displayName} balloon ground track',
               RiderTrailKind.forecastTrack =>
@@ -3728,6 +3741,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 isLeader: widget.rideController.hasFlightAuthority,
                 busy: widget.rideController.busy || _loading,
                 routeName: _activeRoute?.name,
+                routeIsForecast: _activeRoute?.isBalloonForecast == true,
                 onStartRide: _confirmStartRide,
                 onChooseRoute: _requestRouteChange,
                 onJoinGroup: widget.onJoinGroupRequested == null
@@ -3971,9 +3985,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           ? () async => _mapPosition.value
           : _acquireCurrentPosition,
       routeStore: routeStore,
-      canEditRoute:
-          !isBalloonView &&
-          (_isSimulation || widget.rideController.isLocalRideLeader),
+      canEditRoute: _isSimulation || widget.rideController.hasFlightAuthority,
       distanceUnit: widget.distanceUnits.value,
       speedLimitDisplay: isDriverView ? widget.speedLimitDisplay : null,
       chaseVehicle: widget.chaseVehicle?.vehicle ?? ChaseVehicle.unspecified,
@@ -4637,6 +4649,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       locationReady: locationReady,
       isGroup: controller.coordinationMode.isGroup,
       routeName: _activeRoute?.name,
+      routeIsBalloonForecast: _activeRoute?.isBalloonForecast == true,
     );
   }
 
@@ -4911,7 +4924,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final recipients = _ownContactRecipients;
     if (recipients.isEmpty) {
       _showRideSnackBar(
-        'Nobody is holding the leader role yet, so there '
+        'Nobody is coordinating the flight yet, so there '
         'is nobody to give your number to. Nothing has been shared.',
       );
       return;
@@ -5035,12 +5048,17 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           title: const Text('Start this flight?'),
           content: Text(
             route == null
-                ? 'No route is selected. You can choose one now, or start '
-                      'without navigation. Live location sharing and flight '
+                ? 'No forecast plan or chase route is selected. You can '
+                      'choose one now, or start without one. Live location '
+                      'sharing and flight '
                       'recording begin only after you start.'
-                : 'Route: ${route.name}\n\nLive location sharing, route '
-                      'progress, off-course alerts and flight recording will '
-                      'begin for the group.',
+                : route.isBalloonForecast
+                ? 'Forecast plan: ${route.name}\n\nThis is an advisory '
+                      'wind-drift forecast, not a route the balloon can '
+                      'follow. Live location sharing and flight recording '
+                      'will begin for the group.'
+                : 'Chase route: ${route.name}\n\nLive location sharing, road '
+                      'guidance and flight recording will begin for the group.',
           ),
           actions: [
             TextButton(
@@ -5053,7 +5071,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 key: const Key('start-without-route-button'),
                 onPressed: () =>
                     Navigator.pop(dialogContext, _StartRideDecision.start),
-                child: const Text('Start without route'),
+                child: const Text('Start without a plan'),
               ),
               FilledButton.icon(
                 key: const Key('choose-route-before-start-button'),
@@ -5062,7 +5080,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                   _StartRideDecision.chooseRoute,
                 ),
                 icon: const Icon(Icons.route_outlined),
-                label: const Text('Choose route'),
+                label: const Text('Choose plan'),
               ),
             ] else
               FilledButton.icon(
@@ -5152,6 +5170,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     onOpenRoster: _openRoster,
     onShareRoster: _shareRoster,
     onChangeRoute: _requestRouteChange,
+    activeRouteIsForecast: _activeRoute?.isBalloonForecast == true,
     canChangeLandingZone:
         !_isSimulation && widget.rideController.isLocalRideLeader,
     landingZoneLabel: widget.rideController.landingZone?.label,

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -117,6 +117,27 @@ import 'observer_access_sheet.dart';
 import 'ride_dashboard.dart';
 import 'ride_roster_sheet.dart';
 
+const _driverTargetChangeMaximumSpeedMetersPerSecond = 0.75;
+const _driverTargetChangeMaximumFixAge = Duration(seconds: 10);
+
+@visibleForTesting
+bool canChangeChaseGuidanceTarget({
+  required FlightRole role,
+  required MapNavigationPosition? navigation,
+  required DateTime now,
+}) {
+  if (role == FlightRole.chaseCrew) return true;
+  if (role != FlightRole.chaseDriver || navigation == null) return false;
+  final age = now.difference(navigation.recordedAt);
+  final speed = navigation.speedMetersPerSecond;
+  return !age.isNegative &&
+      age <= _driverTargetChangeMaximumFixAge &&
+      speed != null &&
+      speed.isFinite &&
+      speed >= 0 &&
+      speed <= _driverTargetChangeMaximumSpeedMetersPerSecond;
+}
+
 /// Whether a newly calculated route should wait before replacing the current
 /// junction instruction.
 ///
@@ -1369,7 +1390,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       wakeLock: widget.screenWakeLock,
       reassertInterval: widget.screenWakeReassertInterval,
       onError: (error, _) {
-        if (kDebugMode) debugPrint('Could not enforce ride wake lock: $error');
+        if (kDebugMode) {
+          debugPrint('Could not enforce flight wake lock: $error');
+        }
       },
     )..start();
     final carPlayRouting = RoutingConfiguration.fromEnvironment();
@@ -3028,7 +3051,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       }
     } catch (error, stackTrace) {
       if (kDebugMode) {
-        debugPrint('Could not end the completed ride: $error\n$stackTrace');
+        debugPrint('Could not end the completed flight: $error\n$stackTrace');
       }
     } finally {
       _autoEndingRide = false;
@@ -3630,7 +3653,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       await locationController.resumeIfAuthorized();
     } on Object catch (error, stackTrace) {
       if (kDebugMode) {
-        debugPrint('Could not start GPS before the ride: $error\n$stackTrace');
+        debugPrint(
+          'Could not start GPS before the flight: $error\n$stackTrace',
+        );
       }
     }
   }
@@ -4449,6 +4474,24 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   Future<void> _chooseChaseGuidanceTarget() async {
+    final role = widget.rideController.session?.flightRole;
+    if (role == null ||
+        !canChangeChaseGuidanceTarget(
+          role: role,
+          navigation: _mapNavigationPosition.value,
+          now: DateTime.now(),
+        )) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Stop the chase vehicle before changing its guidance target.',
+            ),
+          ),
+        );
+      }
+      return;
+    }
     final landing = _currentChaseGuidanceDestination(
       target: ChaseGuidanceTarget.landingArea,
     );
@@ -4672,7 +4715,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         distanceMeters: previous.distanceMeters,
         armed: false,
         clearedBy: _dismissedEnforcementAlertId == previous.hazard.id
-            ? 'rider tap'
+            ? 'crew tap'
             : 'no longer detected',
       );
     }
@@ -4931,14 +4974,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               !locationController.status.canSample)) {
         final added = _warnings.add(
           'Open Balloon Crumbs on the iPhone and allow location access before '
-          'starting the ride from CarPlay.',
+          'starting the flight from CarPlay.',
         );
         _updateMapOverlays(updateDerivedState: false);
         if (added && mounted) setState(() {});
         return;
       }
 
-      _diagnostics?.recordNote('start ride accepted from CarPlay');
+      _diagnostics?.recordNote('start flight accepted from CarPlay');
       if (await _commitRideStart(source: 'CarPlay')) {
         await _resumeLocationForActiveRide();
       }
@@ -4959,11 +5002,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return true;
     } on Object catch (error, stackTrace) {
       _diagnostics?.recordNote(
-        'start ride failed from $source: ${error.runtimeType}: $error',
+        'start flight failed from $source: ${error.runtimeType}: $error',
       );
       if (kDebugMode) {
         debugPrint(
-          'Could not start the ride from $source: $error\n$stackTrace',
+          'Could not start the flight from $source: $error\n$stackTrace',
         );
       }
       final message = source == 'CarPlay'
@@ -5274,7 +5317,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     // the gate; no entry at all means the tap never reached Dart.
     final controller = widget.rideController;
     _diagnostics?.recordNote(
-      'start ride tapped on the phone: '
+      'start flight tapped on the phone: '
       'role=${controller.session?.role.name ?? 'none'} '
       'started=${controller.rideStarted} '
       'busy=${controller.busy} '
@@ -5282,7 +5325,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     );
     if (_rideStartFlowInProgress) {
       _diagnostics?.recordNote(
-        'start ride refused before the dialog: another start flow is active',
+        'start flight refused before the dialog: another start flow is active',
       );
       return;
     }
@@ -5290,7 +5333,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     try {
       if (!controller.hasFlightAuthority || controller.rideStarted) {
         _diagnostics?.recordNote(
-          'start ride refused before the dialog: not the leader, or already '
+          'start flight refused before the dialog: no pilot authority, or already '
           'started',
         );
         return;
@@ -5348,7 +5391,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         ),
       );
       _diagnostics?.recordNote(
-        'start ride decision: ${decision?.name ?? 'dismissed'}',
+        'start flight decision: ${decision?.name ?? 'dismissed'}',
       );
       if (decision == _StartRideDecision.chooseRoute) {
         _requestRouteChange();
@@ -5439,7 +5482,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         !_isSimulation &&
         _isChaserPerspective &&
         widget.rideController.rideStarted &&
-        !widget.rideController.rideEnded,
+        !widget.rideController.rideEnded &&
+        canChangeChaseGuidanceTarget(
+          role:
+              widget.rideController.session?.flightRole ?? FlightRole.observer,
+          navigation: _mapNavigationPosition.value,
+          now: DateTime.now(),
+        ),
     chaseGuidanceLabel: _chaseGuidanceRouting
         ? 'Calculating a road rendezvous…'
         : _chaseGuidanceTarget == null
@@ -6264,30 +6313,46 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     await widget.rideController.restartSimulationRide(riderCount: riderCount);
   }
 
-  Widget _buildDetails() => RideDashboard(
-    controller: widget.rideController,
-    distanceUnits: widget.distanceUnits,
-    rideActions: _buildRideActions(),
-    onOpenRoster: _openRoster,
-    relayController: _relayController,
-    internetRelayController: _internetRelayController,
-    onSendQuickMessage: _sendLocalQuickMessage,
-    localObserverAssistanceActive:
-        _observerAccessController?.localAssistance != null,
-    serviceWarning: _warnings.isEmpty ? null : _warnings.join('\n'),
-    connectivity: _connectivitySummary,
-    sharedFlightPlan: _liveRoutes.sharedFlightPlan,
-    vehicleRoadRoute: _liveRoutes.vehicleRoadRoute,
-    navigationPosition: _mapNavigationPosition,
-    windForecast: _windForecastController,
-    liveFlightProjection: _liveFlightProjection,
-    chaseGuidanceLabel: _chaseGuidanceRouting
-        ? 'Calculating a road rendezvous…'
-        : _chaseGuidanceTarget?.label,
-    onUpdateFlightPlan: _requestRouteChange,
-    onUpdateLandingArea: () => unawaited(_chooseLandingZoneOnMap()),
-    onChooseChaseGuidance: () => unawaited(_chooseChaseGuidanceTarget()),
-  );
+  Widget _buildDetails() {
+    final role =
+        widget.rideController.session?.flightRole ?? FlightRole.observer;
+    final canChangeChaseTarget = canChangeChaseGuidanceTarget(
+      role: role,
+      navigation: _mapNavigationPosition.value,
+      now: DateTime.now(),
+    );
+    return RideDashboard(
+      controller: widget.rideController,
+      distanceUnits: widget.distanceUnits,
+      rideActions: _buildRideActions(),
+      onOpenRoster: _openRoster,
+      relayController: _relayController,
+      internetRelayController: _internetRelayController,
+      onSendQuickMessage: _sendLocalQuickMessage,
+      localObserverAssistanceActive:
+          _observerAccessController?.localAssistance != null,
+      serviceWarning: _warnings.isEmpty ? null : _warnings.join('\n'),
+      connectivity: _connectivitySummary,
+      sharedFlightPlan: _liveRoutes.sharedFlightPlan,
+      vehicleRoadRoute: _liveRoutes.vehicleRoadRoute,
+      navigationPosition: _mapNavigationPosition,
+      windForecast: _windForecastController,
+      liveFlightProjection: _liveFlightProjection,
+      chaseGuidanceLabel: _chaseGuidanceRouting
+          ? 'Calculating a road rendezvous…'
+          : role == FlightRole.chaseDriver && !canChangeChaseTarget
+          ? [
+              if (_chaseGuidanceTarget != null) _chaseGuidanceTarget!.label,
+              'stop to change target',
+            ].join(' · ')
+          : _chaseGuidanceTarget?.label,
+      onUpdateFlightPlan: _requestRouteChange,
+      onUpdateLandingArea: () => unawaited(_chooseLandingZoneOnMap()),
+      onChooseChaseGuidance: canChangeChaseTarget
+          ? () => unawaited(_chooseChaseGuidanceTarget())
+          : null,
+    );
+  }
 
   Widget _buildSettings() => SafeArea(
     child: UnitSettingsSheet(

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -74,6 +74,7 @@ import '../../services/fixed_speed_camera_catalogue.dart';
 import '../../services/fixed_speed_camera_provider.dart';
 import '../../services/gpx_import_source.dart';
 import '../../services/measurement_formatter.dart';
+import '../../services/live_flight_projection.dart';
 import '../../services/native_push_token_source.dart';
 import '../../services/open_meteo_wind.dart';
 import '../../services/operational_boundary_monitor.dart';
@@ -1260,6 +1261,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   int _chaseGuidanceRouteSequence = 0;
   static const _chaseGuidanceResolver = ChaseGuidanceTargetResolver();
   static const _chaseGuidanceReroutePolicy = ChaseGuidanceReroutePolicy();
+  static const _liveFlightProjectionEngine = LiveFlightProjectionEngine();
+  LiveFlightProjectionAssessment _liveFlightProjection =
+      const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noStructuredPlan,
+      );
+  String? _liveFlightProjectionFingerprint;
   String? _recordedWindContextFingerprint;
   bool _simulationRerouteInFlight = false;
   Duration? _lastSimulationRerouteElapsed;
@@ -1624,6 +1631,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         widget.rideController.refreshMembershipFreshness();
         final awareness = _awarenessController;
         if (awareness != null) unawaited(awareness.refreshStaleness());
+        _refreshLiveFlightProjection();
       });
       _externalHazardTimer = Timer.periodic(const Duration(minutes: 5), (_) {
         final awareness = _awarenessController;
@@ -2400,6 +2408,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return;
     }
     _updateMapOverlays();
+    _refreshWindForFlightContext();
     unawaited(_refreshChaseGuidanceIfNeeded());
     _refreshTrafficOfferState();
     _schedulePublish();
@@ -2594,6 +2603,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           : _latestBalloonFix()?.altitudeMeters;
       _windForecastController?.updateBalloonAltitude(balloonAltitude);
     }
+    _refreshLiveFlightProjection();
 
     // A simulation can finish between throttled overlay frames. Completion
     // needs to inspect the final GPS fixes even when no later overlay frame is
@@ -3177,6 +3187,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 '${trail.displayName} operational boundary',
               RiderTrailKind.originalLandingEnvelope =>
                 '${trail.displayName} original landing envelope',
+              RiderTrailKind.liveProjectionTrack =>
+                '${trail.displayName} live flight projection',
+              RiderTrailKind.liveLandingEnvelope =>
+                '${trail.displayName} live possible landing envelope',
               // RiderTrailRecorder only records where riders have been, so it
               // never produces a route-start connector; the map composes that
               // one itself.
@@ -3199,6 +3213,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       for (final trace in _recordedTrailTraces) _simplifiedForDisplay(trace),
       ..._sharedForecastTraces,
       ..._originalLandingEnvelopeTraces,
+      ..._liveProjectionTraces,
       ..._operationalBoundaryTraces,
     ]);
   }
@@ -3256,10 +3271,36 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     ];
   }
 
+  List<MapOverlayTrace> get _liveProjectionTraces {
+    final role = widget.rideController.session?.flightRole;
+    final projection = _liveFlightProjection.projection;
+    if (role == FlightRole.chaseDriver || projection == null) return const [];
+    final validAt = projection.windValidAt.toLocal();
+    return [
+      if (projection.track.length >= 2)
+        MapOverlayTrace(
+          id: 'live-flight-projection',
+          points: _balloonTrailSimplifier.simplify(projection.track),
+          label:
+              'Live projection · ${projection.windSource} · wind valid $validAt',
+          kind: RiderTrailKind.liveProjectionTrack,
+        ),
+      if (projection.landingEnvelope.length >= 4)
+        MapOverlayTrace(
+          id: 'live-possible-landing-envelope',
+          points: _trailSimplifier.simplify(projection.landingEnvelope),
+          label:
+              'Live possible-landing envelope · forecast wind valid $validAt · suitability unverified',
+          kind: RiderTrailKind.liveLandingEnvelope,
+        ),
+    ];
+  }
+
   MapOverlayTrace _simplifiedForDisplay(MapOverlayTrace trace) {
     final simplified =
         (trace.kind == RiderTrailKind.balloonGroundTrack ||
-                    trace.kind == RiderTrailKind.forecastTrack
+                    trace.kind == RiderTrailKind.forecastTrack ||
+                    trace.kind == RiderTrailKind.liveProjectionTrack
                 ? _balloonTrailSimplifier
                 : _trailSimplifier)
             .simplify(trace.points);
@@ -3338,6 +3379,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   void _onWindForecastChanged() {
+    _refreshLiveFlightProjection();
     final field = _windForecastController?.field;
     if (field == null ||
         !widget.rideController.isLocalRideLeader ||
@@ -3729,20 +3771,26 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     // the journal feeds trails, summaries and GPX recording.
     _updateMapOverlays(updateDerivedState: false, updateOverlayMarkers: false);
     _checkOperationalBoundaries();
-    final point = _mapPosition.value;
-    final wind = _windForecastController;
-    if (point != null && wind != null) {
-      unawaited(
-        wind.refresh(
-          awareness_geo.GeoPoint(
-            latitude: point.latitude,
-            longitude: point.longitude,
-          ),
-        ),
-      );
-    }
+    _refreshWindForFlightContext();
     unawaited(_refreshChaseGuidanceIfNeeded());
     if (warningChanged) setState(() {});
+  }
+
+  void _refreshWindForFlightContext() {
+    final wind = _windForecastController;
+    final role = widget.rideController.session?.flightRole;
+    if (wind == null || role == FlightRole.chaseDriver) return;
+    final balloon = _latestBalloonFix();
+    final local = _mapPosition.value;
+    final center =
+        balloon?.position ??
+        (local == null
+            ? null
+            : awareness_geo.GeoPoint(
+                latitude: local.latitude,
+                longitude: local.longitude,
+              ));
+    if (center != null) unawaited(wind.refresh(center));
   }
 
   void _checkOperationalBoundaries() {
@@ -4074,7 +4122,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       onMapTap: _selectingLandingZone || boundaryDraft != null
           ? _handleFlightSetupMapTap
           : null,
-      windForecastController: _windForecastController,
+      windForecastController: isDriverView ? null : _windForecastController,
       groupRiderCount: widget.rideController.liveParticipants.length,
       onOpenRoster: _openRoster,
       // Deliberately not `onOpenRideMenu`. The control that reaches the other
@@ -4165,6 +4213,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       perspective: isBalloonView
           ? RideMapPerspective.balloon
           : RideMapPerspective.chase,
+      showForecastContext:
+          flightRole == FlightRole.pilot ||
+          flightRole == FlightRole.balloonCrew ||
+          flightRole == FlightRole.chaseCrew,
     );
     if (!_selectingLandingZone && boundaryDraft == null) return map;
     return Stack(
@@ -4347,6 +4399,40 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           right.sample.recordedAt.compareTo(left.sample.recordedAt),
     );
     return candidates.first.sample;
+  }
+
+  void _refreshLiveFlightProjection() {
+    final role = widget.rideController.session?.flightRole;
+    final showsProjection =
+        role == FlightRole.pilot ||
+        role == FlightRole.balloonCrew ||
+        role == FlightRole.chaseCrew;
+    final plan = showsProjection
+        ? _liveRoutes.sharedFlightPlan?.forecastPlan
+        : null;
+    final fix = showsProjection ? _latestBalloonFix() : null;
+    final field = showsProjection ? _windForecastController?.field : null;
+    final now = DateTime.now();
+    final fingerprint = [
+      role?.name ?? 'none',
+      plan?.id ?? 'none',
+      fix?.recordedAt.toUtc().toIso8601String() ?? 'none',
+      fix?.altitudeMeters?.toStringAsFixed(1) ?? 'none',
+      field?.fetchedAt.toUtc().toIso8601String() ?? 'none',
+      field?.validAt.toUtc().toIso8601String() ?? 'none',
+      now.millisecondsSinceEpoch ~/ const Duration(seconds: 15).inMilliseconds,
+    ].join(':');
+    if (fingerprint == _liveFlightProjectionFingerprint) return;
+    _liveFlightProjectionFingerprint = fingerprint;
+    _liveFlightProjection = _liveFlightProjectionEngine.evaluate(
+      plan: plan,
+      balloonFix: fix,
+      wind: field,
+      now: now,
+      allowReferenceWind: _isSimulation,
+    );
+    _pushRiderTrails();
+    if (mounted) setState(() {});
   }
 
   ChaseGuidanceDestination? _currentChaseGuidanceDestination({
@@ -6194,6 +6280,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     vehicleRoadRoute: _liveRoutes.vehicleRoadRoute,
     navigationPosition: _mapNavigationPosition,
     windForecast: _windForecastController,
+    liveFlightProjection: _liveFlightProjection,
     chaseGuidanceLabel: _chaseGuidanceRouting
         ? 'Calculating a road rendezvous…'
         : _chaseGuidanceTarget?.label,

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -58,6 +58,8 @@ import '../../relay/relay_engine.dart';
 import '../../relay/sqlite_relay_queue.dart';
 import '../../services/carplay_bridge.dart';
 import '../../services/chase_guidance_target.dart';
+import '../../services/craft_roster.dart';
+import '../../services/craft_track_reducer.dart';
 import '../../services/fiesta_flight_loader.dart';
 import '../../services/flight_plan_summary.dart';
 import '../../services/geo_calculations.dart';
@@ -341,6 +343,32 @@ RouteStore? activeRideMapStoreWhenReady({
 }) {
   if (initializing) return null;
   return isSimulation ? simulationRouteStore : rideRouteStore;
+}
+
+class _CraftMapLocation {
+  const _CraftMapLocation({
+    required this.id,
+    required this.displayName,
+    required this.sourceDeviceIds,
+    required this.freshnessDeviceId,
+    required this.isBalloon,
+    required this.motorcycleStyle,
+    required this.riderSymbol,
+    required this.riderColor,
+    required this.altitudeMeters,
+    required this.point,
+  });
+
+  final String id;
+  final String displayName;
+  final List<String> sourceDeviceIds;
+  final String freshnessDeviceId;
+  final bool isBalloon;
+  final CraftIconStyle motorcycleStyle;
+  final RiderSymbol riderSymbol;
+  final RiderColor riderColor;
+  final double? altitudeMeters;
+  final route_domain.GeoPoint point;
 }
 
 /// What the ride map should present of the quick messages in the journal, and
@@ -2390,6 +2418,43 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     });
   }
 
+  List<_CraftMapLocation> _productionCraftMapLocations(
+    CraftRoster roster, {
+    required String localRiderId,
+  }) {
+    final locations = <_CraftMapLocation>[];
+    for (final craft in roster.crafts) {
+      if (craft.deviceIds.contains(localRiderId)) continue;
+      final sample = craft.fix.sample;
+      final reporterId = craft.fix.deviceId;
+      if (sample == null || reporterId == null) continue;
+      final reporter = widget.rideController.participantFor(reporterId);
+      locations.add(
+        _CraftMapLocation(
+          id: craft.id,
+          displayName: craft.craft.label,
+          sourceDeviceIds: craft.deviceIds,
+          freshnessDeviceId: reporterId,
+          isBalloon: craft.isBalloon,
+          motorcycleStyle: craft.isBalloon
+              ? CraftIconStyle.balloon
+              : reporter?.motorcycleStyle ?? craftIconStyleDefault,
+          riderSymbol: craft.isBalloon
+              ? riderSymbolDefault
+              : reporter?.riderSymbol ?? riderSymbolDefault,
+          riderColor: reporter?.riderColor ?? riderColorDefault,
+          altitudeMeters: sample.altitudeMeters,
+          point: route_domain.GeoPoint(
+            latitude: sample.position.latitude,
+            longitude: sample.position.longitude,
+            recordedAt: sample.recordedAt,
+          ),
+        ),
+      );
+    }
+    return List.unmodifiable(locations);
+  }
+
   void _updateMapOverlays({
     bool updateDerivedState = true,
     bool updateOverlayMarkers = true,
@@ -2397,14 +2462,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }) {
     final awareness = _awarenessController;
     if (awareness == null) return;
-    final balloonDeviceIds = _isSimulation
-        ? const <String>{}
-        : (widget.rideController
-                  .resolveCraftRoster()
-                  .balloon
-                  ?.deviceIds
-                  .toSet() ??
-              const <String>{});
+    final craftRoster = _isSimulation
+        ? null
+        : widget.rideController.resolveCraftRoster();
     // One reconciled model for both ride phases and both transports, so nobody
     // disappears at the `rideStarted` transition, a late joiner appears at once,
     // and the count can never disagree with the drawn markers (#132).
@@ -2519,6 +2579,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               altitudeRecordedAt: localMapSample?.recordedAt,
             );
       _mapPosition.value = mapPoint;
+      final role = widget.rideController.session?.flightRole;
+      final balloonAltitude = role?.isAboardBalloon == true
+          ? localMapSample?.altitudeMeters
+          : _latestBalloonFix()?.altitudeMeters;
+      _windForecastController?.updateBalloonAltitude(balloonAltitude);
     }
 
     // A simulation can finish between throttled overlay frames. Completion
@@ -2554,36 +2619,20 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       for (final judgement in hazardJudgements)
         if (judgement.isVisible) _hazardOverlayMarker(judgement.report, now),
       ...(simulatedRiders == null
-              ? visibleRiderLocations
-                    .where(
-                      (location) => location.riderId != localLocation?.riderId,
-                    )
-                    .map(
-                      (location) => (
-                        riderId: location.riderId,
-                        displayName: location.displayName,
-                        role: location.role,
-                        motorcycleStyle:
-                            balloonDeviceIds.contains(location.riderId)
-                            ? CraftIconStyle.balloon
-                            : location.motorcycleStyle,
-                        riderSymbol: location.riderSymbol,
-                        riderColor: location.riderColor,
-                        altitudeMeters: location.sample.altitudeMeters,
-                        point: route_domain.GeoPoint(
-                          latitude: location.sample.position.latitude,
-                          longitude: location.sample.position.longitude,
-                          recordedAt: location.sample.recordedAt,
-                        ),
-                      ),
-                    )
+              ? _productionCraftMapLocations(
+                  craftRoster!,
+                  localRiderId:
+                      widget.rideController.session?.localRiderId ?? '',
+                )
               : simulatedRiders
                     .where((rider) => !rider.isLocal)
                     .map(
-                      (rider) => (
-                        riderId: rider.id,
+                      (rider) => _CraftMapLocation(
+                        id: rider.id,
                         displayName: rider.displayName,
-                        role: rider.role,
+                        sourceDeviceIds: [rider.id],
+                        freshnessDeviceId: rider.id,
+                        isBalloon: rider.role == RideRole.lead,
                         motorcycleStyle: rider.role == RideRole.lead
                             ? CraftIconStyle.balloon
                             : rider.motorcycleStyle,
@@ -2597,36 +2646,34 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                       ),
                     ))
           .map((location) {
-            final isLead = location.role == RideRole.lead;
-            final isBalloonCraft = _isSimulation
-                ? isLead
-                : balloonDeviceIds.contains(location.riderId);
+            final isBalloonCraft = location.isBalloon;
             // A position past its freshness threshold is demoted explicitly in
             // the label. The identity fill remains stable across surfaces.
             final freshness =
-                freshnessByRider[location.riderId]?.freshness ??
+                freshnessByRider[location.freshnessDeviceId]?.freshness ??
                 PresenceFreshness.live;
             final ageSuffix = switch (freshness) {
               PresenceFreshness.live => null,
               PresenceFreshness.none => PresenceFreshness.none.label,
               _ =>
-                freshnessByRider[location.riderId]?.freshnessLabel ??
+                freshnessByRider[location.freshnessDeviceId]?.freshnessLabel ??
                     freshness.label,
             };
             // Issue #151's map companion, kept deliberately minimal: the rider
             // who raised something already has a marker, so it says what they
             // raised rather than inventing a second symbol beside it.
-            final raised = quickMessagesBySender[location.riderId];
+            final raised = location.sourceDeviceIds
+                .map((deviceId) => quickMessagesBySender[deviceId])
+                .whereType<ReceivedQuickMessage>()
+                .firstOrNull;
             final roleSuffix = raised != null
                 ? raised.label
                 : isBalloonCraft
                 ? 'Balloon'
-                : isLead
-                ? 'Lead'
-                : null;
+                : 'Chase vehicle';
             final label = [
               location.displayName,
-              ?roleSuffix,
+              roleSuffix,
               if (isBalloonCraft && location.altitudeMeters != null)
                 '${location.altitudeMeters!.round()} m',
               ?ageSuffix,
@@ -2636,7 +2683,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             // rider look like different people across surfaces (#250).
             final baseColor = location.riderColor.color;
             return MapOverlayMarker(
-              id: 'rider-${location.riderId}',
+              id: 'craft-${location.id}',
               point: location.point,
               label: label,
               motorcycleStyle: location.motorcycleStyle,
@@ -3021,53 +3068,51 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   /// controller's leader history, which is rebuilt from the durable journal on
   /// restart, so it survives an app restart mid-ride as far as the journal
   /// allows.
-  void _updateRiderTrails(SituationalAwarenessController awareness) {
+  void _updateRiderTrails(SituationalAwarenessController _) {
     if (!widget.rideController.rideStarted) {
       _trailRecorder.clear();
       _publishRiderTrails(const []);
       return;
     }
-    final balloonDeviceIds =
-        widget.rideController.resolveCraftRoster().balloon?.deviceIds.toSet() ??
-        const <String>{};
+    final tracks = const CraftTrackReducer().fromEvents(
+      widget.rideController.events,
+    );
+    final roster = widget.rideController.resolveCraftRoster();
     _publishRiderTrails(
-      _trailRecorder.update([
-        for (final location in awareness.riderLocations)
-          RiderTrailUpdate(
-            riderId: location.riderId,
-            displayName: location.displayName,
-            position: route_domain.GeoPoint(
-              latitude: location.sample.position.latitude,
-              longitude: location.sample.position.longitude,
-              elevationMeters: location.sample.altitudeMeters,
-              altitudeSource: location.sample.altitudeSource,
-              altitudeDatum: location.sample.altitudeDatum,
-              altitudeAccuracyMeters: location.sample.altitudeAccuracyMeters,
-              recordedAt: location.sample.recordedAt,
-            ),
-            isLeader: location.role == RideRole.lead,
-            isBalloon: balloonDeviceIds.contains(location.riderId),
-            isEligible:
-                widget.rideController
-                    .participantFor(location.riderId)
-                    ?.isEligibleForLivePosition ==
-                true,
-            journalTrail: location.role == RideRole.lead
-                ? [
-                    for (final sample in awareness.leaderLocationSamples)
-                      route_domain.GeoPoint(
-                        latitude: sample.position.latitude,
-                        longitude: sample.position.longitude,
-                        elevationMeters: sample.altitudeMeters,
-                        altitudeSource: sample.altitudeSource,
-                        altitudeDatum: sample.altitudeDatum,
-                        altitudeAccuracyMeters: sample.altitudeAccuracyMeters,
-                        recordedAt: sample.recordedAt,
-                      ),
-                  ]
-                : null,
+      [
+        for (final track in tracks)
+          RiderTrail(
+            riderId: track.craftId,
+            displayName: track.label,
+            kind: track.isBalloon
+                ? RiderTrailKind.balloonGroundTrack
+                : RiderTrailKind.rider,
+            points: _trailRecorder.boundedTrail([
+              for (final sample in track.samples)
+                route_domain.GeoPoint(
+                  latitude: sample.position.latitude,
+                  longitude: sample.position.longitude,
+                  elevationMeters: sample.altitudeMeters,
+                  altitudeSource: sample.altitudeSource,
+                  altitudeDatum: sample.altitudeDatum,
+                  altitudeAccuracyMeters: sample.altitudeAccuracyMeters,
+                  recordedAt: sample.recordedAt,
+                ),
+            ]),
           ),
-      ]),
+      ],
+      colors: {
+        for (final track in tracks)
+          if (!track.isBalloon)
+            track.craftId:
+                widget.rideController
+                    .participantFor(
+                      roster.byId(track.craftId)?.fix.deviceId ?? '',
+                    )
+                    ?.riderColor
+                    .color ??
+                riderColorDefault.color,
+      },
     );
   }
 
@@ -3096,7 +3141,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       ),
   ];
 
-  void _publishRiderTrails(List<RiderTrail> trails) {
+  void _publishRiderTrails(
+    List<RiderTrail> trails, {
+    Map<String, Color> colors = const {},
+  }) {
     _recordedTrailTraces = List.unmodifiable([
       for (final trail in trails.where((trail) => trail.isRenderable))
         for (final (index, points)
@@ -3125,6 +3173,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 '${trail.displayName} route to start',
             },
             kind: trail.kind,
+            color: colors[trail.riderId],
           ),
     ]);
     _pushRiderTrails();

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -2125,19 +2125,26 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       } else {
         await widget.rideController.publishRoute(route);
         final plan = FlightPlanSummary.fromRoute(route);
+        final structuredPlan = route.forecastPlan;
         final intendedLanding = plan?.intendedLanding;
         if (intendedLanding != null) {
+          final plannedArea = structuredPlan?.intendedLandingArea;
           await widget.rideController.setLandingZone(
             LandingZoneTarget(
               center: awareness_geo.GeoPoint(
                 latitude: intendedLanding.latitude,
                 longitude: intendedLanding.longitude,
               ),
-              radiusMeters: _landingRadiusMeters,
+              radiusMeters: plannedArea?.radiusMeters ?? _landingRadiusMeters,
               label: 'Planner intended landing area',
-              updatedAt: DateTime.now(),
+              updatedAt: plannedArea?.updatedAt ?? DateTime.now(),
             ),
           );
+        }
+        for (final boundary
+            in structuredPlan?.operationalBoundaries ??
+                const <OperationalBoundary>[]) {
+          await widget.rideController.upsertOperationalBoundary(boundary);
         }
       }
       _appliedAuthoritativeRouteRevision =
@@ -3168,6 +3175,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               RiderTrailKind.rider => '${trail.displayName} trail',
               RiderTrailKind.operationalBoundary =>
                 '${trail.displayName} operational boundary',
+              RiderTrailKind.originalLandingEnvelope =>
+                '${trail.displayName} original landing envelope',
               // RiderTrailRecorder only records where riders have been, so it
               // never produces a route-start connector; the map composes that
               // one itself.
@@ -3189,13 +3198,20 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     _riderTrails.value = List.unmodifiable([
       for (final trace in _recordedTrailTraces) _simplifiedForDisplay(trace),
       ..._sharedForecastTraces,
+      ..._originalLandingEnvelopeTraces,
       ..._operationalBoundaryTraces,
     ]);
   }
 
   List<MapOverlayTrace> get _sharedForecastTraces {
     final plan = _liveRoutes.sharedFlightPlan;
-    if (_isSimulation || !_isChaserPerspective || plan == null) return const [];
+    final role = widget.rideController.session?.flightRole;
+    if (_isSimulation ||
+        !_isChaserPerspective ||
+        role == FlightRole.chaseDriver ||
+        plan == null) {
+      return const [];
+    }
     return [
       for (final (index, path) in plan.paths.indexed)
         if (path.points.length >= 2)
@@ -3205,6 +3221,38 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             label: path.name ?? '${plan.name} shared flight forecast',
             kind: RiderTrailKind.forecastTrack,
           ),
+    ];
+  }
+
+  List<MapOverlayTrace> get _originalLandingEnvelopeTraces {
+    final role = widget.rideController.session?.flightRole;
+    final plan = _liveRoutes.sharedFlightPlan?.forecastPlan;
+    final envelope = plan?.landingEnvelope ?? const [];
+    if (_isSimulation ||
+        role == FlightRole.chaseDriver ||
+        envelope.length < 3) {
+      return const [];
+    }
+    final points = <route_domain.GeoPoint>[
+      for (final point in envelope)
+        route_domain.GeoPoint(
+          latitude: point.latitude,
+          longitude: point.longitude,
+        ),
+      route_domain.GeoPoint(
+        latitude: envelope.first.latitude,
+        longitude: envelope.first.longitude,
+      ),
+    ];
+    return [
+      MapOverlayTrace(
+        id: 'original-landing-envelope-${plan!.id}',
+        points: _trailSimplifier.simplify(points),
+        label:
+            'Original landing envelope · forecast wind valid to '
+            '${plan.wind.validTo.toLocal()}',
+        kind: RiderTrailKind.originalLandingEnvelope,
+      ),
     ];
   }
 

--- a/apps/mobile/lib/features/ride/flight_assignment_screen.dart
+++ b/apps/mobile/lib/features/ride/flight_assignment_screen.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+import '../../controllers/ride_controller.dart';
+import '../../domain/flight_role.dart';
+import '../../domain/ride_role.dart';
+
+/// One-time repair gate for sessions created before flight roles and crafts.
+///
+/// No live-flight service is mounted behind this screen. Until assignment is
+/// explicit, the app cannot know whether road guidance or airborne information
+/// is appropriate and therefore shows neither.
+class FlightAssignmentScreen extends StatefulWidget {
+  const FlightAssignmentScreen({super.key, required this.controller});
+
+  final RideController controller;
+
+  @override
+  State<FlightAssignmentScreen> createState() => _FlightAssignmentScreenState();
+}
+
+class _FlightAssignmentScreenState extends State<FlightAssignmentScreen> {
+  final _vehicleLabelController = TextEditingController(text: 'Land Rover');
+  FlightRole _role = FlightRole.chaseCrew;
+
+  bool get _legacyCreator => widget.controller.session?.role == RideRole.lead;
+
+  @override
+  void dispose() {
+    _vehicleLabelController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    appBar: AppBar(title: const Text('Confirm your flight role')),
+    body: AnimatedBuilder(
+      animation: widget.controller,
+      builder: (context, _) => SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 560),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Icon(
+                    _legacyCreator
+                        ? Icons.air_outlined
+                        : Icons.groups_2_outlined,
+                    size: 48,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(height: 18),
+                  Text(
+                    _legacyCreator
+                        ? 'Restore this phone as the pilot'
+                        : 'Where are you in this flight?',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    _legacyCreator
+                        ? 'This flight predates separate balloon and chase roles. Confirming creates the balloon and restores pilot authority.'
+                        : 'This flight predates separate balloon and chase roles. Choose your job before location sharing or live controls resume.',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(color: Color(0xFFABB5C1)),
+                  ),
+                  if (!_legacyCreator) ...[
+                    const SizedBox(height: 24),
+                    Wrap(
+                      alignment: WrapAlignment.center,
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        _roleChip(
+                          FlightRole.balloonCrew,
+                          Icons.air,
+                          'Balloon crew',
+                        ),
+                        _roleChip(
+                          FlightRole.chaseDriver,
+                          Icons.directions_car,
+                          'Driver',
+                        ),
+                        _roleChip(
+                          FlightRole.chaseCrew,
+                          Icons.groups_2_outlined,
+                          'Chase crew',
+                        ),
+                      ],
+                    ),
+                    if (_role.isChasing) ...[
+                      const SizedBox(height: 16),
+                      TextField(
+                        key: const Key('repair-vehicle-label-field'),
+                        controller: _vehicleLabelController,
+                        maxLength: 32,
+                        textCapitalization: TextCapitalization.words,
+                        decoration: const InputDecoration(
+                          labelText: 'Chase vehicle',
+                          helperText:
+                              'Use the same name as crewmates in this vehicle.',
+                          counterText: '',
+                        ),
+                      ),
+                    ],
+                  ],
+                  if (widget.controller.errorMessage case final message?) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      message,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                  const SizedBox(height: 24),
+                  FilledButton.icon(
+                    key: const Key('confirm-flight-assignment'),
+                    onPressed: widget.controller.busy ? null : _submit,
+                    icon: widget.controller.busy
+                        ? const SizedBox.square(
+                            dimension: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.check),
+                    label: Text(
+                      _legacyCreator
+                          ? 'Restore pilot view'
+                          : 'Continue as ${_role.label}',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  Widget _roleChip(FlightRole role, IconData icon, String label) => ChoiceChip(
+    key: Key('repair-role-${role.name}'),
+    selected: _role == role,
+    avatar: Icon(icon, size: 18),
+    label: Text(label),
+    onSelected: (_) => setState(() => _role = role),
+  );
+
+  Future<void> _submit() => widget.controller.repairFlightAssignment(
+    role: _legacyCreator ? FlightRole.pilot : _role,
+    vehicleLabel: _vehicleLabelController.text,
+  );
+}

--- a/apps/mobile/lib/features/ride/ice_share_inbox_sheet.dart
+++ b/apps/mobile/lib/features/ride/ice_share_inbox_sheet.dart
@@ -122,7 +122,7 @@ class _ReceivedIceShareCard extends StatelessWidget {
       children: [
         Text(
           'From ${share.sharedByDisplayName}'
-          '${share.toWholeGroup ? '' : ' (shared with the leader)'}',
+          '${share.toWholeGroup ? '' : ' (shared with the coordinator)'}',
           style: const TextStyle(fontWeight: FontWeight.w700),
         ),
         const SizedBox(height: 6),
@@ -199,7 +199,7 @@ class _SentIceShareTile extends StatelessWidget {
             share.toWholeGroup
                 ? 'Shared with the group - '
                       '${share.viewedAt != null ? 'seen' : 'not yet seen'}'
-                : 'Shared with the leader - '
+                : 'Shared with the coordinator - '
                       '${share.viewedAt != null ? 'seen' : 'not yet seen'}',
             style: const TextStyle(color: Color(0xFF98A3B1)),
           ),

--- a/apps/mobile/lib/features/ride/previous_rides_screen.dart
+++ b/apps/mobile/lib/features/ride/previous_rides_screen.dart
@@ -374,7 +374,7 @@ class _PreviousRideDetailScreenState extends State<PreviousRideDetailScreen> {
                 title: Text('Which route should be reused?'),
                 subtitle: Text(
                   'The planned route is recommended. The recorded track '
-                  'includes where the bike actually went.',
+                  'includes where the crew vehicle actually went.',
                 ),
               ),
               for (final option in candidates)

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -14,6 +14,7 @@ import '../../domain/quick_message.dart';
 import '../../domain/ride_coordination_mode.dart';
 import '../../domain/ride_event.dart';
 import '../../services/flight_plan_summary.dart';
+import '../../services/live_flight_projection.dart';
 import '../../services/open_meteo_wind.dart';
 import '../../services/ride_connectivity_summary.dart';
 import '../internet/internet_relay_status_card.dart';
@@ -38,6 +39,7 @@ class RideDashboard extends StatelessWidget {
     this.vehicleRoadRoute,
     this.navigationPosition,
     this.windForecast,
+    this.liveFlightProjection,
     this.chaseGuidanceLabel,
     this.onUpdateFlightPlan,
     this.onUpdateLandingArea,
@@ -61,6 +63,7 @@ class RideDashboard extends StatelessWidget {
   final ImportedRoute? vehicleRoadRoute;
   final ValueListenable<MapNavigationPosition?>? navigationPosition;
   final WindForecastController? windForecast;
+  final LiveFlightProjectionAssessment? liveFlightProjection;
   final String? chaseGuidanceLabel;
   final VoidCallback? onUpdateFlightPlan;
   final VoidCallback? onUpdateLandingArea;
@@ -106,6 +109,7 @@ class RideDashboard extends StatelessWidget {
                     vehicleRoadRoute: vehicleRoadRoute,
                     navigationPosition: navigationPosition,
                     windForecast: windForecast,
+                    liveFlightProjection: liveFlightProjection,
                     landingAreaLabel: controller.landingZone?.label,
                     landingAreaUpdatedAt: controller.landingZone?.updatedAt,
                     chaseGuidanceLabel: chaseGuidanceLabel,
@@ -282,6 +286,7 @@ class _RoleLivePanel extends StatelessWidget {
     required this.vehicleRoadRoute,
     required this.navigationPosition,
     required this.windForecast,
+    required this.liveFlightProjection,
     required this.landingAreaLabel,
     required this.landingAreaUpdatedAt,
     required this.chaseGuidanceLabel,
@@ -295,6 +300,7 @@ class _RoleLivePanel extends StatelessWidget {
   final ImportedRoute? vehicleRoadRoute;
   final ValueListenable<MapNavigationPosition?>? navigationPosition;
   final WindForecastController? windForecast;
+  final LiveFlightProjectionAssessment? liveFlightProjection;
   final String? landingAreaLabel;
   final DateTime? landingAreaUpdatedAt;
   final String? chaseGuidanceLabel;
@@ -395,6 +401,8 @@ class _RoleLivePanel extends StatelessWidget {
               const SizedBox(height: 12),
               _WindSummary(wind: wind),
               const SizedBox(height: 12),
+              _LiveProjectionSummary(assessment: liveFlightProjection),
+              const SizedBox(height: 12),
               _FlightPlanOverview(summary: summary),
               const SizedBox(height: 12),
               _LandingIntentRow(
@@ -435,6 +443,8 @@ class _RoleLivePanel extends StatelessWidget {
                 ),
                 const SizedBox(height: 12),
                 _WindSummary(wind: wind),
+                const SizedBox(height: 12),
+                _LiveProjectionSummary(assessment: liveFlightProjection),
               ],
             ] else ...[
               _FlightPlanOverview(summary: summary, reduced: true),
@@ -562,6 +572,35 @@ class _WindSummary extends StatelessWidget {
   }
 }
 
+class _LiveProjectionSummary extends StatelessWidget {
+  const _LiveProjectionSummary({required this.assessment});
+
+  final LiveFlightProjectionAssessment? assessment;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = assessment;
+    final projection = value?.projection;
+    if (projection == null) {
+      return _InformationRow(
+        key: const Key('role-live-flight-projection'),
+        icon: Icons.online_prediction_outlined,
+        title: 'Live projection unavailable',
+        detail:
+            '${value?.message ?? 'Waiting for structured plan, balloon telemetry and fresh wind.'} The original forecast remains unchanged.',
+      );
+    }
+    final landing = projection.computedAt.add(projection.duration);
+    return _InformationRow(
+      key: const Key('role-live-flight-projection'),
+      icon: Icons.online_prediction,
+      title: 'Live projection · landing about ${_formatTime(context, landing)}',
+      detail:
+          '${projection.windSource} · wind valid ${_formatTime(context, projection.windValidAt)} · recalculated ${_compactAge(DateTime.now().difference(projection.computedAt))} ago · ${projection.landingEnvelope.isEmpty ? 'endpoint spread unavailable' : 'possible-landing envelope shown'}. Forecast model only; landing suitability and access are unverified.',
+    );
+  }
+}
+
 class _FlightPlanOverview extends StatelessWidget {
   const _FlightPlanOverview({required this.summary, this.reduced = false});
 
@@ -579,6 +618,16 @@ class _FlightPlanOverview extends StatelessWidget {
         detail: 'The pilot has not shared a timed altitude plan.',
       );
     }
+    final now = DateTime.now();
+    final currentStageIndex =
+        plan.startTime != null &&
+            plan.landingTime != null &&
+            !now.isBefore(plan.startTime!) &&
+            !now.isAfter(plan.landingTime!)
+        ? plan.stages.lastIndexWhere(
+            (stage) => stage.time == null || !stage.time!.isAfter(now),
+          )
+        : -1;
     final times = plan.startTime == null
         ? 'Start time unavailable'
         : plan.landingTime == null
@@ -642,8 +691,12 @@ class _FlightPlanOverview extends StatelessWidget {
             title: Text('${plan.stages.length} altitude and time stages'),
             subtitle: const Text('Launch, climb, descent and landing forecast'),
             children: [
-              for (final stage in plan.stages)
+              for (final (index, stage) in plan.stages.indexed)
                 ListTile(
+                  selected: index == currentStageIndex,
+                  selectedTileColor: Theme.of(
+                    context,
+                  ).colorScheme.primaryContainer.withValues(alpha: 0.35),
                   dense: true,
                   contentPadding: const EdgeInsets.only(left: 8, right: 4),
                   leading: Icon(_stageIcon(stage.phase), size: 19),
@@ -651,7 +704,7 @@ class _FlightPlanOverview extends StatelessWidget {
                   subtitle: Text(
                     stage.time == null
                         ? 'Time unavailable'
-                        : _formatTime(context, stage.time!),
+                        : '${_formatTime(context, stage.time!)}${index == currentStageIndex ? ' · Current planned stage' : ''}',
                   ),
                   trailing: Text(
                     stage.altitudeMetersMsl == null

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -7,13 +7,17 @@ import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/internet_relay_controller.dart';
 import '../../controllers/ride_controller.dart';
 import '../../controllers/nearby_relay_controller.dart';
-import '../../domain/quick_message.dart';
+import '../../domain/altitude.dart';
 import '../../domain/flight_role.dart';
+import '../../domain/imported_route.dart';
+import '../../domain/quick_message.dart';
 import '../../domain/ride_coordination_mode.dart';
 import '../../domain/ride_event.dart';
-import '../../domain/ride_role.dart';
+import '../../services/flight_plan_summary.dart';
+import '../../services/open_meteo_wind.dart';
 import '../../services/ride_connectivity_summary.dart';
 import '../internet/internet_relay_status_card.dart';
+import '../map/ride_map_feature.dart';
 import '../nearby/relay_status_card.dart';
 import 'ride_invitation_qr_sheet.dart';
 
@@ -30,6 +34,14 @@ class RideDashboard extends StatelessWidget {
     this.localObserverAssistanceActive = false,
     this.serviceWarning,
     this.connectivity,
+    this.sharedFlightPlan,
+    this.vehicleRoadRoute,
+    this.navigationPosition,
+    this.windForecast,
+    this.chaseGuidanceLabel,
+    this.onUpdateFlightPlan,
+    this.onUpdateLandingArea,
+    this.onChooseChaseGuidance,
   });
 
   final RideController controller;
@@ -45,6 +57,14 @@ class RideDashboard extends StatelessWidget {
 
   /// The reconciled answer to "is the group seeing where I am".
   final RideConnectivitySummary? connectivity;
+  final ImportedRoute? sharedFlightPlan;
+  final ImportedRoute? vehicleRoadRoute;
+  final ValueListenable<MapNavigationPosition?>? navigationPosition;
+  final WindForecastController? windForecast;
+  final String? chaseGuidanceLabel;
+  final VoidCallback? onUpdateFlightPlan;
+  final VoidCallback? onUpdateLandingArea;
+  final VoidCallback? onChooseChaseGuidance;
 
   @override
   Widget build(BuildContext context) {
@@ -62,76 +82,105 @@ class RideDashboard extends StatelessWidget {
         builder: (context, _) => Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 760),
-            child: ListView(
+            child: SingleChildScrollView(
               padding: const EdgeInsets.fromLTRB(18, 8, 18, 40),
-              children: [
-                _RideHeader(
-                  rideCode: session.rideCode,
-                  displayName: session.displayName,
-                  role: session.flightRole,
-                  craftLabel:
-                      controller.localCraft?.craft.label ??
-                      (session.flightRole.isAboardBalloon
-                          ? 'Balloon'
-                          : 'Unassigned craft'),
-                  coordinationMode: mode,
-                  onRoleChanged: controller.setFlightRole,
-                ),
-                const SizedBox(height: 14),
-                _RoleBriefingCard(role: session.flightRole),
-                rideActions,
-                if (!isSolo) ...[
-                  const SizedBox(height: 14),
-                  _ConnectionCard(
-                    controller: controller,
-                    onOpenRoster: onOpenRoster,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _RideHeader(
+                    rideCode: session.rideCode,
+                    displayName: session.displayName,
+                    role: session.flightRole,
+                    craftLabel:
+                        controller.localCraft?.craft.label ??
+                        (session.flightRole.isAboardBalloon
+                            ? 'Balloon'
+                            : 'Unassigned craft'),
+                    coordinationMode: mode,
+                    onRoleChanged: controller.setFlightRole,
                   ),
-                ],
-                // One answer above the per-channel cards (#174). Three accurate
-                // cards that disagreed left a rider unable to tell whether the
-                // app was working; the channels keep their own detail below.
-                if (!isSolo) ...[
-                  if (connectivity case final connectivity?) ...[
-                    const SizedBox(height: 14),
-                    _ConnectivitySummaryCard(summary: connectivity),
-                  ],
-                  if (relayController case final relayController?) ...[
-                    const SizedBox(height: 14),
-                    RelayStatusCard(controller: relayController),
-                  ],
-                  if (internetRelayController
-                      case final internetRelayController?) ...[
-                    const SizedBox(height: 14),
-                    InternetRelayStatusCard(
-                      controller: internetRelayController,
+                  const SizedBox(height: 14),
+                  _RoleLivePanel(
+                    role: session.flightRole,
+                    sharedFlightPlan: sharedFlightPlan,
+                    vehicleRoadRoute: vehicleRoadRoute,
+                    navigationPosition: navigationPosition,
+                    windForecast: windForecast,
+                    landingAreaLabel: controller.landingZone?.label,
+                    landingAreaUpdatedAt: controller.landingZone?.updatedAt,
+                    chaseGuidanceLabel: chaseGuidanceLabel,
+                    onUpdateFlightPlan: onUpdateFlightPlan,
+                    onUpdateLandingArea: onUpdateLandingArea,
+                    onChooseChaseGuidance: onChooseChaseGuidance,
+                  ),
+                  rideActions,
+                  // One answer above the per-channel cards (#174). Three accurate
+                  // cards that disagreed left a rider unable to tell whether the
+                  // app was working; the channels keep their own detail below.
+                  if (!isSolo) ...[
+                    if (connectivity case final connectivity?) ...[
+                      const SizedBox(height: 14),
+                      _ConnectivitySummaryCard(summary: connectivity),
+                    ],
+                    const SizedBox(height: 6),
+                    ExpansionTile(
+                      key: const Key('flight-technical-details'),
+                      leading: const Icon(Icons.hub_outlined),
+                      title: const Text('Connection and technical details'),
+                      subtitle: const Text(
+                        'Crew presence, offline queue and relay channels',
+                      ),
+                      children: [
+                        _ConnectionCard(
+                          controller: controller,
+                          onOpenRoster: onOpenRoster,
+                        ),
+                        if (relayController case final relayController?) ...[
+                          const SizedBox(height: 8),
+                          RelayStatusCard(controller: relayController),
+                        ],
+                        if (internetRelayController
+                            case final internetRelayController?) ...[
+                          const SizedBox(height: 8),
+                          InternetRelayStatusCard(
+                            controller: internetRelayController,
+                          ),
+                        ],
+                      ],
                     ),
                   ],
-                ],
-                if (serviceWarning case final warning?) ...[
-                  const SizedBox(height: 14),
-                  _ServiceWarning(message: warning),
-                ],
-                if (!isSolo) ...[
-                  const SizedBox(height: 22),
-                  Text(
-                    'QUICK MESSAGES',
-                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                      color: const Color(0xFF8D98A7),
-                      letterSpacing: 1.1,
+                  if (serviceWarning case final warning?) ...[
+                    const SizedBox(height: 14),
+                    _ServiceWarning(message: warning),
+                  ],
+                  if (!isSolo) ...[
+                    const SizedBox(height: 22),
+                    Text(
+                      'QUICK MESSAGES',
+                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                        color: const Color(0xFF8D98A7),
+                        letterSpacing: 1.1,
+                      ),
                     ),
+                    const SizedBox(height: 10),
+                    QuickMessageGrid(
+                      busy: controller.busy,
+                      onSend: onSendQuickMessage ?? controller.sendQuickMessage,
+                      showResolved: localObserverAssistanceActive,
+                    ),
+                    const SizedBox(height: 22),
+                    _RideCodeCard(controller: controller),
+                  ],
+                  const SizedBox(height: 12),
+                  ExpansionTile(
+                    key: const Key('flight-event-history'),
+                    leading: const Icon(Icons.history),
+                    title: const Text('Flight event history'),
+                    subtitle: const Text('Local offline-safe journal'),
+                    children: [_EventTimeline(controller: controller)],
                   ),
-                  const SizedBox(height: 10),
-                  QuickMessageGrid(
-                    busy: controller.busy,
-                    onSend: onSendQuickMessage ?? controller.sendQuickMessage,
-                    showResolved: localObserverAssistanceActive,
-                  ),
-                  const SizedBox(height: 22),
-                  _RideCodeCard(controller: controller),
                 ],
-                const SizedBox(height: 22),
-                _EventTimeline(controller: controller),
-              ],
+              ),
             ),
           ),
         ),
@@ -226,50 +275,525 @@ class _RideHeader extends StatelessWidget {
   }
 }
 
-class _RoleBriefingCard extends StatelessWidget {
-  const _RoleBriefingCard({required this.role});
+class _RoleLivePanel extends StatelessWidget {
+  const _RoleLivePanel({
+    required this.role,
+    required this.sharedFlightPlan,
+    required this.vehicleRoadRoute,
+    required this.navigationPosition,
+    required this.windForecast,
+    required this.landingAreaLabel,
+    required this.landingAreaUpdatedAt,
+    required this.chaseGuidanceLabel,
+    required this.onUpdateFlightPlan,
+    required this.onUpdateLandingArea,
+    required this.onChooseChaseGuidance,
+  });
 
   final FlightRole role;
+  final ImportedRoute? sharedFlightPlan;
+  final ImportedRoute? vehicleRoadRoute;
+  final ValueListenable<MapNavigationPosition?>? navigationPosition;
+  final WindForecastController? windForecast;
+  final String? landingAreaLabel;
+  final DateTime? landingAreaUpdatedAt;
+  final String? chaseGuidanceLabel;
+  final VoidCallback? onUpdateFlightPlan;
+  final VoidCallback? onUpdateLandingArea;
+  final VoidCallback? onChooseChaseGuidance;
 
   @override
   Widget build(BuildContext context) {
+    final position = navigationPosition;
+    if (position == null) return _buildForPosition(context, null);
+    return ValueListenableBuilder<MapNavigationPosition?>(
+      valueListenable: position,
+      builder: (context, value, _) => _buildForPosition(context, value),
+    );
+  }
+
+  Widget _buildForPosition(
+    BuildContext context,
+    MapNavigationPosition? position,
+  ) {
+    final wind = windForecast;
+    if (wind == null) return _buildCard(context, position, null);
+    return AnimatedBuilder(
+      animation: wind,
+      builder: (context, _) => _buildCard(context, position, wind),
+    );
+  }
+
+  Widget _buildCard(
+    BuildContext context,
+    MapNavigationPosition? position,
+    WindForecastController? wind,
+  ) {
+    final summary = FlightPlanSummary.fromRoute(sharedFlightPlan);
     final (icon, title, detail) = switch (role) {
       FlightRole.pilot => (
         Icons.air_outlined,
         'Pilot flight deck',
-        'The map prioritises altitude, forecast wind, the altitude-coloured track, airspace context and landing intent. Road directions and speed limits are hidden.',
+        'Airborne telemetry, wind and the shared forecast. Road directions and speed limits stay hidden.',
       ),
       FlightRole.balloonCrew => (
         Icons.air,
-        'Airborne crew view',
-        'Inspect the wind grid, altitude profile, possible landing areas and chase craft without changing pilot authority.',
+        'Airborne crew',
+        'Read-only flight profile, wind and pilot landing intent.',
       ),
       FlightRole.chaseDriver => (
         Icons.directions_car,
         'Driver navigation',
-        'Road guidance, speed limits and spoken alerts are prioritised. Tactical editing stays with chase crew while the vehicle is moving.',
+        'Road guidance stays focused on the selected safe rendezvous.',
       ),
       FlightRole.chaseCrew => (
         Icons.groups_2_outlined,
         'Chase coordination',
-        'Use the team map to compare the balloon, shared tracks, landing intent and this vehicle’s road rendezvous.',
+        'Shared balloon forecast, landing intent and this vehicle’s road route.',
       ),
       FlightRole.observer => (
         Icons.visibility_outlined,
         'Observer',
-        'This role is read-only and receives reduced flight information.',
+        'Read-only shared flight status with reduced detail.',
       ),
     };
     return Card(
       key: Key('flight-role-briefing-${role.name}'),
-      child: ListTile(
-        leading: Icon(icon, color: Theme.of(context).colorScheme.primary),
-        title: Text(title, style: const TextStyle(fontWeight: FontWeight.w700)),
-        subtitle: Text(detail),
+      child: Padding(
+        padding: const EdgeInsets.all(18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(icon, color: Theme.of(context).colorScheme.primary),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        detail,
+                        style: const TextStyle(color: Color(0xFFABB5C1)),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (role.isAboardBalloon) ...[
+              _AirborneTelemetry(position: position),
+              const SizedBox(height: 12),
+              _WindSummary(wind: wind),
+              const SizedBox(height: 12),
+              _FlightPlanOverview(summary: summary),
+              const SizedBox(height: 12),
+              _LandingIntentRow(
+                label: landingAreaLabel,
+                updatedAt: landingAreaUpdatedAt,
+                onPressed: role == FlightRole.pilot
+                    ? onUpdateLandingArea
+                    : null,
+              ),
+              if (role == FlightRole.pilot && onUpdateFlightPlan != null)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    key: const Key('pilot-update-flight-plan'),
+                    onPressed: onUpdateFlightPlan,
+                    icon: const Icon(Icons.route_outlined),
+                    label: Text(
+                      summary == null
+                          ? 'Add forecast flight plan'
+                          : 'Replace forecast flight plan',
+                    ),
+                  ),
+                ),
+            ] else if (role.isChasing) ...[
+              _ChaseTargetRow(
+                label: chaseGuidanceLabel,
+                onPressed: onChooseChaseGuidance,
+              ),
+              const SizedBox(height: 12),
+              _RoadRouteOverview(route: vehicleRoadRoute),
+              if (role == FlightRole.chaseCrew) ...[
+                const SizedBox(height: 12),
+                _FlightPlanOverview(summary: summary),
+                const SizedBox(height: 12),
+                _LandingIntentRow(
+                  label: landingAreaLabel,
+                  updatedAt: landingAreaUpdatedAt,
+                ),
+                const SizedBox(height: 12),
+                _WindSummary(wind: wind),
+              ],
+            ] else ...[
+              _FlightPlanOverview(summary: summary, reduced: true),
+              const SizedBox(height: 12),
+              _LandingIntentRow(
+                label: landingAreaLabel,
+                updatedAt: landingAreaUpdatedAt,
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }
 }
+
+class _AirborneTelemetry extends StatelessWidget {
+  const _AirborneTelemetry({required this.position});
+
+  final MapNavigationPosition? position;
+
+  @override
+  Widget build(BuildContext context) {
+    final fix = position;
+    final altitude = fix?.altitudeMeters;
+    final verticalRate = fix?.verticalSpeedMetersPerSecond;
+    final fixAge = fix == null
+        ? null
+        : DateTime.now().difference(fix.recordedAt);
+    return Container(
+      key: const Key('airborne-live-telemetry'),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: _Metric(
+              label: 'ALTITUDE',
+              value: altitude == null ? 'Unavailable' : '${altitude.round()} m',
+              detail: altitude == null
+                  ? 'No altitude fix'
+                  : '${_altitudeSourceLabel(fix!.altitudeSource)} · ${_altitudeDatumLabel(fix.altitudeDatum)}',
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: _Metric(
+              label: 'VERTICAL RATE',
+              value: verticalRate == null
+                  ? 'Unavailable'
+                  : '${verticalRate >= 0 ? '+' : ''}${verticalRate.toStringAsFixed(1)} m/s',
+              detail: fixAge == null
+                  ? 'No fix'
+                  : 'Fix ${_compactAge(fixAge)} ago',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({
+    required this.label,
+    required this.value,
+    required this.detail,
+  });
+
+  final String label;
+  final String value;
+  final String detail;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: const Color(0xFF8D98A7),
+          letterSpacing: 0.8,
+        ),
+      ),
+      const SizedBox(height: 3),
+      Text(
+        value,
+        style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
+      ),
+      const SizedBox(height: 2),
+      Text(
+        detail,
+        style: const TextStyle(color: Color(0xFF98A3B1), fontSize: 12),
+      ),
+    ],
+  );
+}
+
+class _WindSummary extends StatelessWidget {
+  const _WindSummary({required this.wind});
+
+  final WindForecastController? wind;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = wind;
+    final field = controller?.field;
+    final enabled = controller?.enabled ?? false;
+    final level = controller?.selectedAltitudeMetersMsl;
+    return _InformationRow(
+      key: const Key('role-wind-summary'),
+      icon: Icons.air,
+      title: enabled && level != null
+          ? 'Forecast wind · $level m MSL'
+          : 'Forecast wind off',
+      detail: field == null
+          ? controller?.loading == true
+                ? 'Loading Open-Meteo forecast…'
+                : 'No wind forecast loaded'
+          : '${field.sourceLabel} · valid ${_formatTime(context, field.validAt)} · fetched ${_compactAge(DateTime.now().difference(field.fetchedAt))} ago. Forecast model only; not an aviation briefing.',
+    );
+  }
+}
+
+class _FlightPlanOverview extends StatelessWidget {
+  const _FlightPlanOverview({required this.summary, this.reduced = false});
+
+  final FlightPlanSummary? summary;
+  final bool reduced;
+
+  @override
+  Widget build(BuildContext context) {
+    final plan = summary;
+    if (plan == null) {
+      return const _InformationRow(
+        key: Key('role-flight-plan-summary'),
+        icon: Icons.route_outlined,
+        title: 'No shared flight forecast',
+        detail: 'The pilot has not shared a timed altitude plan.',
+      );
+    }
+    final times = plan.startTime == null
+        ? 'Start time unavailable'
+        : plan.landingTime == null
+        ? 'Start ${_formatTime(context, plan.startTime!)}'
+        : '${_formatTime(context, plan.startTime!)}–${_formatTime(context, plan.landingTime!)}';
+    final duration = plan.duration == null
+        ? null
+        : _formatDuration(plan.duration!);
+    final altitude = plan.maximumAltitudeMetersMsl == null
+        ? null
+        : 'max ${plan.maximumAltitudeMetersMsl!.round()} m MSL';
+    final climb = plan.maximumAscentRateMetersPerSecond == null
+        ? null
+        : 'climb ${plan.maximumAscentRateMetersPerSecond!.toStringAsFixed(1)} m/s';
+    final descent = plan.maximumDescentRateMetersPerSecond == null
+        ? null
+        : 'descent ${plan.maximumDescentRateMetersPerSecond!.toStringAsFixed(1)} m/s';
+    final detail = [
+      times,
+      duration,
+      altitude,
+      climb,
+      descent,
+    ].whereType<String>().join(' · ');
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _InformationRow(
+          key: const Key('role-flight-plan-summary'),
+          icon: Icons.route_outlined,
+          title: plan.routeName,
+          detail: '$detail. Forecast path only; actual drift may differ.',
+        ),
+        if (!reduced && plan.stages.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          ExpansionTile(
+            key: const Key('flight-plan-altitude-stages'),
+            tilePadding: EdgeInsets.zero,
+            childrenPadding: EdgeInsets.zero,
+            title: Text('${plan.stages.length} altitude and time stages'),
+            subtitle: const Text('Launch, climb, descent and landing forecast'),
+            children: [
+              for (final stage in plan.stages)
+                ListTile(
+                  dense: true,
+                  contentPadding: const EdgeInsets.only(left: 8, right: 4),
+                  leading: Icon(_stageIcon(stage.phase), size: 19),
+                  title: Text(stage.label),
+                  subtitle: Text(
+                    stage.time == null
+                        ? 'Time unavailable'
+                        : _formatTime(context, stage.time!),
+                  ),
+                  trailing: Text(
+                    stage.altitudeMetersMsl == null
+                        ? '—'
+                        : '${stage.altitudeMetersMsl!.round()} m MSL',
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _LandingIntentRow extends StatelessWidget {
+  const _LandingIntentRow({
+    required this.label,
+    required this.updatedAt,
+    this.onPressed,
+  });
+
+  final String? label;
+  final DateTime? updatedAt;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) => _InformationRow(
+    key: const Key('role-landing-intent'),
+    icon: Icons.flag_outlined,
+    title: label ?? 'No intended landing area',
+    detail: label == null
+        ? 'The pilot can set and update an approximate rendezvous area during the flight.'
+        : 'Pilot intent · updated ${updatedAt == null ? 'time unavailable' : '${_compactAge(DateTime.now().difference(updatedAt!))} ago'} · access and landing suitability are unverified.',
+    actionLabel: onPressed == null
+        ? null
+        : label == null
+        ? 'Set'
+        : 'Update',
+    onPressed: onPressed,
+  );
+}
+
+class _ChaseTargetRow extends StatelessWidget {
+  const _ChaseTargetRow({required this.label, required this.onPressed});
+
+  final String? label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) => _InformationRow(
+    key: const Key('role-chase-target'),
+    icon: Icons.assistant_direction_outlined,
+    title: label ?? 'No chase target selected',
+    detail:
+        'Routes dynamically to a road-accessible endpoint near the selected target and never directs off-road.',
+    actionLabel: onPressed == null ? null : 'Change',
+    onPressed: onPressed,
+  );
+}
+
+class _RoadRouteOverview extends StatelessWidget {
+  const _RoadRouteOverview({required this.route});
+
+  final ImportedRoute? route;
+
+  @override
+  Widget build(BuildContext context) {
+    final roadRoute = route;
+    return _InformationRow(
+      key: const Key('role-road-route-summary'),
+      icon: Icons.directions_car_outlined,
+      title: roadRoute?.name ?? 'Road route not ready',
+      detail: roadRoute == null
+          ? 'Choose a target when balloon and vehicle positions are available.'
+          : '${roadRoute.plannedDuration == null ? 'ETA updates while driving' : 'Planned ${_formatDuration(roadRoute.plannedDuration!)}'} · recalculates after meaningful target movement.',
+    );
+  }
+}
+
+class _InformationRow extends StatelessWidget {
+  const _InformationRow({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.detail,
+    this.actionLabel,
+    this.onPressed,
+  });
+
+  final IconData icon;
+  final String title;
+  final String detail;
+  final String? actionLabel;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) => Row(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Icon(icon, size: 21, color: const Color(0xFF8D98A7)),
+      const SizedBox(width: 10),
+      Expanded(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: const TextStyle(fontWeight: FontWeight.w700)),
+            const SizedBox(height: 2),
+            Text(
+              detail,
+              style: const TextStyle(color: Color(0xFF98A3B1), fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+      if (actionLabel != null && onPressed != null)
+        TextButton(onPressed: onPressed, child: Text(actionLabel!)),
+    ],
+  );
+}
+
+IconData _stageIcon(FlightPlanStagePhase phase) => switch (phase) {
+  FlightPlanStagePhase.launch => Icons.flight_takeoff,
+  FlightPlanStagePhase.climb => Icons.trending_up,
+  FlightPlanStagePhase.level => Icons.trending_flat,
+  FlightPlanStagePhase.descend => Icons.trending_down,
+  FlightPlanStagePhase.peak => Icons.vertical_align_top,
+  FlightPlanStagePhase.landing => Icons.flight_land,
+};
+
+String _formatTime(BuildContext context, DateTime value) =>
+    MaterialLocalizations.of(context).formatTimeOfDay(
+      TimeOfDay.fromDateTime(value.toLocal()),
+      alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context),
+    );
+
+String _formatDuration(Duration duration) {
+  final hours = duration.inHours;
+  final minutes = duration.inMinutes.remainder(60);
+  if (hours == 0) return '$minutes min';
+  return minutes == 0 ? '$hours hr' : '$hours hr $minutes min';
+}
+
+String _compactAge(Duration age) {
+  if (age.isNegative) return '0s';
+  if (age.inSeconds < 60) return '${age.inSeconds}s';
+  if (age.inMinutes < 60) return '${age.inMinutes}m';
+  return '${age.inHours}h';
+}
+
+String _altitudeSourceLabel(AltitudeSource source) => switch (source) {
+  AltitudeSource.gnss => 'GNSS',
+  AltitudeSource.barometric => 'Barometric',
+  AltitudeSource.unknown => 'Source unknown',
+};
+
+String _altitudeDatumLabel(AltitudeDatum datum) => switch (datum) {
+  AltitudeDatum.wgs84Geoid => 'MSL',
+  AltitudeDatum.wgs84Ellipsoid => 'WGS84 ellipsoid',
+  AltitudeDatum.relativeToLaunch => 'relative to launch',
+  AltitudeDatum.unknown => 'datum unknown',
+};
 
 class _ConnectionCard extends StatelessWidget {
   const _ConnectionCard({required this.controller, required this.onOpenRoster});
@@ -492,7 +1016,7 @@ class _RideCodeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final session = controller.session!;
-    if (session.role != RideRole.lead) {
+    if (!controller.hasFlightAuthority) {
       return const SizedBox.shrink();
     }
     return Card(

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -1272,6 +1272,8 @@ class _EventRow extends StatelessWidget {
       RideEventType.chaseGuidanceTargetSelected =>
         '${event.payload['vehicleLabel'] ?? 'Chase vehicle'} now targets '
             '${event.payload['target'] == 'balloon' ? 'the balloon' : 'the intended landing area'}',
+      RideEventType.pilotHandoverOffered => 'Pilot handover offered',
+      RideEventType.pilotHandoverAccepted => 'Pilot handover accepted',
       // #188. The activity list says a number was shared and with whom, never
       // what the number is: this is a log, not a place to read a number off a
       // screen.

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -8,6 +8,7 @@ import '../../controllers/internet_relay_controller.dart';
 import '../../controllers/ride_controller.dart';
 import '../../controllers/nearby_relay_controller.dart';
 import '../../domain/quick_message.dart';
+import '../../domain/flight_role.dart';
 import '../../domain/ride_coordination_mode.dart';
 import '../../domain/ride_event.dart';
 import '../../domain/ride_role.dart';
@@ -67,10 +68,17 @@ class RideDashboard extends StatelessWidget {
                 _RideHeader(
                   rideCode: session.rideCode,
                   displayName: session.displayName,
-                  role: controller.session!.role,
+                  role: session.flightRole,
+                  craftLabel:
+                      controller.localCraft?.craft.label ??
+                      (session.flightRole.isAboardBalloon
+                          ? 'Balloon'
+                          : 'Unassigned craft'),
                   coordinationMode: mode,
-                  onRoleChanged: controller.setRole,
+                  onRoleChanged: controller.setFlightRole,
                 ),
+                const SizedBox(height: 14),
+                _RoleBriefingCard(role: session.flightRole),
                 rideActions,
                 if (!isSolo) ...[
                   const SizedBox(height: 14),
@@ -137,15 +145,17 @@ class _RideHeader extends StatelessWidget {
     required this.rideCode,
     required this.displayName,
     required this.role,
+    required this.craftLabel,
     required this.coordinationMode,
     required this.onRoleChanged,
   });
 
   final String rideCode;
   final String displayName;
-  final RideRole role;
+  final FlightRole role;
+  final String craftLabel;
   final RideCoordinationMode coordinationMode;
-  final ValueChanged<RideRole> onRoleChanged;
+  final ValueChanged<FlightRole> onRoleChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -181,16 +191,21 @@ class _RideHeader extends StatelessWidget {
                   displayName,
                   style: Theme.of(context).textTheme.headlineMedium,
                 ),
+                const SizedBox(height: 4),
+                Text(
+                  '${role.label} · $craftLabel',
+                  style: const TextStyle(color: Color(0xFFABB5C1)),
+                ),
               ],
             ),
           ),
           const SizedBox(width: 12),
-          if (coordinationMode != RideCoordinationMode.solo)
+          if (coordinationMode != RideCoordinationMode.solo && role.isChasing)
             DropdownButtonHideUnderline(
-              child: DropdownButton<RideRole>(
+              child: DropdownButton<FlightRole>(
                 value: role,
                 borderRadius: BorderRadius.circular(14),
-                items: RideRole.values
+                items: const [FlightRole.chaseDriver, FlightRole.chaseCrew]
                     .map(
                       (item) => DropdownMenuItem(
                         value: item,
@@ -206,6 +221,51 @@ class _RideHeader extends StatelessWidget {
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _RoleBriefingCard extends StatelessWidget {
+  const _RoleBriefingCard({required this.role});
+
+  final FlightRole role;
+
+  @override
+  Widget build(BuildContext context) {
+    final (icon, title, detail) = switch (role) {
+      FlightRole.pilot => (
+        Icons.air_outlined,
+        'Pilot flight deck',
+        'The map prioritises altitude, forecast wind, the altitude-coloured track, airspace context and landing intent. Road directions and speed limits are hidden.',
+      ),
+      FlightRole.balloonCrew => (
+        Icons.air,
+        'Airborne crew view',
+        'Inspect the wind grid, altitude profile, possible landing areas and chase craft without changing pilot authority.',
+      ),
+      FlightRole.chaseDriver => (
+        Icons.directions_car,
+        'Driver navigation',
+        'Road guidance, speed limits and spoken alerts are prioritised. Tactical editing stays with chase crew while the vehicle is moving.',
+      ),
+      FlightRole.chaseCrew => (
+        Icons.groups_2_outlined,
+        'Chase coordination',
+        'Use the team map to compare the balloon, shared tracks, landing intent and this vehicle’s road rendezvous.',
+      ),
+      FlightRole.observer => (
+        Icons.visibility_outlined,
+        'Observer',
+        'This role is read-only and receives reduced flight information.',
+      ),
+    };
+    return Card(
+      key: Key('flight-role-briefing-${role.name}'),
+      child: ListTile(
+        leading: Icon(icon, color: Theme.of(context).colorScheme.primary),
+        title: Text(title, style: const TextStyle(fontWeight: FontWeight.w700)),
+        subtitle: Text(detail),
       ),
     );
   }

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -587,9 +587,17 @@ class _FlightPlanOverview extends StatelessWidget {
     final duration = plan.duration == null
         ? null
         : _formatDuration(plan.duration!);
-    final altitude = plan.maximumAltitudeMetersMsl == null
+    final altitude = plan.altitudeCeilingMetersMsl == null
+        ? plan.maximumAltitudeMetersMsl == null
+              ? null
+              : 'forecast max ${plan.maximumAltitudeMetersMsl!.round()} m MSL'
+        : 'ceiling ${plan.altitudeCeilingMetersMsl!.round()} m MSL';
+    final window = plan.matchingWindowStart == null
         ? null
-        : 'max ${plan.maximumAltitudeMetersMsl!.round()} m MSL';
+        : plan.matchingWindowEnd == null ||
+              plan.matchingWindowEnd == plan.matchingWindowStart
+        ? 'matching start ${_formatTime(context, plan.matchingWindowStart!)}'
+        : 'start window ${_formatTime(context, plan.matchingWindowStart!)}–${_formatTime(context, plan.matchingWindowEnd!)}';
     final climb = plan.maximumAscentRateMetersPerSecond == null
         ? null
         : 'climb ${plan.maximumAscentRateMetersPerSecond!.toStringAsFixed(1)} m/s';
@@ -599,6 +607,7 @@ class _FlightPlanOverview extends StatelessWidget {
     final detail = [
       times,
       duration,
+      window,
       altitude,
       climb,
       descent,
@@ -612,6 +621,18 @@ class _FlightPlanOverview extends StatelessWidget {
           title: plan.routeName,
           detail: '$detail. Forecast path only; actual drift may differ.',
         ),
+        if (!reduced && plan.windProvider != null) ...[
+          const SizedBox(height: 8),
+          _InformationRow(
+            key: const Key('flight-plan-original-wind'),
+            icon: Icons.air_outlined,
+            title:
+                'Original wind · ${plan.windProvider} ${plan.windModel ?? ''}'
+                    .trim(),
+            detail:
+                'Valid ${plan.windValidFrom == null ? 'time unavailable' : _formatTime(context, plan.windValidFrom!)}–${plan.windValidTo == null ? 'time unavailable' : _formatTime(context, plan.windValidTo!)} · forecast model only; not an aviation briefing.',
+          ),
+        ],
         if (!reduced && plan.stages.isNotEmpty) ...[
           const SizedBox(height: 8),
           ExpansionTile(

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -1195,6 +1195,9 @@ class _EventRow extends StatelessWidget {
         'Operational boundary updated',
       RideEventType.operationalBoundaryRemoved =>
         'Operational boundary removed',
+      RideEventType.chaseGuidanceTargetSelected =>
+        '${event.payload['vehicleLabel'] ?? 'Chase vehicle'} now targets '
+            '${event.payload['target'] == 'balloon' ? 'the balloon' : 'the intended landing area'}',
       // #188. The activity list says a number was shared and with whom, never
       // what the number is: this is a log, not a place to read a number off a
       // screen.

--- a/apps/mobile/lib/features/ride/ride_roster_sheet.dart
+++ b/apps/mobile/lib/features/ride/ride_roster_sheet.dart
@@ -109,7 +109,7 @@ class _RideRosterSheetState extends State<RideRosterSheet> {
                 segments: const [
                   ButtonSegment(
                     value: _RosterFilter.active,
-                    icon: Icon(Icons.motorcycle_outlined),
+                    icon: Icon(Icons.location_on_outlined),
                     label: Text('Current'),
                   ),
                   ButtonSegment(

--- a/apps/mobile/lib/features/settings/emergency_info_sheet.dart
+++ b/apps/mobile/lib/features/settings/emergency_info_sheet.dart
@@ -163,7 +163,7 @@ class _EmergencyInfoSheetState extends State<EmergencyInfoSheet> {
           title: const Text('Share automatically with the coordinator'),
           subtitle: const Text(
             'If you send an emergency-stop alert, this info goes straight '
-            'to whoever is currently the leader - useful if you can\'t take '
+            'to whoever is coordinating the flight - useful if you can\'t take '
             'a further step yourself. You can also share it with the whole '
             'group at any time from the Flight page.',
           ),

--- a/apps/mobile/lib/features/situational_awareness/situational_awareness_screen.dart
+++ b/apps/mobile/lib/features/situational_awareness/situational_awareness_screen.dart
@@ -211,7 +211,7 @@ class _TrafficRerouteCard extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             const Text(
-              'The group route changes only after the leader reviews and '
+              'The group route changes only after the coordinator reviews and '
               'confirms the alternative.',
               style: TextStyle(color: Color(0xFFAD9E90), fontSize: 12),
             ),

--- a/apps/mobile/lib/internet/internet_relay_client.dart
+++ b/apps/mobile/lib/internet/internet_relay_client.dart
@@ -75,6 +75,11 @@ abstract final class RelayProtocolCapabilities {
   /// this" instead of appearing to have shared a number that went nowhere.
   static const riderContactSharing = 'rider-contact-sharing-v1';
 
+  /// Two-party pilot authority transfer. Older relays reject its additive
+  /// event names, so clients must withhold them and state the limitation until
+  /// the service advertises support.
+  static const pilotHandover = 'pilot-handover-v1';
+
   /// Anonymous rider verdicts on catalogued roads (issue #159).
   ///
 
@@ -97,6 +102,7 @@ abstract final class RelayProtocolCapabilities {
     trafficIncidents,
     trafficReroutes,
     riderContactSharing,
+    pilotHandover,
     rideReopen,
   };
 }

--- a/apps/mobile/lib/internet/internet_relay_worker.dart
+++ b/apps/mobile/lib/internet/internet_relay_worker.dart
@@ -448,6 +448,9 @@ class InternetRelayWorker {
       RideEventType.routeCleared => RelayProtocolCapabilities.routeRevisions,
       RideEventType.riderContactShared =>
         RelayProtocolCapabilities.riderContactSharing,
+      RideEventType.pilotHandoverOffered ||
+      RideEventType.pilotHandoverAccepted =>
+        RelayProtocolCapabilities.pilotHandover,
       RideEventType.rideReopened => RelayProtocolCapabilities.rideReopen,
       _ => null,
     };

--- a/apps/mobile/lib/internet/plan_directory.dart
+++ b/apps/mobile/lib/internet/plan_directory.dart
@@ -4,16 +4,18 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
+import '../domain/forecast_plan.dart';
 import 'internet_relay_client.dart';
 
 /// A fetched pre-ride route plan. Unrelated to a live ride: fetching one
 /// never claims a ride or touches the ride/join-code tables, and the caller
 /// still runs its own unchanged create-ride flow with the returned GPX.
 class FetchedPlan {
-  const FetchedPlan({required this.name, required this.gpx});
+  const FetchedPlan({required this.name, required this.gpx, this.forecastPlan});
 
   final String? name;
   final String gpx;
+  final ForecastPlanDocument? forecastPlan;
 }
 
 class PlanDirectoryException implements Exception {
@@ -90,13 +92,33 @@ class HttpPlanDirectory implements PlanDirectory {
       final json = Map<String, Object?>.from(value);
       final gpx = json['gpx'];
       final name = json['name'];
+      final rawForecastPlan = json['forecastPlan'];
       if (gpx is! String || gpx.isEmpty) {
         throw const FormatException('Response gpx field is invalid.');
       }
       if (name != null && name is! String) {
         throw const FormatException('Response name field is invalid.');
       }
-      return FetchedPlan(name: name as String?, gpx: gpx);
+      if (rawForecastPlan != null && rawForecastPlan is! Map) {
+        throw const FormatException(
+          'Response structured plan field is invalid.',
+        );
+      }
+      final forecastPlan = rawForecastPlan is Map
+          ? ForecastPlanDocument.fromJson(
+              Map<String, Object?>.from(rawForecastPlan),
+            )
+          : null;
+      if (forecastPlan != null && forecastPlan.gpxFallback != gpx) {
+        throw const FormatException(
+          'Structured plan does not match its GPX fallback.',
+        );
+      }
+      return FetchedPlan(
+        name: name as String?,
+        gpx: gpx,
+        forecastPlan: forecastPlan,
+      );
     } on FormatException {
       throw const PlanDirectoryException(
         'Plan service returned an invalid response.',

--- a/apps/mobile/lib/relay/relay_engine.dart
+++ b/apps/mobile/lib/relay/relay_engine.dart
@@ -225,7 +225,9 @@ class RelayEngine {
       RideEventType.routeRevisionChunk ||
       RideEventType.routeRevisionPublished ||
       RideEventType.routeCleared ||
-      RideEventType.chaseGuidanceTargetSelected => const Duration(hours: 72),
+      RideEventType.chaseGuidanceTargetSelected ||
+      RideEventType.pilotHandoverOffered ||
+      RideEventType.pilotHandoverAccepted => const Duration(hours: 72),
       _ => switch (event.priority) {
         EventPriority.routine => const Duration(hours: 2),
         EventPriority.important => const Duration(hours: 8),

--- a/apps/mobile/lib/relay/relay_engine.dart
+++ b/apps/mobile/lib/relay/relay_engine.dart
@@ -198,7 +198,9 @@ class RelayEngine {
     if (config.rideId.isEmpty ||
         config.localDeviceId.isEmpty ||
         config.rideSecret.length < 16) {
-      throw ArgumentError('A complete, authenticated ride session is required');
+      throw ArgumentError(
+        'A complete, authenticated flight session is required',
+      );
     }
     await stop();
     _config = config;
@@ -216,7 +218,7 @@ class RelayEngine {
   Future<void> enqueueLocal(RideEvent event) async {
     final config = _requireConfig();
     if (event.rideId != config.rideId) {
-      throw ArgumentError('Cannot relay an event from another ride');
+      throw ArgumentError('Cannot relay an event from another flight');
     }
     final now = _clock();
     final defaultLifetime = switch (event.type) {

--- a/apps/mobile/lib/relay/relay_engine.dart
+++ b/apps/mobile/lib/relay/relay_engine.dart
@@ -222,7 +222,8 @@ class RelayEngine {
     final defaultLifetime = switch (event.type) {
       RideEventType.routeRevisionChunk ||
       RideEventType.routeRevisionPublished ||
-      RideEventType.routeCleared => const Duration(hours: 72),
+      RideEventType.routeCleared ||
+      RideEventType.chaseGuidanceTargetSelected => const Duration(hours: 72),
       _ => switch (event.priority) {
         EventPriority.routine => const Duration(hours: 2),
         EventPriority.important => const Duration(hours: 8),

--- a/apps/mobile/lib/relay/relay_protocol.dart
+++ b/apps/mobile/lib/relay/relay_protocol.dart
@@ -130,7 +130,7 @@ class RelayProtocol {
     }
     final rideId = _boundedString(json['rideId'], 'rideId', 128);
     if (rideId != expectedRideId) {
-      throw const RelayProtocolException('Frame belongs to another ride');
+      throw const RelayProtocolException('Frame belongs to another flight');
     }
     final senderId = _boundedString(json['senderId'], 'senderId', 128);
     final frameId = _boundedString(json['frameId'], 'frameId', 128);
@@ -183,7 +183,7 @@ class RelayProtocol {
       );
       if (riderId != senderId) {
         throw const RelayProtocolException(
-          'Presence rider does not match sender',
+          'Presence participant does not match sender',
         );
       }
       final expiresAt = _date(presence['expiresAt'], 'presence expiresAt');
@@ -284,7 +284,7 @@ class RelayProtocol {
         throw const RelayProtocolException('Event schema is invalid');
       }
       if (event.rideId != rideId) {
-        throw const RelayProtocolException('Event ride does not match frame');
+        throw const RelayProtocolException('Event flight does not match frame');
       }
       final firstSeenAt = _date(queued['firstSeenAt'], 'firstSeenAt');
       final expiresAt = _date(queued['expiresAt'], 'expiresAt');
@@ -412,7 +412,7 @@ class RelayProtocol {
 
   void _requireSecret(String secret) {
     if (secret.length < 16 || secret.length > 512) {
-      throw const RelayProtocolException('Ride secret is unavailable');
+      throw const RelayProtocolException('Flight secret is unavailable');
     }
   }
 }

--- a/apps/mobile/lib/services/carplay_bridge.dart
+++ b/apps/mobile/lib/services/carplay_bridge.dart
@@ -654,11 +654,15 @@ class CarPlayRideStart {
     required bool locationReady,
     required bool isGroup,
     String? routeName,
+    bool routeIsBalloonForecast = false,
   }) {
     if (!hasSession || !isLeader || rideStarted || rideEnded) return null;
     return CarPlayRideStart(
       enabled: !busy && locationReady,
-      detail: routeName == null
+      detail: routeIsBalloonForecast
+          ? '${routeName ?? 'Forecast plan selected'}. This is advisory; '
+                'recording and group location sharing will start.'
+          : routeName == null
           ? 'No route selected. Recording and group location sharing will start.'
           : '$routeName. Recording, sharing and navigation will start.',
       warning: null,

--- a/apps/mobile/lib/services/chase_guidance_target.dart
+++ b/apps/mobile/lib/services/chase_guidance_target.dart
@@ -105,6 +105,8 @@ class ChaseGuidanceSelectionReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/services/chase_guidance_target.dart
+++ b/apps/mobile/lib/services/chase_guidance_target.dart
@@ -1,5 +1,7 @@
+import '../domain/craft.dart';
 import '../domain/geo_point.dart';
 import '../domain/landing_zone.dart';
+import '../domain/ride_event.dart';
 import '../domain/rider_location.dart';
 import 'geo_calculations.dart';
 
@@ -11,6 +13,103 @@ extension ChaseGuidanceTargetLabel on ChaseGuidanceTarget {
     ChaseGuidanceTarget.landingArea => 'Intended landing area',
     ChaseGuidanceTarget.balloon => 'Road rendezvous near balloon',
   };
+}
+
+ChaseGuidanceTarget? chaseGuidanceTargetFromName(Object? name) => name is String
+    ? ChaseGuidanceTarget.values
+          .where((target) => target.name == name)
+          .firstOrNull
+    : null;
+
+class ChaseGuidanceSelection {
+  const ChaseGuidanceSelection({
+    required this.craftId,
+    required this.target,
+    required this.changedAt,
+    required this.changedByDeviceId,
+  });
+
+  final String craftId;
+  final ChaseGuidanceTarget target;
+  final DateTime changedAt;
+  final String changedByDeviceId;
+}
+
+/// Replays one shared guidance choice per chase vehicle.
+///
+/// A selection is accepted only when its author was attached to that vehicle
+/// at the time. A phone cannot redirect another vehicle by naming its craft id.
+class ChaseGuidanceSelectionReducer {
+  const ChaseGuidanceSelectionReducer();
+
+  Map<String, ChaseGuidanceSelection> fromEvents(Iterable<RideEvent> events) {
+    final craftKinds = <String, CraftKind>{};
+    final deviceToCraft = <String, String>{};
+    final selections = <String, ChaseGuidanceSelection>{};
+    final ordered = events.toList()
+      ..sort((first, second) {
+        final byTime = first.createdAt.compareTo(second.createdAt);
+        return byTime != 0 ? byTime : first.id.compareTo(second.id);
+      });
+
+    for (final event in ordered) {
+      switch (event.type) {
+        case RideEventType.craftRegistered:
+          final craftId = event.payload['craftId'] ?? event.payload['id'];
+          if (craftId is String && craftId.isNotEmpty) {
+            craftKinds[craftId] = craftKindFromName(event.payload['kind']);
+          }
+        case RideEventType.deviceAttachedToCraft:
+          final deviceId = event.payload['deviceId'];
+          final craftId = event.payload['craftId'];
+          if (deviceId is String && craftId is String) {
+            deviceToCraft[deviceId] = craftId;
+          }
+        case RideEventType.chaseGuidanceTargetSelected:
+          final craftId = event.payload['craftId'];
+          final target = chaseGuidanceTargetFromName(event.payload['target']);
+          if (craftId is! String ||
+              target == null ||
+              craftKinds[craftId] != CraftKind.vehicle ||
+              deviceToCraft[event.deviceId] != craftId) {
+            break;
+          }
+          selections[craftId] = ChaseGuidanceSelection(
+            craftId: craftId,
+            target: target,
+            changedAt: event.createdAt,
+            changedByDeviceId: event.deviceId,
+          );
+        case RideEventType.rideCreated:
+        case RideEventType.riderJoined:
+        case RideEventType.riderLeft:
+        case RideEventType.roleChanged:
+        case RideEventType.rideStarted:
+        case RideEventType.statusMessage:
+        case RideEventType.riderLocationUpdated:
+        case RideEventType.hazardReported:
+        case RideEventType.hazardCleared:
+        case RideEventType.routeRevisionChunk:
+        case RideEventType.routeRevisionPublished:
+        case RideEventType.routeCleared:
+        case RideEventType.ridePaused:
+        case RideEventType.rideResumed:
+        case RideEventType.rideEnded:
+        case RideEventType.iceInfoShared:
+        case RideEventType.iceInfoViewed:
+        case RideEventType.riderContactShared:
+        case RideEventType.rideReopened:
+        case RideEventType.craftPrimaryDeviceNominated:
+        case RideEventType.craftChaseAssigned:
+        case RideEventType.landingAreaNoted:
+        case RideEventType.windContextNoted:
+        case RideEventType.operationalBoundaryUpserted:
+        case RideEventType.operationalBoundaryRemoved:
+          break;
+      }
+    }
+    return Map.unmodifiable(selections);
+  }
 }
 
 /// A target suitable for asking a road-routing engine for a personal route.

--- a/apps/mobile/lib/services/craft_roster.dart
+++ b/apps/mobile/lib/services/craft_roster.dart
@@ -170,6 +170,8 @@ class CraftRosterReducer {
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
         case RideEventType.chaseGuidanceTargetSelected:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/services/craft_roster.dart
+++ b/apps/mobile/lib/services/craft_roster.dart
@@ -169,6 +169,7 @@ class CraftRosterReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.chaseGuidanceTargetSelected:
           break;
       }
     }

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -96,6 +96,8 @@ class CraftTrackReducer {
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
         case RideEventType.chaseGuidanceTargetSelected:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -95,6 +95,7 @@ class CraftTrackReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.chaseGuidanceTargetSelected:
           break;
       }
     }

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -1,0 +1,192 @@
+import '../domain/craft.dart';
+import '../domain/ride_event.dart';
+import '../domain/rider_location.dart';
+import 'craft_telemetry_election.dart';
+
+class CraftTrack {
+  const CraftTrack({
+    required this.craftId,
+    required this.label,
+    required this.kind,
+    required this.samples,
+  });
+
+  final String craftId;
+  final String label;
+  final CraftKind kind;
+  final List<LocationSample> samples;
+
+  bool get isBalloon => kind == CraftKind.balloon;
+}
+
+/// Reduces device fixes into one deterministic measured track per craft.
+///
+/// Several phones may report from the same basket or vehicle. Replaying those
+/// fixes as separate lines creates movement that did not happen, so the same
+/// election used for the current craft fix is replayed through measurement
+/// time. Out-of-order and duplicate fixes cannot regress the result.
+class CraftTrackReducer {
+  const CraftTrackReducer({this.election = const CraftTelemetryElection()});
+
+  final CraftTelemetryElection election;
+
+  List<CraftTrack> fromEvents(Iterable<RideEvent> events) {
+    final crafts = <String, Craft>{};
+    final deviceToCraft = <String, String>{};
+    final primaryByCraft = <String, String>{};
+    final candidatesByCraft = <String, List<_TimedCandidate>>{};
+    final ordered = events.toList()
+      ..sort((first, second) {
+        final byTime = first.createdAt.compareTo(second.createdAt);
+        return byTime != 0 ? byTime : first.id.compareTo(second.id);
+      });
+
+    for (final event in ordered) {
+      switch (event.type) {
+        case RideEventType.craftRegistered:
+          final craft = _craft(event.payload);
+          if (craft != null) crafts[craft.id] = craft;
+        case RideEventType.deviceAttachedToCraft:
+          final deviceId = event.payload['deviceId'];
+          final craftId = event.payload['craftId'];
+          if (deviceId is String && craftId is String) {
+            deviceToCraft[deviceId] = craftId;
+          }
+        case RideEventType.craftPrimaryDeviceNominated:
+          final craftId = event.payload['craftId'];
+          final deviceId = event.payload['deviceId'];
+          if (craftId is String && deviceId is String) {
+            primaryByCraft[craftId] = deviceId;
+          }
+        case RideEventType.riderLocationUpdated:
+          final craftId = deviceToCraft[event.deviceId];
+          final sample = _sample(event.payload);
+          if (craftId == null || sample == null) break;
+          candidatesByCraft
+              .putIfAbsent(craftId, () => [])
+              .add(
+                _TimedCandidate(
+                  deviceId: event.deviceId,
+                  sample: sample,
+                  isNominatedPrimary: primaryByCraft[craftId] == event.deviceId,
+                  eventId: event.id,
+                ),
+              );
+        case RideEventType.rideCreated:
+        case RideEventType.riderJoined:
+        case RideEventType.riderLeft:
+        case RideEventType.roleChanged:
+        case RideEventType.rideStarted:
+        case RideEventType.statusMessage:
+        case RideEventType.hazardReported:
+        case RideEventType.hazardCleared:
+        case RideEventType.routeRevisionChunk:
+        case RideEventType.routeRevisionPublished:
+        case RideEventType.routeCleared:
+        case RideEventType.ridePaused:
+        case RideEventType.rideResumed:
+        case RideEventType.rideEnded:
+        case RideEventType.iceInfoShared:
+        case RideEventType.iceInfoViewed:
+        case RideEventType.riderContactShared:
+        case RideEventType.rideReopened:
+        case RideEventType.craftChaseAssigned:
+        case RideEventType.landingAreaNoted:
+        case RideEventType.windContextNoted:
+        case RideEventType.operationalBoundaryUpserted:
+        case RideEventType.operationalBoundaryRemoved:
+          break;
+      }
+    }
+
+    final tracks = <CraftTrack>[];
+    for (final craft in crafts.values) {
+      final candidates = [...?candidatesByCraft[craft.id]]
+        ..sort((first, second) {
+          final byMeasurement = first.sample.recordedAt.compareTo(
+            second.sample.recordedAt,
+          );
+          return byMeasurement != 0
+              ? byMeasurement
+              : first.eventId.compareTo(second.eventId);
+        });
+      final latestByDevice = <String, _TimedCandidate>{};
+      final samples = <LocationSample>[];
+      String? incumbentDeviceId;
+      for (final candidate in candidates) {
+        final previous = latestByDevice[candidate.deviceId];
+        if (previous != null &&
+            !candidate.sample.recordedAt.isAfter(previous.sample.recordedAt)) {
+          continue;
+        }
+        latestByDevice[candidate.deviceId] = candidate;
+        final fix = election.elect(
+          candidates: [
+            for (final current in latestByDevice.values)
+              CraftFixCandidate(
+                deviceId: current.deviceId,
+                sample: current.sample,
+                isNominatedPrimary: current.isNominatedPrimary,
+              ),
+          ],
+          now: candidate.sample.recordedAt,
+          incumbentDeviceId: incumbentDeviceId,
+        );
+        final elected = fix.sample;
+        if (elected == null) continue;
+        incumbentDeviceId = fix.deviceId;
+        if (samples.isNotEmpty &&
+            !elected.recordedAt.isAfter(samples.last.recordedAt)) {
+          continue;
+        }
+        samples.add(elected);
+      }
+      tracks.add(
+        CraftTrack(
+          craftId: craft.id,
+          label: craft.label,
+          kind: craft.kind,
+          samples: List.unmodifiable(samples),
+        ),
+      );
+    }
+    tracks.sort((first, second) {
+      if (first.isBalloon != second.isBalloon) {
+        return first.isBalloon ? -1 : 1;
+      }
+      return first.label.compareTo(second.label);
+    });
+    return List.unmodifiable(tracks);
+  }
+
+  static Craft? _craft(Map<String, Object?> payload) {
+    final id = payload['craftId'] ?? payload['id'];
+    if (id is! String || id.isEmpty) return null;
+    final kind = craftKindFromName(payload['kind']);
+    return Craft(id: id, kind: kind, label: payload['label'] as String? ?? id);
+  }
+
+  static LocationSample? _sample(Map<String, Object?> payload) {
+    final raw = payload['sample'];
+    if (raw is! Map) return null;
+    try {
+      return LocationSample.fromJson(Map<String, Object?>.from(raw));
+    } on Object {
+      return null;
+    }
+  }
+}
+
+class _TimedCandidate {
+  const _TimedCandidate({
+    required this.deviceId,
+    required this.sample,
+    required this.isNominatedPrimary,
+    required this.eventId,
+  });
+
+  final String deviceId;
+  final LocationSample sample;
+  final bool isNominatedPrimary;
+  final String eventId;
+}

--- a/apps/mobile/lib/services/flight_plan_summary.dart
+++ b/apps/mobile/lib/services/flight_plan_summary.dart
@@ -43,6 +43,14 @@ class FlightPlanSummary {
     required this.maximumDescentRateMetersPerSecond,
     required this.forecastLanding,
     required this.intendedLanding,
+    this.matchingWindowStart,
+    this.matchingWindowEnd,
+    this.altitudeCeilingMetersMsl,
+    this.windProvider,
+    this.windModel,
+    this.windValidFrom,
+    this.windValidTo,
+    this.landingEnvelope = const [],
   });
 
   final String routeName;
@@ -56,6 +64,14 @@ class FlightPlanSummary {
   final double? maximumDescentRateMetersPerSecond;
   final GeoPoint? forecastLanding;
   final GeoPoint? intendedLanding;
+  final DateTime? matchingWindowStart;
+  final DateTime? matchingWindowEnd;
+  final double? altitudeCeilingMetersMsl;
+  final String? windProvider;
+  final String? windModel;
+  final DateTime? windValidFrom;
+  final DateTime? windValidTo;
+  final List<GeoPoint> landingEnvelope;
 
   bool get hasTimedAltitudeProfile =>
       stages.any((stage) => stage.time != null) &&
@@ -66,9 +82,14 @@ class FlightPlanSummary {
     final points = [for (final path in route.paths) ...path.points];
     if (points.isEmpty) return null;
 
+    final structured = route.forecastPlan;
     final timed = points.where((point) => point.recordedAt != null).toList();
-    final startTime = timed.isEmpty ? null : timed.first.recordedAt;
-    final landingTime = timed.isEmpty ? null : timed.last.recordedAt;
+    final startTime =
+        structured?.departure.selectedAt ??
+        (timed.isEmpty ? null : timed.first.recordedAt);
+    final landingTime =
+        structured?.altitudeStages.last.plannedAt ??
+        (timed.isEmpty ? null : timed.last.recordedAt);
     final timedDuration = startTime != null && landingTime != null
         ? landingTime.difference(startTime)
         : null;
@@ -123,18 +144,33 @@ class FlightPlanSummary {
         : points.indexWhere(
             (point) => point.elevationMeters == maximumAltitude,
           );
-    final stages = <FlightPlanStage>[];
-    for (final index in stageIndices) {
-      final point = points[index];
-      stages.add(
-        FlightPlanStage(
-          point: point,
-          time: point.recordedAt,
-          altitudeMetersMsl: point.elevationMeters,
-          phase: _phaseAt(points, index, maximumIndex: maximumIndex),
-        ),
-      );
-    }
+    final stages = structured == null
+        ? <FlightPlanStage>[
+            for (final index in stageIndices)
+              FlightPlanStage(
+                point: points[index],
+                time: points[index].recordedAt,
+                altitudeMetersMsl: points[index].elevationMeters,
+                phase: _phaseAt(points, index, maximumIndex: maximumIndex),
+              ),
+          ]
+        : <FlightPlanStage>[
+            for (final (index, stage) in structured.altitudeStages.indexed)
+              FlightPlanStage(
+                point: _nearestPointAt(points, stage.plannedAt),
+                time: stage.plannedAt,
+                altitudeMetersMsl: stage.altitudeMetersMsl,
+                phase: index == 0
+                    ? FlightPlanStagePhase.launch
+                    : index == structured.altitudeStages.length - 1
+                    ? FlightPlanStagePhase.landing
+                    : stage.changeRateMetersPerSecond > 0.01
+                    ? FlightPlanStagePhase.climb
+                    : stage.changeRateMetersPerSecond < -0.01
+                    ? FlightPlanStagePhase.descend
+                    : FlightPlanStagePhase.level,
+              ),
+          ];
 
     GeoPoint? waypointNamed(String text) {
       for (final waypoint in route.waypoints) {
@@ -156,12 +192,48 @@ class FlightPlanSummary {
       duration: duration,
       minimumAltitudeMetersMsl: minimumAltitude,
       maximumAltitudeMetersMsl: maximumAltitude,
-      maximumAscentRateMetersPerSecond: maximumAscentRate,
-      maximumDescentRateMetersPerSecond: maximumDescentRate,
-      forecastLanding: waypointNamed('forecast landing') ?? points.last,
-      intendedLanding: waypointNamed('intended landing'),
+      maximumAscentRateMetersPerSecond:
+          structured?.constraints.maximumAscentRateMetersPerSecond ??
+          maximumAscentRate,
+      maximumDescentRateMetersPerSecond:
+          structured?.constraints.maximumDescentRateMetersPerSecond ??
+          maximumDescentRate,
+      forecastLanding: structured == null
+          ? waypointNamed('forecast landing') ?? points.last
+          : GeoPoint(
+              latitude: structured.forecastLanding.latitude,
+              longitude: structured.forecastLanding.longitude,
+            ),
+      intendedLanding: structured == null
+          ? waypointNamed('intended landing')
+          : GeoPoint(
+              latitude: structured.intendedLandingArea.center.latitude,
+              longitude: structured.intendedLandingArea.center.longitude,
+            ),
+      matchingWindowStart: structured?.departure.matchingWindowStart,
+      matchingWindowEnd: structured?.departure.matchingWindowEnd,
+      altitudeCeilingMetersMsl:
+          structured?.constraints.altitudeCeilingMetersMsl,
+      windProvider: structured?.wind.provider,
+      windModel: structured?.wind.model,
+      windValidFrom: structured?.wind.validFrom,
+      windValidTo: structured?.wind.validTo,
+      landingEnvelope: [
+        for (final point in structured?.landingEnvelope ?? const [])
+          GeoPoint(latitude: point.latitude, longitude: point.longitude),
+      ],
     );
   }
+}
+
+GeoPoint _nearestPointAt(List<GeoPoint> points, DateTime time) {
+  final timed = points.where((point) => point.recordedAt != null).toList();
+  if (timed.isEmpty) return points.first;
+  return timed.reduce((best, candidate) {
+    final bestDistance = best.recordedAt!.difference(time).abs();
+    final candidateDistance = candidate.recordedAt!.difference(time).abs();
+    return candidateDistance < bestDistance ? candidate : best;
+  });
 }
 
 List<int> _stageIndices(List<GeoPoint> points) {

--- a/apps/mobile/lib/services/flight_plan_summary.dart
+++ b/apps/mobile/lib/services/flight_plan_summary.dart
@@ -1,0 +1,231 @@
+import '../domain/imported_route.dart';
+
+enum FlightPlanStagePhase { launch, climb, level, descend, peak, landing }
+
+class FlightPlanStage {
+  const FlightPlanStage({
+    required this.point,
+    required this.phase,
+    this.time,
+    this.altitudeMetersMsl,
+  });
+
+  final GeoPoint point;
+  final FlightPlanStagePhase phase;
+  final DateTime? time;
+  final double? altitudeMetersMsl;
+
+  String get label => switch (phase) {
+    FlightPlanStagePhase.launch => 'Launch',
+    FlightPlanStagePhase.climb => 'Climb',
+    FlightPlanStagePhase.level => 'Level flight',
+    FlightPlanStagePhase.descend => 'Descent',
+    FlightPlanStagePhase.peak => 'Maximum altitude',
+    FlightPlanStagePhase.landing => 'Forecast landing',
+  };
+}
+
+/// A compact, aviation-specific interpretation of a planner forecast.
+///
+/// Planner GPX files contain a timed, altitude-bearing line rather than road
+/// manoeuvres. This model keeps that distinction explicit and gives the live
+/// flight UI a bounded set of useful stages instead of hundreds of raw fixes.
+class FlightPlanSummary {
+  const FlightPlanSummary({
+    required this.routeName,
+    required this.stages,
+    required this.startTime,
+    required this.landingTime,
+    required this.duration,
+    required this.minimumAltitudeMetersMsl,
+    required this.maximumAltitudeMetersMsl,
+    required this.maximumAscentRateMetersPerSecond,
+    required this.maximumDescentRateMetersPerSecond,
+    required this.forecastLanding,
+    required this.intendedLanding,
+  });
+
+  final String routeName;
+  final List<FlightPlanStage> stages;
+  final DateTime? startTime;
+  final DateTime? landingTime;
+  final Duration? duration;
+  final double? minimumAltitudeMetersMsl;
+  final double? maximumAltitudeMetersMsl;
+  final double? maximumAscentRateMetersPerSecond;
+  final double? maximumDescentRateMetersPerSecond;
+  final GeoPoint? forecastLanding;
+  final GeoPoint? intendedLanding;
+
+  bool get hasTimedAltitudeProfile =>
+      stages.any((stage) => stage.time != null) &&
+      stages.any((stage) => stage.altitudeMetersMsl != null);
+
+  static FlightPlanSummary? fromRoute(ImportedRoute? route) {
+    if (route == null || !route.isBalloonForecast) return null;
+    final points = [for (final path in route.paths) ...path.points];
+    if (points.isEmpty) return null;
+
+    final timed = points.where((point) => point.recordedAt != null).toList();
+    final startTime = timed.isEmpty ? null : timed.first.recordedAt;
+    final landingTime = timed.isEmpty ? null : timed.last.recordedAt;
+    final timedDuration = startTime != null && landingTime != null
+        ? landingTime.difference(startTime)
+        : null;
+    final duration = timedDuration != null && !timedDuration.isNegative
+        ? timedDuration
+        : route.plannedDuration;
+
+    final altitudes = points
+        .map((point) => point.elevationMeters)
+        .whereType<double>()
+        .toList(growable: false);
+    final minimumAltitude = altitudes.isEmpty
+        ? null
+        : altitudes.reduce((first, second) => first < second ? first : second);
+    final maximumAltitude = altitudes.isEmpty
+        ? null
+        : altitudes.reduce((first, second) => first > second ? first : second);
+
+    double? maximumAscentRate;
+    double? maximumDescentRate;
+    for (var index = 1; index < points.length; index += 1) {
+      final previous = points[index - 1];
+      final current = points[index];
+      final previousTime = previous.recordedAt;
+      final currentTime = current.recordedAt;
+      final previousAltitude = previous.elevationMeters;
+      final currentAltitude = current.elevationMeters;
+      if (previousTime == null ||
+          currentTime == null ||
+          previousAltitude == null ||
+          currentAltitude == null) {
+        continue;
+      }
+      final seconds =
+          currentTime.difference(previousTime).inMilliseconds / 1000;
+      if (seconds <= 0) continue;
+      final rate = (currentAltitude - previousAltitude) / seconds;
+      if (rate > 0 && (maximumAscentRate == null || rate > maximumAscentRate)) {
+        maximumAscentRate = rate;
+      }
+      if (rate < 0) {
+        final descent = -rate;
+        if (maximumDescentRate == null || descent > maximumDescentRate) {
+          maximumDescentRate = descent;
+        }
+      }
+    }
+
+    final stageIndices = _stageIndices(points);
+    final maximumIndex = maximumAltitude == null
+        ? null
+        : points.indexWhere(
+            (point) => point.elevationMeters == maximumAltitude,
+          );
+    final stages = <FlightPlanStage>[];
+    for (final index in stageIndices) {
+      final point = points[index];
+      stages.add(
+        FlightPlanStage(
+          point: point,
+          time: point.recordedAt,
+          altitudeMetersMsl: point.elevationMeters,
+          phase: _phaseAt(points, index, maximumIndex: maximumIndex),
+        ),
+      );
+    }
+
+    GeoPoint? waypointNamed(String text) {
+      for (final waypoint in route.waypoints) {
+        final searchable = [
+          waypoint.name,
+          waypoint.description,
+          waypoint.symbol,
+        ].whereType<String>().join(' ').toLowerCase();
+        if (searchable.contains(text)) return waypoint.point;
+      }
+      return null;
+    }
+
+    return FlightPlanSummary(
+      routeName: route.name,
+      stages: List.unmodifiable(stages),
+      startTime: startTime,
+      landingTime: landingTime,
+      duration: duration,
+      minimumAltitudeMetersMsl: minimumAltitude,
+      maximumAltitudeMetersMsl: maximumAltitude,
+      maximumAscentRateMetersPerSecond: maximumAscentRate,
+      maximumDescentRateMetersPerSecond: maximumDescentRate,
+      forecastLanding: waypointNamed('forecast landing') ?? points.last,
+      intendedLanding: waypointNamed('intended landing'),
+    );
+  }
+}
+
+List<int> _stageIndices(List<GeoPoint> points) {
+  if (points.length <= 10) {
+    return List.generate(points.length, (index) => index, growable: false);
+  }
+
+  final important = <int>{0, points.length - 1};
+  double? maximumAltitude;
+  int? maximumIndex;
+  for (final (index, point) in points.indexed) {
+    final altitude = point.elevationMeters;
+    if (altitude != null &&
+        (maximumAltitude == null || altitude > maximumAltitude)) {
+      maximumAltitude = altitude;
+      maximumIndex = index;
+    }
+    if (index == 0 || index == points.length - 1) continue;
+    final before = _altitudeDirection(points[index - 1], point);
+    final after = _altitudeDirection(point, points[index + 1]);
+    if (before != after && before != 0 && after != 0) important.add(index);
+  }
+  if (maximumIndex != null) important.add(maximumIndex);
+
+  for (var step = 1; step < 8; step += 1) {
+    important.add(((points.length - 1) * step / 8).round());
+  }
+
+  final ordered = important.toList()..sort();
+  if (ordered.length <= 10) return ordered;
+  final retained = <int>{0, points.length - 1};
+  if (maximumIndex != null) retained.add(maximumIndex);
+  final interior = ordered
+      .where((index) => !retained.contains(index))
+      .toList(growable: false);
+  final spaces = 10 - retained.length;
+  for (var slot = 0; slot < spaces; slot += 1) {
+    final position =
+        ((slot + 1) * (interior.length + 1) / (spaces + 1)).round() - 1;
+    retained.add(interior[position.clamp(0, interior.length - 1)]);
+  }
+  return retained.toList()..sort();
+}
+
+FlightPlanStagePhase _phaseAt(
+  List<GeoPoint> points,
+  int index, {
+  required int? maximumIndex,
+}) {
+  if (index == 0) return FlightPlanStagePhase.launch;
+  if (index == points.length - 1) return FlightPlanStagePhase.landing;
+  if (index == maximumIndex) return FlightPlanStagePhase.peak;
+
+  final direction = _altitudeDirection(points[index - 1], points[index + 1]);
+  if (direction > 0) return FlightPlanStagePhase.climb;
+  if (direction < 0) return FlightPlanStagePhase.descend;
+  return FlightPlanStagePhase.level;
+}
+
+int _altitudeDirection(GeoPoint first, GeoPoint second) {
+  final firstAltitude = first.elevationMeters;
+  final secondAltitude = second.elevationMeters;
+  if (firstAltitude == null || secondAltitude == null) return 0;
+  final difference = secondAltitude - firstAltitude;
+  if (difference.abs() < 2) return 0;
+  return difference > 0 ? 1 : -1;
+}

--- a/apps/mobile/lib/services/flight_replay_archiver.dart
+++ b/apps/mobile/lib/services/flight_replay_archiver.dart
@@ -130,6 +130,7 @@ class FlightReplayArchiver {
           break;
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.chaseGuidanceTargetSelected:
           break;
       }
     }

--- a/apps/mobile/lib/services/flight_replay_archiver.dart
+++ b/apps/mobile/lib/services/flight_replay_archiver.dart
@@ -131,6 +131,8 @@ class FlightReplayArchiver {
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
         case RideEventType.chaseGuidanceTargetSelected:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/services/forecast_plan_importer.dart
+++ b/apps/mobile/lib/services/forecast_plan_importer.dart
@@ -1,0 +1,99 @@
+import '../domain/altitude.dart';
+import '../domain/forecast_plan.dart';
+import '../domain/imported_route.dart';
+
+class ForecastPlanImporter {
+  const ForecastPlanImporter();
+
+  ImportedRoute import(
+    ForecastPlanDocument plan, {
+    required DateTime importedAt,
+    required String sourceFileName,
+  }) {
+    GeoPoint point(
+      double latitude,
+      double longitude, {
+      double? altitudeMetersMsl,
+      DateTime? recordedAt,
+    }) => GeoPoint(
+      latitude: latitude,
+      longitude: longitude,
+      elevationMeters: altitudeMetersMsl,
+      // Forecast is not a sensor source. The plan's wind provenance and
+      // immutable purpose carry that distinction; altitude source remains
+      // unknown rather than pretending it was measured.
+      altitudeSource: AltitudeSource.unknown,
+      altitudeDatum: altitudeMetersMsl == null
+          ? AltitudeDatum.unknown
+          : _datum(plan.launchAltitudeDatum),
+      recordedAt: recordedAt,
+    );
+
+    final track = [
+      for (final sample in plan.plannedTrack)
+        point(
+          sample.point.latitude,
+          sample.point.longitude,
+          altitudeMetersMsl: sample.altitudeMetersMsl,
+          recordedAt: plan.departure.selectedAt.add(
+            Duration(milliseconds: (sample.elapsedSeconds * 1000).round()),
+          ),
+        ),
+    ];
+    return ImportedRoute(
+      id: plan.id,
+      name: plan.name,
+      description:
+          'Original forecast from ${plan.source}. ${plan.wind.provider} '
+          '${plan.wind.model}; forecast model only, not an aviation briefing.',
+      purpose: ImportedRoutePurpose.balloonForecast,
+      importedAt: importedAt,
+      sourceFileName: sourceFileName,
+      paths: [
+        RoutePath(
+          kind: RoutePathKind.track,
+          name: 'Original forecast',
+          points: List.unmodifiable(track),
+        ),
+      ],
+      waypoints: [
+        RouteWaypoint(
+          point: point(
+            plan.launch.latitude,
+            plan.launch.longitude,
+            altitudeMetersMsl: plan.launchElevationMetersMsl,
+            recordedAt: plan.departure.selectedAt,
+          ),
+          name: 'Launch',
+          symbol: 'Launch',
+        ),
+        RouteWaypoint(
+          point: point(
+            plan.forecastLanding.latitude,
+            plan.forecastLanding.longitude,
+          ),
+          name: 'Forecast landing',
+          symbol: 'Forecast landing',
+        ),
+        RouteWaypoint(
+          point: point(
+            plan.intendedLandingArea.center.latitude,
+            plan.intendedLandingArea.center.longitude,
+          ),
+          name: 'Pilot intended landing area',
+          description: 'Approximate area from the original planner forecast.',
+          symbol: 'Landing area',
+        ),
+      ],
+      plannedDuration: plan.plannedDuration,
+      forecastPlan: plan,
+    );
+  }
+
+  static AltitudeDatum _datum(String name) => switch (name) {
+    'wgs84Geoid' => AltitudeDatum.wgs84Geoid,
+    'wgs84Ellipsoid' => AltitudeDatum.wgs84Ellipsoid,
+    'relativeToLaunch' => AltitudeDatum.relativeToLaunch,
+    _ => AltitudeDatum.unknown,
+  };
+}

--- a/apps/mobile/lib/services/gpx_parser.dart
+++ b/apps/mobile/lib/services/gpx_parser.dart
@@ -84,8 +84,10 @@ class GpxParser {
     }
 
     final paths = <RoutePath>[];
+    var purpose = ImportedRoutePurpose.unspecified;
     for (final track in _children(root, 'trk')) {
       final trackName = _childText(track, 'name');
+      final trackPurpose = _childText(track, 'type')?.trim().toLowerCase();
       final isCalculatedRoadRoute = _children(track, 'extensions')
           .expand((extensions) => extensions.childElements)
           .any(
@@ -100,6 +102,9 @@ class GpxParser {
           'trkpt',
         ).map(parsePoint).toList(growable: false);
         if (points.isEmpty) continue;
+        if (trackPurpose == 'balloon-flight-forecast') {
+          purpose = ImportedRoutePurpose.balloonForecast;
+        }
         final segmentName = segments.length > 1 && trackName != null
             ? '$trackName · segment ${index + 1}'
             : trackName;
@@ -194,6 +199,7 @@ class GpxParser {
           firstPathName ??
           _nameWithoutExtension(sourceFileName),
       description: metadata == null ? null : _childText(metadata, 'desc'),
+      purpose: purpose,
       importedAt: importedAt.toUtc(),
       sourceFileName: sourceFileName,
       paths: selectedPaths,

--- a/apps/mobile/lib/services/live_flight_projection.dart
+++ b/apps/mobile/lib/services/live_flight_projection.dart
@@ -1,0 +1,412 @@
+import 'dart:math' as math;
+
+import '../domain/forecast_plan.dart';
+import '../domain/geo_point.dart' as live;
+import '../domain/imported_route.dart' as route;
+import '../domain/rider_location.dart';
+import 'open_meteo_wind.dart';
+
+enum LiveFlightProjectionStatus {
+  available,
+  noStructuredPlan,
+  noBalloonFix,
+  staleBalloonFix,
+  noCompatibleAltitude,
+  noWind,
+  staleWind,
+  outsideWindValidity,
+  noUsableWindVector,
+}
+
+class LiveFlightProjection {
+  const LiveFlightProjection({
+    required this.track,
+    required this.landingEnvelope,
+    required this.computedAt,
+    required this.windValidAt,
+    required this.windFetchedAt,
+    required this.windSource,
+    required this.duration,
+  });
+
+  final List<route.GeoPoint> track;
+  final List<route.GeoPoint> landingEnvelope;
+  final DateTime computedAt;
+  final DateTime windValidAt;
+  final DateTime windFetchedAt;
+  final String windSource;
+  final Duration duration;
+}
+
+class LiveFlightProjectionAssessment {
+  const LiveFlightProjectionAssessment(this.status, {this.projection});
+
+  final LiveFlightProjectionStatus status;
+  final LiveFlightProjection? projection;
+
+  bool get isAvailable => projection != null;
+
+  String get message => switch (status) {
+    LiveFlightProjectionStatus.available =>
+      'Recalculated from the latest balloon fix and forecast wind.',
+    LiveFlightProjectionStatus.noStructuredPlan =>
+      'A structured forecast plan is needed for a live projection.',
+    LiveFlightProjectionStatus.noBalloonFix =>
+      'Waiting for the balloon position and altitude.',
+    LiveFlightProjectionStatus.staleBalloonFix =>
+      'The balloon fix is too old to project safely.',
+    LiveFlightProjectionStatus.noCompatibleAltitude =>
+      'The balloon altitude datum cannot be compared with the plan.',
+    LiveFlightProjectionStatus.noWind => 'No forecast wind field is available.',
+    LiveFlightProjectionStatus.staleWind =>
+      'The forecast wind field is stale; the last projection is not extended.',
+    LiveFlightProjectionStatus.outsideWindValidity =>
+      'The forecast is not valid near the current flight time.',
+    LiveFlightProjectionStatus.noUsableWindVector =>
+      'The forecast contains no usable wind at the balloon position.',
+  };
+}
+
+/// Advisory projection from current aircraft telemetry and forecast model wind.
+///
+/// This is deliberately deterministic and has no network dependency. The wind
+/// controller fetches a bounded field; this engine only consumes a fresh field,
+/// applies the imported ascent/descent limits, and labels the result as model
+/// output. It never changes the pilot's intended landing area.
+class LiveFlightProjectionEngine {
+  const LiveFlightProjectionEngine({
+    this.maximumFixAge = const Duration(seconds: 45),
+    this.maximumWindAge = const Duration(minutes: 30),
+    this.maximumWindValidityOffset = const Duration(minutes: 90),
+    this.maximumDuration = const Duration(hours: 6),
+    this.step = const Duration(minutes: 1),
+  });
+
+  final Duration maximumFixAge;
+  final Duration maximumWindAge;
+  final Duration maximumWindValidityOffset;
+  final Duration maximumDuration;
+  final Duration step;
+
+  LiveFlightProjectionAssessment evaluate({
+    required ForecastPlanDocument? plan,
+    required LocationSample? balloonFix,
+    required WindForecastField? wind,
+    required DateTime now,
+    bool allowReferenceWind = false,
+  }) {
+    if (plan == null) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noStructuredPlan,
+      );
+    }
+    if (balloonFix == null || balloonFix.altitudeMeters == null) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noBalloonFix,
+      );
+    }
+    final utcNow = now.toUtc();
+    if (balloonFix.ageAt(utcNow) > maximumFixAge) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.staleBalloonFix,
+      );
+    }
+    final altitudeMsl = _altitudeMsl(plan, balloonFix);
+    if (altitudeMsl == null) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noCompatibleAltitude,
+      );
+    }
+    if (wind == null) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noWind,
+      );
+    }
+    if (!allowReferenceWind && !wind.isLiveForecast) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noWind,
+      );
+    }
+    if (!allowReferenceWind &&
+        utcNow.difference(wind.fetchedAt.toUtc()).abs() > maximumWindAge) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.staleWind,
+      );
+    }
+    if (utcNow.difference(wind.validAt.toUtc()).abs() >
+        maximumWindValidityOffset) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.outsideWindValidity,
+      );
+    }
+
+    final duration = _boundedDuration(plan);
+    final primary = _integrate(
+      start: balloonFix.position,
+      startAltitudeMsl: altitudeMsl,
+      duration: duration,
+      wind: wind,
+      altitudeAt: (fraction) =>
+          _plannedAltitude(plan, fraction, startAltitudeMsl: altitudeMsl),
+      constraints: plan.constraints,
+      retainTrack: true,
+      startedAt: utcNow,
+      datum: balloonFix.altitudeDatum,
+    );
+    if (primary == null) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noUsableWindVector,
+      );
+    }
+
+    final endpoints = <route.GeoPoint>[];
+    for (final level in openMeteoWindAltitudeLevels) {
+      final target = math.min(
+        level.toDouble(),
+        plan.constraints.altitudeCeilingMetersMsl,
+      );
+      if (target < plan.launchElevationMetersMsl) continue;
+      final endpoint = _integrate(
+        start: balloonFix.position,
+        startAltitudeMsl: altitudeMsl,
+        duration: duration,
+        wind: wind,
+        altitudeAt: (fraction) => _candidateAltitude(
+          fraction: fraction,
+          duration: duration,
+          startAltitudeMsl: altitudeMsl,
+          targetAltitudeMsl: target,
+          landingAltitudeMsl: plan.launchElevationMetersMsl,
+          maximumAscentRate: plan.constraints.maximumAscentRateMetersPerSecond,
+          maximumDescentRate:
+              plan.constraints.maximumDescentRateMetersPerSecond,
+        ),
+        constraints: plan.constraints,
+        retainTrack: false,
+        startedAt: utcNow,
+        datum: balloonFix.altitudeDatum,
+      )?.last;
+      if (endpoint != null) endpoints.add(endpoint);
+    }
+    endpoints.add(primary.last);
+    final envelope = _convexHull(endpoints);
+    return LiveFlightProjectionAssessment(
+      LiveFlightProjectionStatus.available,
+      projection: LiveFlightProjection(
+        track: List.unmodifiable(primary),
+        landingEnvelope: List.unmodifiable(envelope),
+        computedAt: utcNow,
+        windValidAt: wind.validAt.toUtc(),
+        windFetchedAt: wind.fetchedAt.toUtc(),
+        windSource: wind.sourceLabel,
+        duration: duration,
+      ),
+    );
+  }
+
+  Duration _boundedDuration(ForecastPlanDocument plan) {
+    final maximum = Duration(
+      milliseconds: (plan.constraints.maximumDurationMinutes * 60000).round(),
+    );
+    final candidate = plan.plannedDuration < maximum
+        ? plan.plannedDuration
+        : maximum;
+    if (candidate > maximumDuration) return maximumDuration;
+    return candidate < const Duration(minutes: 10)
+        ? const Duration(minutes: 10)
+        : candidate;
+  }
+
+  static double? _altitudeMsl(ForecastPlanDocument plan, LocationSample fix) =>
+      switch (fix.altitudeDatum) {
+        AltitudeDatum.wgs84Geoid => fix.altitudeMeters,
+        AltitudeDatum.relativeToLaunch =>
+          plan.launchElevationMetersMsl + fix.altitudeMeters!,
+        AltitudeDatum.wgs84Ellipsoid || AltitudeDatum.unknown => null,
+      };
+
+  static double _plannedAltitude(
+    ForecastPlanDocument plan,
+    double fraction, {
+    required double startAltitudeMsl,
+  }) {
+    final stages = plan.altitudeStages;
+    ForecastPlanStage below = stages.first;
+    ForecastPlanStage above = stages.last;
+    for (var index = 1; index < stages.length; index += 1) {
+      if (fraction <= stages[index].fraction) {
+        below = stages[index - 1];
+        above = stages[index];
+        break;
+      }
+    }
+    final span = above.fraction - below.fraction;
+    final local = span <= 0 ? 0.0 : (fraction - below.fraction) / span;
+    final planned =
+        below.altitudeMetersMsl +
+        (above.altitudeMetersMsl - below.altitudeMetersMsl) * local;
+    // Begin at the measured altitude without translating the landing altitude.
+    // The correction fades out across the flight rather than drawing an
+    // impossible vertical jump at the first forecast sample.
+    return planned +
+        (startAltitudeMsl - stages.first.altitudeMetersMsl) * (1 - fraction);
+  }
+
+  static double _candidateAltitude({
+    required double fraction,
+    required Duration duration,
+    required double startAltitudeMsl,
+    required double targetAltitudeMsl,
+    required double landingAltitudeMsl,
+    required double maximumAscentRate,
+    required double maximumDescentRate,
+  }) {
+    final seconds = duration.inMilliseconds / 1000;
+    final elapsed = seconds * fraction;
+    final ascentSeconds = math.max(
+      0,
+      (targetAltitudeMsl - startAltitudeMsl) / maximumAscentRate,
+    );
+    final descentSeconds = math.max(
+      0,
+      (targetAltitudeMsl - landingAltitudeMsl) / maximumDescentRate,
+    );
+    if (elapsed < ascentSeconds) {
+      return startAltitudeMsl + maximumAscentRate * elapsed;
+    }
+    final descentStarts = math.max(ascentSeconds, seconds - descentSeconds);
+    if (elapsed <= descentStarts) return targetAltitudeMsl;
+    return math.max(
+      landingAltitudeMsl,
+      targetAltitudeMsl - maximumDescentRate * (elapsed - descentStarts),
+    );
+  }
+
+  List<route.GeoPoint>? _integrate({
+    required live.GeoPoint start,
+    required double startAltitudeMsl,
+    required Duration duration,
+    required WindForecastField wind,
+    required double Function(double fraction) altitudeAt,
+    required ForecastPlanConstraints constraints,
+    required bool retainTrack,
+    required DateTime startedAt,
+    required AltitudeDatum datum,
+  }) {
+    final totalSeconds = duration.inMilliseconds / 1000;
+    final stepSeconds = math.max(1.0, step.inMilliseconds / 1000);
+    var position = start;
+    var altitude = startAltitudeMsl;
+    final output = <route.GeoPoint>[
+      _routePoint(position, altitude, startedAt, datum),
+    ];
+    for (var elapsed = 0.0; elapsed < totalSeconds;) {
+      final seconds = math.min(stepSeconds, totalSeconds - elapsed);
+      final nextElapsed = elapsed + seconds;
+      final desired = altitudeAt(
+        nextElapsed / totalSeconds,
+      ).clamp(-500.0, constraints.altitudeCeilingMetersMsl);
+      final maximumRise =
+          constraints.maximumAscentRateMetersPerSecond * seconds;
+      final maximumFall =
+          constraints.maximumDescentRateMetersPerSecond * seconds;
+      altitude = desired > altitude
+          ? math.min(desired, altitude + maximumRise)
+          : math.max(desired, altitude - maximumFall);
+      final vector = wind.at(position, altitude);
+      if (vector == null) return null;
+      position = _move(
+        position,
+        eastMeters: vector.eastMetersPerSecond * seconds,
+        northMeters: vector.northMetersPerSecond * seconds,
+      );
+      elapsed = nextElapsed;
+      if (retainTrack || elapsed >= totalSeconds) {
+        output.add(
+          _routePoint(
+            position,
+            altitude,
+            startedAt.add(Duration(milliseconds: (elapsed * 1000).round())),
+            datum,
+          ),
+        );
+      }
+    }
+    return output;
+  }
+
+  static route.GeoPoint _routePoint(
+    live.GeoPoint point,
+    double altitudeMsl,
+    DateTime recordedAt,
+    AltitudeDatum sourceDatum,
+  ) => route.GeoPoint(
+    latitude: point.latitude,
+    longitude: point.longitude,
+    elevationMeters: altitudeMsl,
+    altitudeSource: AltitudeSource.unknown,
+    altitudeDatum: sourceDatum == AltitudeDatum.relativeToLaunch
+        ? AltitudeDatum.wgs84Geoid
+        : sourceDatum,
+    recordedAt: recordedAt,
+  );
+
+  static live.GeoPoint _move(
+    live.GeoPoint point, {
+    required double eastMeters,
+    required double northMeters,
+  }) {
+    final longitudeScale = math
+        .cos(point.latitude * math.pi / 180)
+        .abs()
+        .clamp(0.01, 1.0);
+    return live.GeoPoint(
+      latitude: (point.latitude + northMeters / 111320).clamp(-90, 90),
+      longitude: (point.longitude + eastMeters / (111320 * longitudeScale))
+          .clamp(-180, 180),
+    );
+  }
+
+  static List<route.GeoPoint> _convexHull(List<route.GeoPoint> points) {
+    final unique =
+        <String, route.GeoPoint>{
+          for (final point in points)
+            '${point.latitude.toStringAsFixed(7)}:'
+                    '${point.longitude.toStringAsFixed(7)}':
+                point,
+        }.values.toList()..sort((first, second) {
+          final byLongitude = first.longitude.compareTo(second.longitude);
+          return byLongitude != 0
+              ? byLongitude
+              : first.latitude.compareTo(second.latitude);
+        });
+    if (unique.length < 3) return const [];
+
+    double cross(route.GeoPoint a, route.GeoPoint b, route.GeoPoint c) =>
+        (b.longitude - a.longitude) * (c.latitude - a.latitude) -
+        (b.latitude - a.latitude) * (c.longitude - a.longitude);
+
+    final lower = <route.GeoPoint>[];
+    for (final point in unique) {
+      while (lower.length >= 2 &&
+          cross(lower[lower.length - 2], lower.last, point) <= 0) {
+        lower.removeLast();
+      }
+      lower.add(point);
+    }
+    final upper = <route.GeoPoint>[];
+    for (final point in unique.reversed) {
+      while (upper.length >= 2 &&
+          cross(upper[upper.length - 2], upper.last, point) <= 0) {
+        upper.removeLast();
+      }
+      upper.add(point);
+    }
+    final hull = [
+      ...lower.take(lower.length - 1),
+      ...upper.take(upper.length - 1),
+    ];
+    if (hull.length < 3) return const [];
+    return List.unmodifiable([...hull, hull.first]);
+  }
+}

--- a/apps/mobile/lib/services/open_meteo_wind.dart
+++ b/apps/mobile/lib/services/open_meteo_wind.dart
@@ -173,9 +173,9 @@ abstract interface class WindForecastProvider {
 /// Latest UK Met Office UKV wind forecast, delivered by Open-Meteo.
 ///
 /// This is forecast model output, not an airborne observation and not an
-/// aviation weather briefing. The request intentionally asks for a small 3×3
-/// grid and a short time window; slider changes reuse the vertical profile and
-/// never create another network request.
+/// aviation weather briefing. The request asks for the same 5×5, approximately
+/// 120 km field as the planner and a short time window; slider changes reuse
+/// the vertical profile and never create another network request.
 class OpenMeteoWindProvider implements WindForecastProvider {
   OpenMeteoWindProvider({
     required this.client,
@@ -305,10 +305,10 @@ class OpenMeteoWindProvider implements WindForecastProvider {
   }
 }
 
-/// Nine sample points covering roughly 9 × 9 km around [center].
+/// Twenty-five sample points covering roughly 120 × 120 km around [center].
 List<GeoPoint> windForecastGrid(GeoPoint center) => List.unmodifiable([
-  for (final latitudeOffset in const [-0.04, 0.0, 0.04])
-    for (final longitudeOffset in const [-0.06, 0.0, 0.06])
+  for (final latitudeOffset in const [-0.54, -0.27, 0.0, 0.27, 0.54])
+    for (final longitudeOffset in const [-0.85, -0.425, 0.0, 0.425, 0.85])
       GeoPoint(
         latitude: (center.latitude + latitudeOffset).clamp(-90, 90),
         longitude: (center.longitude + longitudeOffset).clamp(-180, 180),
@@ -322,18 +322,23 @@ class WindForecastController extends ChangeNotifier {
     WindForecastField? initialField,
     bool enabled = true,
     int selectedAltitudeMetersMsl = 500,
+    bool followBalloonAltitude = true,
+    this.recenterDistanceMeters = 25000,
   }) : _clock = clock ?? DateTime.now,
        _field = initialField,
        _selectedAltitudeMetersMsl = _nearestLevel(
          selectedAltitudeMetersMsl.toDouble(),
        ) {
     _enabled = enabled;
+    _followBalloonAltitude = followBalloonAltitude;
   }
 
   final WindForecastProvider _provider;
   final DateTime Function() _clock;
+  final double recenterDistanceMeters;
   WindForecastField? _field;
   bool _enabled = true;
+  bool _followBalloonAltitude = true;
   int _selectedAltitudeMetersMsl;
   bool _loading = false;
   String? _error;
@@ -343,6 +348,7 @@ class WindForecastController extends ChangeNotifier {
 
   WindForecastField? get field => _field;
   bool get enabled => _enabled;
+  bool get followBalloonAltitude => _followBalloonAltitude;
   bool get loading => _loading;
   String? get error => _error;
   int get selectedAltitudeMetersMsl => _selectedAltitudeMetersMsl;
@@ -354,7 +360,25 @@ class WindForecastController extends ChangeNotifier {
   }
 
   void setSelectedAltitude(double value) {
+    _followBalloonAltitude = false;
     final next = _nearestLevel(value);
+    if (next == _selectedAltitudeMetersMsl) {
+      notifyListeners();
+      return;
+    }
+    _selectedAltitudeMetersMsl = next;
+    notifyListeners();
+  }
+
+  void setFollowBalloonAltitude(bool value) {
+    if (_followBalloonAltitude == value) return;
+    _followBalloonAltitude = value;
+    notifyListeners();
+  }
+
+  void updateBalloonAltitude(double? altitudeMetersMsl) {
+    if (!_followBalloonAltitude || altitudeMetersMsl == null) return;
+    final next = _nearestLevel(altitudeMetersMsl);
     if (next == _selectedAltitudeMetersMsl) return;
     _selectedAltitudeMetersMsl = next;
     notifyListeners();
@@ -377,7 +401,8 @@ class WindForecastController extends ChangeNotifier {
         now.difference(field.fetchedAt).abs() < const Duration(minutes: 30);
     final nearby =
         lastCenter != null &&
-        GeoCalculations.distanceMeters(lastCenter, center) < 5000;
+        GeoCalculations.distanceMeters(lastCenter, center) <
+            recenterDistanceMeters;
     if (!force && fresh && nearby && field.isLiveForecast) return;
     final generation = ++_generation;
     _lastAttemptAt = now;

--- a/apps/mobile/lib/services/pilot_handover.dart
+++ b/apps/mobile/lib/services/pilot_handover.dart
@@ -1,0 +1,204 @@
+import '../domain/flight_role.dart';
+import '../domain/ride_event.dart';
+import '../domain/ride_role.dart';
+import 'ride_lifecycle.dart';
+
+class PilotHandoverOffer {
+  const PilotHandoverOffer({
+    required this.transferId,
+    required this.fromDeviceId,
+    required this.toDeviceId,
+    required this.offeredAt,
+    required this.expiresAt,
+  });
+
+  final String transferId;
+  final String fromDeviceId;
+  final String toDeviceId;
+  final DateTime offeredAt;
+  final DateTime expiresAt;
+}
+
+class PilotAuthorityState {
+  const PilotAuthorityState({
+    required this.pilotDeviceId,
+    required this.pendingOffers,
+    required this.hasAcceptedHandover,
+  });
+
+  final String? pilotDeviceId;
+  final List<PilotHandoverOffer> pendingOffers;
+  final bool hasAcceptedHandover;
+
+  PilotHandoverOffer? pendingFor(String deviceId) =>
+      pendingOffers.where((offer) => offer.toDeviceId == deviceId).lastOrNull;
+}
+
+/// Replays pilot authority without trusting a visible role label on its own.
+///
+/// A transfer is effective only when the current pilot offered it to a device
+/// already attached to the balloon and that same target device accepted before
+/// expiry. A partial, stale or out-of-order pair leaves authority unchanged.
+class PilotAuthorityReducer {
+  const PilotAuthorityReducer();
+
+  static const maximumClockSkew = Duration(minutes: 2);
+
+  PilotAuthorityState fromEvents({
+    required Iterable<RideEvent> events,
+    required DateTime now,
+  }) {
+    final ordered = events.toList(growable: false)
+      ..sort(RideLifecycleReducer.compareEvents);
+    final balloonCraftIds = <String>{};
+    final deviceCraft = <String, String>{};
+    // Craft assignment is journal state, not wall-clock authority. Build it
+    // before replaying offers so a harmless difference between two phones'
+    // clocks cannot make a valid handover disappear merely because the offer
+    // sorts just before the target's already-observed attachment event.
+    for (final event in ordered) {
+      switch (event.type) {
+        case RideEventType.craftRegistered:
+          final craftId = event.payload['craftId'];
+          if (craftId is String && event.payload['kind'] == 'balloon') {
+            balloonCraftIds.add(craftId);
+          }
+        case RideEventType.deviceAttachedToCraft:
+          final deviceId = event.payload['deviceId'];
+          final craftId = event.payload['craftId'];
+          if (deviceId is String && craftId is String) {
+            deviceCraft[deviceId] = craftId;
+          }
+        default:
+          break;
+      }
+    }
+    final offers = <String, PilotHandoverOffer>{};
+    final acceptances = <String, RideEvent>{};
+    String? pilotDeviceId;
+
+    for (final event in ordered) {
+      switch (event.type) {
+        case RideEventType.rideCreated:
+          final flightRole = flightRoleFromName(event.payload['flightRole']);
+          final legacyRole = rideRoleFromName(event.payload['role']);
+          if (pilotDeviceId == null &&
+              (flightRole == FlightRole.pilot || legacyRole == RideRole.lead)) {
+            pilotDeviceId = event.deviceId;
+          }
+        case RideEventType.craftRegistered:
+        case RideEventType.deviceAttachedToCraft:
+          break;
+        case RideEventType.pilotHandoverOffered:
+          final offer = _offer(event);
+          if (offer == null ||
+              event.deviceId != offer.fromDeviceId ||
+              !balloonCraftIds.contains(deviceCraft[offer.toDeviceId])) {
+            break;
+          }
+          offers[offer.transferId] = offer;
+        case RideEventType.pilotHandoverAccepted:
+          final transferId = event.payload['transferId'];
+          if (transferId is String) {
+            final existing = acceptances[transferId];
+            if (existing == null ||
+                RideLifecycleReducer.compareEvents(event, existing) < 0) {
+              acceptances[transferId] = event;
+            }
+          }
+        default:
+          break;
+      }
+    }
+
+    final applied = <String>{};
+    while (pilotDeviceId != null) {
+      final candidates =
+          offers.values
+              .where(
+                (offer) =>
+                    !applied.contains(offer.transferId) &&
+                    offer.fromDeviceId == pilotDeviceId &&
+                    _acceptanceMatches(acceptances[offer.transferId], offer),
+              )
+              .toList(growable: false)
+            ..sort((left, right) {
+              final leftAccepted = acceptances[left.transferId]!;
+              final rightAccepted = acceptances[right.transferId]!;
+              final byAcceptance = RideLifecycleReducer.compareEvents(
+                leftAccepted,
+                rightAccepted,
+              );
+              if (byAcceptance != 0) return byAcceptance;
+              return left.transferId.compareTo(right.transferId);
+            });
+      if (candidates.isEmpty) break;
+      final accepted = candidates.first;
+      applied.add(accepted.transferId);
+      pilotDeviceId = accepted.toDeviceId;
+    }
+
+    final pending =
+        offers.values
+            .where(
+              (offer) =>
+                  offer.fromDeviceId == pilotDeviceId &&
+                  !applied.contains(offer.transferId) &&
+                  offer.expiresAt.isAfter(now),
+            )
+            .toList(growable: false)
+          ..sort((left, right) {
+            final byTime = left.offeredAt.compareTo(right.offeredAt);
+            return byTime != 0
+                ? byTime
+                : left.transferId.compareTo(right.transferId);
+          });
+
+    return PilotAuthorityState(
+      pilotDeviceId: pilotDeviceId,
+      hasAcceptedHandover: applied.isNotEmpty,
+      pendingOffers: List.unmodifiable(pending),
+    );
+  }
+
+  static bool _acceptanceMatches(
+    RideEvent? acceptance,
+    PilotHandoverOffer offer,
+  ) {
+    if (acceptance == null ||
+        acceptance.payload['fromDeviceId'] != offer.fromDeviceId ||
+        acceptance.payload['toDeviceId'] != offer.toDeviceId ||
+        acceptance.deviceId != offer.toDeviceId ||
+        acceptance.createdAt.isAfter(offer.expiresAt)) {
+      return false;
+    }
+    return !acceptance.createdAt.isBefore(
+      offer.offeredAt.subtract(maximumClockSkew),
+    );
+  }
+
+  static PilotHandoverOffer? _offer(RideEvent event) {
+    final transferId = event.payload['transferId'];
+    final fromDeviceId = event.payload['fromDeviceId'];
+    final toDeviceId = event.payload['toDeviceId'];
+    final expiresAtValue = event.payload['expiresAt'];
+    final expiresAt = expiresAtValue is String
+        ? DateTime.tryParse(expiresAtValue)?.toUtc()
+        : event.expiresAt?.toUtc();
+    if (transferId is! String ||
+        transferId.isEmpty ||
+        fromDeviceId is! String ||
+        toDeviceId is! String ||
+        fromDeviceId == toDeviceId ||
+        expiresAt == null) {
+      return null;
+    }
+    return PilotHandoverOffer(
+      transferId: transferId,
+      fromDeviceId: fromDeviceId,
+      toDeviceId: toDeviceId,
+      offeredAt: event.createdAt,
+      expiresAt: expiresAt,
+    );
+  }
+}

--- a/apps/mobile/lib/services/relay_traffic_reroute_provider.dart
+++ b/apps/mobile/lib/services/relay_traffic_reroute_provider.dart
@@ -235,7 +235,7 @@ class RelayTrafficRerouteProvider {
       id: _idFactory(),
       name: '${original.name} · traffic alternative',
       description:
-          'Leader-reviewed TomTom traffic alternative calculated '
+          'Pilot-reviewed TomTom traffic alternative calculated '
           '${now.toIso8601String()}.',
       importedAt: now,
       sourceFileName: 'tail-end-charlie-traffic-${_idFactory()}.gpx',

--- a/apps/mobile/lib/services/ride_event_authenticator.dart
+++ b/apps/mobile/lib/services/ride_event_authenticator.dart
@@ -25,7 +25,7 @@ class RideEventAuthenticator {
   /// also releases its entry when the event is collected, so a removed ride
   /// leaves nothing behind.
   static final Expando<_Verdict> _verdicts = Expando<_Verdict>(
-    'ride event signature verdict',
+    'flight event signature verdict',
   );
 
   /// How many events have actually been authenticated, as opposed to answered

--- a/apps/mobile/lib/services/ride_lifecycle.dart
+++ b/apps/mobile/lib/services/ride_lifecycle.dart
@@ -74,6 +74,7 @@ class RideLifecycleReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.chaseGuidanceTargetSelected:
           break;
       }
     }

--- a/apps/mobile/lib/services/ride_lifecycle.dart
+++ b/apps/mobile/lib/services/ride_lifecycle.dart
@@ -75,6 +75,8 @@ class RideLifecycleReducer {
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
         case RideEventType.chaseGuidanceTargetSelected:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/services/ride_membership.dart
+++ b/apps/mobile/lib/services/ride_membership.dart
@@ -7,6 +7,7 @@ import '../features/map/craft_icon.dart';
 import '../relay/live_presence.dart';
 import 'ride_event_authenticator.dart';
 import 'ride_lifecycle.dart';
+import 'pilot_handover.dart';
 
 /// The membership lifecycle from #27, with #144's departure retention.
 ///
@@ -706,7 +707,31 @@ class RideMembershipReducer {
             if (byJoin != 0) return byJoin;
             return left.riderId.compareTo(right.riderId);
           });
-    return List.unmodifiable(_withOneLeader(result, leadClaimedAt));
+    final pilotAuthority = const PilotAuthorityReducer().fromEvents(
+      events: ordered,
+      now: now,
+    );
+    final pilotDeviceId = pilotAuthority.pilotDeviceId;
+    final authorityResolved =
+        !pilotAuthority.hasAcceptedHandover || pilotDeviceId == null
+        ? result
+        : [
+            for (final participant in result)
+              if (participant.riderId == pilotDeviceId)
+                participant.copyWith(
+                  role: RideRole.lead,
+                  flightRole: FlightRole.pilot,
+                )
+              else if (participant.role == RideRole.lead ||
+                  participant.flightRole == FlightRole.pilot)
+                participant.copyWith(
+                  role: RideRole.rider,
+                  flightRole: FlightRole.balloonCrew,
+                )
+              else
+                participant,
+          ];
+    return List.unmodifiable(_withOneLeader(authorityResolved, leadClaimedAt));
   }
 
   /// Leaves exactly one rider holding [RideRole.lead].

--- a/apps/mobile/lib/services/ride_membership.dart
+++ b/apps/mobile/lib/services/ride_membership.dart
@@ -295,7 +295,7 @@ class RideLiveView {
   RideLiveView._(this.participants, this.renderedPositions)
     : assert(
         participants.every((participant) => participant.hasStatedPositionState),
-        'A rider in the live count must have a position or a stated reason.',
+        'A crew member in the live count must have a position or a stated reason.',
       );
 
   /// Builds the reconciled view from the membership roster and the reconciled

--- a/apps/mobile/lib/services/ride_membership.dart
+++ b/apps/mobile/lib/services/ride_membership.dart
@@ -1,4 +1,5 @@
 import '../domain/ride_event.dart';
+import '../domain/flight_role.dart';
 import '../domain/ride_role.dart';
 import '../domain/rider_color.dart';
 import '../domain/rider_location.dart';
@@ -84,6 +85,7 @@ class RideParticipant {
     required this.riderId,
     required this.displayName,
     required this.role,
+    this.flightRole = FlightRole.observer,
     required this.joinedAt,
     required this.lastSeenAt,
     required this.state,
@@ -103,6 +105,7 @@ class RideParticipant {
   final String riderId;
   final String displayName;
   final RideRole role;
+  final FlightRole flightRole;
   final DateTime joinedAt;
   final DateTime lastSeenAt;
   final DateTime? leftAt;
@@ -241,6 +244,7 @@ class RideParticipant {
   RideParticipant copyWith({
     String? displayName,
     RideRole? role,
+    FlightRole? flightRole,
     DateTime? joinedAt,
     DateTime? lastSeenAt,
     DateTime? leftAt,
@@ -260,6 +264,7 @@ class RideParticipant {
     riderId: riderId,
     displayName: displayName ?? this.displayName,
     role: role ?? this.role,
+    flightRole: flightRole ?? this.flightRole,
     joinedAt: joinedAt ?? this.joinedAt,
     lastSeenAt: lastSeenAt ?? this.lastSeenAt,
     leftAt: clearLeftAt ? null : (leftAt ?? this.leftAt),
@@ -378,6 +383,7 @@ class RideMembershipReducer {
     required String localRiderId,
     required String localDisplayName,
     required RideRole localRole,
+    FlightRole localFlightRole = FlightRole.observer,
     required DateTime localJoinedAt,
     required CraftIconStyle localMotorcycleStyle,
     required RiderColor localRiderColor,
@@ -402,6 +408,7 @@ class RideMembershipReducer {
         riderId: localRiderId,
         displayName: localDisplayName,
         role: localRole,
+        flightRole: localFlightRole,
         joinedAt: localJoinedAt,
         lastSeenAt: localJoinedAt,
         state: RideMembershipState.joined,
@@ -434,6 +441,7 @@ class RideMembershipReducer {
         final displayName = _nonEmptyString(event.payload['displayName']);
         final role = _role(event.payload['role']);
         if (displayName == null || role == null) continue;
+        final flightRole = flightRoleFromName(event.payload['flightRole']);
         final isLocal = event.deviceId == localRiderId;
         final joiningRole = isLocal ? localRole : role;
         if (joiningRole == RideRole.lead) {
@@ -443,6 +451,7 @@ class RideMembershipReducer {
           riderId: event.deviceId,
           displayName: isLocal ? localDisplayName : displayName,
           role: joiningRole,
+          flightRole: isLocal ? localFlightRole : flightRole,
           joinedAt: event.createdAt,
           lastSeenAt: event.createdAt,
           state: RideMembershipState.joined,
@@ -524,11 +533,16 @@ class RideMembershipReducer {
       if (event.type == RideEventType.roleChanged) {
         final role = _role(event.payload['role']);
         if (role == null) continue;
+        final flightRole = flightRoleFromName(
+          event.payload['flightRole'],
+          fallback: existing.flightRole,
+        );
         if (role == RideRole.lead) {
           leadClaimedAt[event.deviceId] = event.createdAt;
         }
         participants[event.deviceId] = existing.copyWith(
           role: existing.isLocal ? localRole : role,
+          flightRole: existing.isLocal ? localFlightRole : flightRole,
           lastSeenAt: event.createdAt,
           transportEvidence: Set.unmodifiable(evidence),
         );

--- a/apps/mobile/lib/services/ride_route_reducer.dart
+++ b/apps/mobile/lib/services/ride_route_reducer.dart
@@ -161,6 +161,7 @@ class RideRouteReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.chaseGuidanceTargetSelected:
           break;
       }
     }

--- a/apps/mobile/lib/services/ride_route_reducer.dart
+++ b/apps/mobile/lib/services/ride_route_reducer.dart
@@ -162,6 +162,8 @@ class RideRouteReducer {
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
         case RideEventType.chaseGuidanceTargetSelected:
+        case RideEventType.pilotHandoverOffered:
+        case RideEventType.pilotHandoverAccepted:
           break;
       }
     }

--- a/apps/mobile/lib/services/ride_summary_exporter.dart
+++ b/apps/mobile/lib/services/ride_summary_exporter.dart
@@ -181,15 +181,15 @@ class RideSummaryExporter {
 
   String toCsv(RideSummary summary) {
     final rows = <List<Object?>>[
-      ['ride_code', summary.rideCode],
-      ['ride_id', summary.rideId],
-      ['rider', summary.displayName],
+      ['flight_code', summary.rideCode],
+      ['flight_id', summary.rideId],
+      ['crew_member', summary.displayName],
       ['started_at_utc', summary.startedAt.toUtc().toIso8601String()],
       ['ended_at_utc', summary.endedAt?.toUtc().toIso8601String()],
       ['generated_at_utc', summary.generatedAt.toUtc().toIso8601String()],
-      ['ride_duration_seconds', summary.rideDuration.inSeconds],
+      ['flight_duration_seconds', summary.rideDuration.inSeconds],
       ['event_count', summary.eventCount],
-      ['rider_count', summary.riderCount],
+      ['crew_count', summary.riderCount],
       ['distance_meters', summary.totalDistanceMeters.round()],
     ];
     return '${rows.map(_csvRow).join('\r\n')}\r\n';

--- a/apps/mobile/lib/services/rider_trail_recorder.dart
+++ b/apps/mobile/lib/services/rider_trail_recorder.dart
@@ -20,6 +20,10 @@ enum RiderTrailKind {
   /// underneath a road route or be mistaken for a chase vehicle's path.
   balloonGroundTrack,
 
+  /// The pilot-published future aircraft path. Unlike the ground track this is
+  /// forecast geometry, so it is dashed; altitude samples still colour it.
+  forecastTrack,
+
   /// Pilot-authored advisory geometry. It is shared with the crew but is not a
   /// travelled trail and therefore never receives direction arrows.
   operationalBoundary,

--- a/apps/mobile/lib/services/rider_trail_recorder.dart
+++ b/apps/mobile/lib/services/rider_trail_recorder.dart
@@ -28,6 +28,11 @@ enum RiderTrailKind {
   /// travelled trail and therefore never receives direction arrows.
   operationalBoundary,
 
+  /// The immutable set of feasible endpoints retained from the imported web
+  /// planner forecast. It is evidence from planning time, not pilot intent and
+  /// not a claim that any point inside it is suitable for landing.
+  originalLandingEnvelope,
+
   /// The road route from where the rider is to the start of the planned route
   /// (#133). The one kind that is not recorded history: it is where the routing
   /// engine says to go next, which is why it is never produced by

--- a/apps/mobile/lib/services/rider_trail_recorder.dart
+++ b/apps/mobile/lib/services/rider_trail_recorder.dart
@@ -33,6 +33,14 @@ enum RiderTrailKind {
   /// not a claim that any point inside it is suitable for landing.
   originalLandingEnvelope,
 
+  /// Recalculated from the latest usable balloon fix and a fresh forecast wind
+  /// field. It is advisory future geometry, never measured track history.
+  liveProjectionTrack,
+
+  /// Feasible forecast endpoints recalculated from the latest usable balloon
+  /// state. Separate from both pilot intent and the original plan envelope.
+  liveLandingEnvelope,
+
   /// The road route from where the rider is to the start of the planned route
   /// (#133). The one kind that is not recorded history: it is where the routing
   /// engine says to go next, which is why it is never produced by

--- a/apps/mobile/lib/services/route_geometry_enricher.dart
+++ b/apps/mobile/lib/services/route_geometry_enricher.dart
@@ -99,6 +99,7 @@ class RouteGeometryEnricher {
         id: route.id,
         name: route.name,
         description: route.description,
+        purpose: route.purpose,
         importedAt: route.importedAt,
         sourceFileName: route.sourceFileName,
         paths: List.unmodifiable(paths),

--- a/apps/mobile/lib/services/stored_route_library.dart
+++ b/apps/mobile/lib/services/stored_route_library.dart
@@ -61,7 +61,13 @@ class StoredRouteCandidate {
 
   /// True when this is a recording rather than a plan, and therefore when the
   /// tidied/raw choice applies.
-  bool get isRecording => origin != StoredRouteOrigin.previousRidePlan;
+  bool get isRecording =>
+      origin != StoredRouteOrigin.previousRidePlan &&
+      !geometry.isBalloonForecast;
+
+  /// A wind forecast is time-directional. Reversing its geometry would invent
+  /// a flight that the forecast never described.
+  bool get canReverse => !geometry.isBalloonForecast;
 
   int get pointCount => geometry.pathPointCount;
 
@@ -203,6 +209,9 @@ class StoredRouteLibrary {
   /// Builds the selection into a route, and states plainly what it is.
   PreparedStoredRoute prepare(StoredRouteSelection selection) {
     final candidate = selection.candidate;
+    if (selection.reversed && !candidate.canReverse) {
+      throw const FormatException('A forecast flight plan cannot be reversed.');
+    }
     final tidying =
         candidate.isRecording && selection.variant == StoredRouteVariant.tidied;
     var paths = candidate.geometry.paths;
@@ -246,7 +255,10 @@ class StoredRouteLibrary {
         name: selection.reversed
             ? '${candidate.title} (reversed)'
             : candidate.title,
-        description: _description(candidate),
+        description: candidate.geometry.isBalloonForecast
+            ? candidate.geometry.description
+            : _description(candidate),
+        purpose: candidate.geometry.purpose,
         importedAt: _clock(),
         sourceFileName: _sourceLabel(candidate),
         paths: List.unmodifiable(paths),
@@ -296,11 +308,14 @@ class StoredRouteLibrary {
     required bool reversed,
   }) => [
     switch (candidate.origin) {
+      _ when candidate.geometry.isBalloonForecast =>
+        'This is an advisory balloon forecast, not a controllable route or a '
+            'recording of where the balloon travelled.',
       StoredRouteOrigin.previousRidePlan =>
         'This is the route that flight was planned with, not a recording of it.',
       _ when tidied =>
         'This is a tidied recording, not a planned route. Stops and GPS '
-            'wander were removed. Every road the bike actually took is kept, '
+            'wander were removed. Every road the vehicle actually took is kept, '
             'including any wrong turns and car park loops.',
       _ =>
         'This is the raw recorded track: every fix as it was recorded, '

--- a/apps/mobile/test/app/ride_invitation_link_gate_test.dart
+++ b/apps/mobile/test/app/ride_invitation_link_gate_test.dart
@@ -8,6 +8,8 @@ import 'package:balloon_crumbs/controllers/ride_invitation_link_controller.dart'
 import 'package:balloon_crumbs/controllers/rider_profile_controller.dart';
 import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
+import 'package:balloon_crumbs/domain/craft.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
 import 'package:balloon_crumbs/internet/internet_relay_client.dart';
 import 'package:balloon_crumbs/services/nearby_bridge.dart';
@@ -50,9 +52,34 @@ void main() {
       expect(directory.seenToken, token);
       expect(fixture.rideController.session?.rideCode, '123456');
       expect(fixture.rideController.session?.inviteSecret, directory.secret);
+      expect(fixture.rideController.session?.flightRole, FlightRole.chaseCrew);
+      expect(fixture.rideController.localCraft?.craft.kind, CraftKind.vehicle);
       expect(fixture.links.hasNotice, isFalse);
     },
   );
+
+  testWidgets('a link join explicitly assigns balloon crew to the balloon', (
+    tester,
+  ) async {
+    const token = 'Abcdefghijklmnop12345678';
+    final fixture = await _Fixture.create(
+      directory: _Directory(expectedCode: '123456', expectedToken: token),
+      link: rideInvitationUrl('123456', token),
+    );
+    addTearDown(fixture.dispose);
+
+    await tester.pumpWidget(fixture.app);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('invitation-role-balloonCrew')));
+    await tester.pump();
+    expect(find.byKey(const Key('invitation-vehicle-label')), findsNothing);
+    await tester.tap(find.byKey(const Key('accept-ride-invitation-link')));
+    await tester.pumpAndSettle();
+
+    expect(fixture.rideController.session?.flightRole, FlightRole.balloonCrew);
+    expect(fixture.rideController.localCraft?.craft.kind, CraftKind.balloon);
+    expect(fixture.rideController.hasFlightAuthority, isFalse);
+  });
 
   testWidgets('an invitation cannot silently replace an active ride', (
     tester,

--- a/apps/mobile/test/controllers/ride_controller_craft_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_craft_test.dart
@@ -10,6 +10,7 @@ import 'package:balloon_crumbs/domain/ride_join_payload.dart';
 import 'package:balloon_crumbs/domain/ride_role.dart';
 import 'package:balloon_crumbs/internet/internet_relay_client.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/services/chase_guidance_target.dart';
 import 'package:balloon_crumbs/services/nearby_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -264,6 +265,28 @@ void main() {
         isFalse,
       );
     });
+  });
+
+  test('a chaser records a target choice against their vehicle', () async {
+    final driver = await joinedAs(FlightRole.chaseDriver);
+
+    expect(
+      await driver.setLocalChaseGuidanceTarget(ChaseGuidanceTarget.landingArea),
+      isTrue,
+    );
+    expect(
+      driver.localChaseGuidanceSelection?.target,
+      ChaseGuidanceTarget.landingArea,
+    );
+    expect(driver.events.last.type, RideEventType.chaseGuidanceTargetSelected);
+    expect(driver.events.last.payload['craftId'], driver.localCraftId);
+  });
+
+  test('a balloon device cannot set chase guidance', () async {
+    expect(
+      await controller.setLocalChaseGuidanceTarget(ChaseGuidanceTarget.balloon),
+      isFalse,
+    );
   });
 
   test('the roster survives a journal replay', () async {

--- a/apps/mobile/test/controllers/ride_controller_craft_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_craft_test.dart
@@ -5,7 +5,9 @@ import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/craft.dart';
 import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
 import 'package:balloon_crumbs/domain/ride_join_payload.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
 import 'package:balloon_crumbs/internet/internet_relay_client.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
 import 'package:balloon_crumbs/services/nearby_bridge.dart';
@@ -283,6 +285,91 @@ void main() {
     expect(second.crafts.map((c) => c.id), first.crafts.map((c) => c.id));
     expect(second.byId('v1')!.craft.chasing, controller.localCraftId);
     expect(second.balloon!.crewCount, 1);
+  });
+
+  group('legacy assignment repair', () {
+    Future<({RideController controller, InMemoryEventStore events})>
+    restoreLegacy(RideRole legacyRole) async {
+      final sessions = InMemorySessionStore();
+      final events = InMemoryEventStore();
+      final persisted =
+          RideSession(
+              rideId: 'legacy-flight',
+              rideCode: '123456',
+              inviteSecret: 'legacy-secret-with-enough-entropy',
+              joinToken: 'legacy-token-with-enough-entropy',
+              localRiderId: 'legacy-device',
+              displayName: 'Alex',
+              role: legacyRole,
+              joinedAt: DateTime.utc(2026, 8, 1),
+            ).toJson()
+            ..remove('flightRole')
+            ..remove('localCraftId');
+      await sessions.save(RideSession.fromJson(persisted));
+      var eventId = 0;
+      final restored = RideController(
+        events,
+        sessions,
+        const _FakeNearbyBridge(),
+        clock: () => DateTime.utc(2026, 8, 23, 9),
+        idFactory: () => 'repair-${eventId++}',
+        rideCodeDirectory: _InMemoryRideCodeDirectory(),
+      );
+      addTearDown(restored.dispose);
+      await restored.initialize();
+      return (controller: restored, events: events);
+    }
+
+    test('the legacy creator explicitly restores pilot and balloon', () async {
+      final fixture = await restoreLegacy(RideRole.lead);
+      expect(fixture.controller.hasFlightAuthority, isFalse);
+      expect(fixture.controller.session!.requiresFlightAssignment, isTrue);
+
+      await fixture.controller.repairFlightAssignment(role: FlightRole.pilot);
+
+      expect(fixture.controller.errorMessage, isNull);
+      expect(fixture.controller.localFlightRole, FlightRole.pilot);
+      expect(fixture.controller.hasFlightAuthority, isTrue);
+      expect(fixture.controller.session!.requiresFlightAssignment, isFalse);
+      expect(fixture.controller.localCraft?.craft.kind, CraftKind.balloon);
+      expect(fixture.controller.localCraft?.primaryDeviceId, 'legacy-device');
+      final recorded = await fixture.events.eventsForRide('legacy-flight');
+      expect(
+        recorded.map((event) => event.type),
+        containsAll(<RideEventType>[
+          RideEventType.roleChanged,
+          RideEventType.craftRegistered,
+          RideEventType.deviceAttachedToCraft,
+          RideEventType.craftPrimaryDeviceNominated,
+        ]),
+      );
+    });
+
+    test('a legacy participant repairs into a named chase vehicle', () async {
+      final fixture = await restoreLegacy(RideRole.rider);
+
+      await fixture.controller.repairFlightAssignment(
+        role: FlightRole.chaseDriver,
+        vehicleLabel: '  Land   Rover  ',
+      );
+
+      expect(fixture.controller.errorMessage, isNull);
+      expect(fixture.controller.localFlightRole, FlightRole.chaseDriver);
+      expect(fixture.controller.hasFlightAuthority, isFalse);
+      expect(fixture.controller.localCraft?.craft.kind, CraftKind.vehicle);
+      expect(fixture.controller.localCraft?.craft.label, 'Land Rover');
+    });
+
+    test('a legacy participant cannot claim pilot authority', () async {
+      final fixture = await restoreLegacy(RideRole.rider);
+
+      await fixture.controller.repairFlightAssignment(role: FlightRole.pilot);
+
+      expect(fixture.controller.errorMessage, isNotNull);
+      expect(fixture.controller.localFlightRole, FlightRole.observer);
+      expect(fixture.controller.session!.requiresFlightAssignment, isTrue);
+      expect(fixture.controller.hasFlightAuthority, isFalse);
+    });
   });
 }
 

--- a/apps/mobile/test/controllers/ride_controller_craft_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_craft_test.dart
@@ -4,7 +4,8 @@ import 'package:balloon_crumbs/controllers/ride_controller.dart';
 import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/craft.dart';
-import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/ride_join_payload.dart';
 import 'package:balloon_crumbs/internet/internet_relay_client.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
 import 'package:balloon_crumbs/services/nearby_bridge.dart';
@@ -33,29 +34,54 @@ void main() {
 
   tearDown(() => controller.dispose());
 
-  test('a flight starts with no crafts until one is registered', () {
-    expect(controller.resolveCraftRoster().crafts, isEmpty);
-    expect(controller.resolveCraftRoster().balloon, isNull);
-    expect(controller.localCraft, isNull);
+  Future<RideController> joinedAs(
+    FlightRole role, {
+    String vehicleLabel = 'Land Rover',
+  }) async {
+    final flight = controller.session!;
+    final joined = RideController(
+      InMemoryEventStore(),
+      InMemorySessionStore(),
+      const _FakeNearbyBridge(),
+      clock: () => DateTime.utc(2026, 8, 17, 10, 1),
+      idFactory: () => 'joined-${(id++).toString().padLeft(3, '0')}',
+      random: Random(84),
+      rideCodeDirectory: _InMemoryRideCodeDirectory(),
+    );
+    addTearDown(joined.dispose);
+    await joined.initialize();
+    await joined.joinRideFromInvitation(
+      RideJoinPayload(
+        rideId: flight.rideId,
+        rideCode: flight.rideCode,
+        inviteSecret: flight.inviteSecret,
+        joinToken: flight.joinToken,
+      ),
+      'Alex',
+      flightRole: role,
+      vehicleLabel: vehicleLabel,
+    );
+    return joined;
+  }
+
+  test('a new flight registers and attaches its balloon atomically', () {
+    final roster = controller.resolveCraftRoster();
+    expect(roster.balloons, hasLength(1));
+    expect(roster.balloon?.id, controller.localCraftId);
+    expect(controller.localCraft?.id, controller.localCraftId);
+    expect(controller.localCraft?.crewCount, 1);
   });
 
   test(
     'the pilot registers the balloon and attaches this device to it',
     () async {
-      expect(
-        await controller.registerCraft(
-          craftId: 'balloon',
-          kind: CraftKind.balloon,
-          label: 'Balloon',
-        ),
-        isTrue,
-      );
-      expect(await controller.attachLocalDeviceToCraft('balloon'), isTrue);
+      final balloonId = controller.localCraftId!;
+      expect(controller.localCraft?.id, balloonId);
 
       final roster = controller.resolveCraftRoster();
       expect(roster.balloons, hasLength(1));
       expect(roster.balloon!.craft.label, 'Balloon');
-      expect(controller.localCraft?.id, 'balloon');
+      expect(controller.localCraft?.id, balloonId);
       // No fix has been reported yet, and the roster says which kind of nothing
       // that is rather than inventing a position.
       expect(roster.balloon!.fix.hasFix, isFalse);
@@ -67,13 +93,14 @@ void main() {
     () async {
       // Two devices can race to introduce the balloon. They must converge, not
       // put two aircraft on the map.
+      final balloonId = controller.localCraftId!;
       await controller.registerCraft(
-        craftId: 'balloon',
+        craftId: balloonId,
         kind: CraftKind.balloon,
         label: 'Balloon',
       );
       await controller.registerCraft(
-        craftId: 'balloon',
+        craftId: balloonId,
         kind: CraftKind.balloon,
         label: 'G-ABCD',
       );
@@ -88,18 +115,12 @@ void main() {
     'moving a device between crafts is one event, not a leave and a join',
     () async {
       await controller.registerCraft(
-        craftId: 'balloon',
-        kind: CraftKind.balloon,
-        label: 'Balloon',
-      );
-      await controller.registerCraft(
         craftId: 'v1',
         kind: CraftKind.vehicle,
         label: 'Land Rover',
       );
 
-      await controller.attachLocalDeviceToCraft('balloon');
-      expect(controller.localCraft?.id, 'balloon');
+      expect(controller.localCraft?.id, controller.localCraftId);
 
       await controller.attachLocalDeviceToCraft('v1');
       expect(controller.localCraft?.id, 'v1');
@@ -118,53 +139,46 @@ void main() {
 
   group('authority', () {
     test('a non-pilot cannot introduce the balloon', () async {
-      // The creator holds authority in this session, so drop it to prove the
-      // gate rather than asserting it from the happy path.
-      await controller.setRole(RideRole.rider);
-      expect(controller.hasFlightAuthority, isFalse);
+      final crew = await joinedAs(FlightRole.balloonCrew);
+      expect(crew.hasFlightAuthority, isFalse);
 
       expect(
-        await controller.registerCraft(
-          craftId: 'balloon',
+        await crew.registerCraft(
+          craftId: 'another-balloon',
           kind: CraftKind.balloon,
           label: 'Balloon',
         ),
         isFalse,
       );
-      expect(controller.resolveCraftRoster().balloons, isEmpty);
+      expect(crew.resolveCraftRoster().balloons, hasLength(1));
     });
 
     test(
       'a chase vehicle can register itself without the pilot acting',
       () async {
-        await controller.setRole(RideRole.rider);
+        final crew = await joinedAs(FlightRole.chaseCrew);
 
         // A crew joining mid-flight must not need the pilot to press something
         // while they are flying.
         expect(
-          await controller.registerCraft(
+          await crew.registerCraft(
             craftId: 'v2',
             kind: CraftKind.vehicle,
             label: 'Vehicle 2',
           ),
           isTrue,
         );
-        expect(controller.resolveCraftRoster().vehicles, hasLength(1));
+        expect(crew.resolveCraftRoster().byId('v2'), isNotNull);
       },
     );
 
     test('only the pilot nominates a craft reporting device', () async {
-      await controller.registerCraft(
-        craftId: 'balloon',
-        kind: CraftKind.balloon,
-        label: 'Balloon',
-      );
-      await controller.attachLocalDeviceToCraft('balloon');
+      final balloonId = controller.localCraftId!;
       final deviceId = controller.session!.localRiderId;
 
       expect(
         await controller.nominateCraftPrimaryDevice(
-          craftId: 'balloon',
+          craftId: balloonId,
           deviceId: deviceId,
         ),
         isTrue,
@@ -174,28 +188,22 @@ void main() {
         deviceId,
       );
 
-      await controller.setRole(RideRole.rider);
+      final crew = await joinedAs(FlightRole.balloonCrew);
       expect(
-        await controller.nominateCraftPrimaryDevice(
-          craftId: 'balloon',
-          deviceId: deviceId,
+        await crew.nominateCraftPrimaryDevice(
+          craftId: crew.localCraftId!,
+          deviceId: crew.session!.localRiderId,
         ),
         isFalse,
       );
     });
 
     test('nominating a device that is not aboard is refused', () async {
-      await controller.registerCraft(
-        craftId: 'balloon',
-        kind: CraftKind.balloon,
-        label: 'Balloon',
-      );
-
       // Writing it would silently do nothing at election time, which is worse
       // than saying no.
       expect(
         await controller.nominateCraftPrimaryDevice(
-          craftId: 'balloon',
+          craftId: controller.localCraftId!,
           deviceId: 'someone-elses-phone',
         ),
         isFalse,
@@ -205,11 +213,6 @@ void main() {
 
   group('chase assignment', () {
     setUp(() async {
-      await controller.registerCraft(
-        craftId: 'balloon',
-        kind: CraftKind.balloon,
-        label: 'Balloon',
-      );
       await controller.registerCraft(
         craftId: 'v1',
         kind: CraftKind.vehicle,
@@ -221,13 +224,13 @@ void main() {
       expect(
         await controller.assignChase(
           vehicleCraftId: 'v1',
-          targetCraftId: 'balloon',
+          targetCraftId: controller.localCraftId,
         ),
         isTrue,
       );
       expect(
         controller.resolveCraftRoster().byId('v1')!.craft.chasing,
-        'balloon',
+        controller.localCraftId,
       );
 
       expect(
@@ -240,7 +243,7 @@ void main() {
     test('a balloon cannot be given something to chase', () async {
       expect(
         await controller.assignChase(
-          vehicleCraftId: 'balloon',
+          vehicleCraftId: controller.localCraftId!,
           targetCraftId: 'v1',
         ),
         isFalse,
@@ -263,19 +266,13 @@ void main() {
 
   test('the roster survives a journal replay', () async {
     await controller.registerCraft(
-      craftId: 'balloon',
-      kind: CraftKind.balloon,
-      label: 'Balloon',
-    );
-    await controller.registerCraft(
       craftId: 'v1',
       kind: CraftKind.vehicle,
       label: 'Land Rover',
     );
-    await controller.attachLocalDeviceToCraft('balloon');
     await controller.assignChase(
       vehicleCraftId: 'v1',
-      targetCraftId: 'balloon',
+      targetCraftId: controller.localCraftId,
     );
 
     // The same events reduced twice must give the same answer: this is what a
@@ -284,7 +281,7 @@ void main() {
     final second = controller.resolveCraftRoster();
 
     expect(second.crafts.map((c) => c.id), first.crafts.map((c) => c.id));
-    expect(second.byId('v1')!.craft.chasing, 'balloon');
+    expect(second.byId('v1')!.craft.chasing, controller.localCraftId);
     expect(second.balloon!.crewCount, 1);
   });
 }

--- a/apps/mobile/test/controllers/ride_controller_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_test.dart
@@ -107,6 +107,54 @@ void main() {
     },
   );
 
+  test(
+    'pilot handover is offered, accepted and applied on both devices',
+    () async {
+      await controller.createRide('Oliver');
+      final crew = await joinedController(FlightRole.balloonCrew);
+
+      for (final event in crew.events) {
+        controller.ingestStoredEvent(event);
+      }
+      for (final event in controller.events) {
+        crew.ingestStoredEvent(event);
+      }
+
+      await controller.offerPilotHandover(crew.session!.localRiderId);
+      expect(controller.errorMessage, isNull);
+      final offer = controller.events.singleWhere(
+        (event) => event.type == RideEventType.pilotHandoverOffered,
+      );
+      expect(offer.expiresAt, isNull, reason: 'the accepted pair must replay');
+      expect(
+        DateTime.parse(offer.payload['expiresAt']! as String),
+        DateTime.utc(2026, 7, 16, 12, 10),
+      );
+      expect(controller.hasFlightAuthority, isTrue);
+
+      expect(crew.ingestStoredEvent(offer), isTrue);
+      expect(crew.pendingLocalPilotHandover, isNotNull);
+      expect(crew.hasFlightAuthority, isFalse);
+
+      await crew.acceptPilotHandover();
+      expect(crew.errorMessage, isNull);
+      expect(crew.session?.flightRole, FlightRole.pilot);
+      expect(crew.session?.role, RideRole.lead);
+      expect(crew.hasFlightAuthority, isTrue);
+      final acceptance = crew.events.last;
+      expect(acceptance.type, RideEventType.pilotHandoverAccepted);
+
+      expect(controller.ingestStoredEvent(acceptance), isTrue);
+      expect(controller.session?.flightRole, FlightRole.balloonCrew);
+      expect(controller.session?.role, RideRole.rider);
+      expect(controller.hasFlightAuthority, isFalse);
+      expect(
+        controller.participantFor(crew.session!.localRiderId)?.flightRole,
+        FlightRole.pilot,
+      );
+    },
+  );
+
   test('ride coordination mode is persisted and published', () async {
     await controller.createRide(
       'Oliver',

--- a/apps/mobile/test/controllers/ride_controller_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/quick_message.dart';
 import 'package:balloon_crumbs/domain/completed_ride_store.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart' as route_domain;
 import 'package:balloon_crumbs/domain/ride_event.dart';
 import 'package:balloon_crumbs/domain/ride_coordination_mode.dart';
@@ -52,20 +53,59 @@ void main() {
 
   tearDown(() => controller.dispose());
 
-  test('new ride is persisted with lead role and a signed event', () async {
-    await controller.createRide('Oliver');
+  Future<RideController> joinedController(FlightRole role) async {
+    await controller.publishRideCode();
+    final joined = RideController(
+      InMemoryEventStore(),
+      InMemorySessionStore(),
+      const _FakeNearbyBridge(),
+      clock: () => DateTime.utc(2026, 7, 16, 12, 1),
+      idFactory: () => 'joined-${(id++).toString().padLeft(3, '0')}',
+      random: Random(84),
+      rideCodeDirectory: rideCodes,
+    );
+    addTearDown(joined.dispose);
+    await joined.initialize();
+    await joined.joinRide(
+      controller.session!.rideCode,
+      'Alex',
+      flightRole: role,
+    );
+    return joined;
+  }
 
-    expect(controller.session?.role, RideRole.lead);
-    expect(controller.session?.displayName, 'Oliver');
-    expect(controller.session?.rideCode, matches(RegExp(r'^\d{6}$')));
-    expect(controller.events, hasLength(1));
-    expect(controller.events.single.type, RideEventType.rideCreated);
-    expect(controller.events.single.signature, hasLength(64));
-    expect(controller.rideStarted, isFalse);
+  test(
+    'new flight persists pilot role and atomic balloon assignment',
+    () async {
+      await controller.createRide('Oliver');
 
-    final restored = await sessionStore.load();
-    expect(restored?.rideId, controller.session?.rideId);
-  });
+      expect(controller.session?.role, RideRole.lead);
+      expect(controller.session?.flightRole, FlightRole.pilot);
+      expect(controller.hasFlightAuthority, isTrue);
+      expect(controller.session?.displayName, 'Oliver');
+      expect(controller.session?.rideCode, matches(RegExp(r'^\d{6}$')));
+      expect(controller.events, hasLength(4));
+      expect(controller.events.first.type, RideEventType.rideCreated);
+      expect(
+        controller.events.map((event) => event.type),
+        containsAllInOrder([
+          RideEventType.rideCreated,
+          RideEventType.craftRegistered,
+          RideEventType.deviceAttachedToCraft,
+          RideEventType.craftPrimaryDeviceNominated,
+        ]),
+      );
+      expect(
+        controller.events.every((event) => event.signature.length == 64),
+        isTrue,
+      );
+      expect(controller.localCraft?.isBalloon, isTrue);
+      expect(controller.rideStarted, isFalse);
+
+      final restored = await sessionStore.load();
+      expect(restored?.rideId, controller.session?.rideId);
+    },
+  );
 
   test('ride coordination mode is persisted and published', () async {
     await controller.createRide(
@@ -79,7 +119,9 @@ void main() {
     );
     expect(controller.coordinationMode, RideCoordinationMode.keepTogether);
     expect(
-      controller.events.single.payload['coordinationMode'],
+      controller.events
+          .singleWhere((event) => event.type == RideEventType.rideCreated)
+          .payload['coordinationMode'],
       RideCoordinationMode.keepTogether.name,
     );
   });
@@ -237,7 +279,7 @@ void main() {
 
   test('a non-leader cannot publish or clear the group route', () async {
     await controller.createRide('Oliver');
-    await controller.setRole(RideRole.rider);
+    final follower = await joinedController(FlightRole.chaseCrew);
     final route = route_domain.ImportedRoute(
       id: 'route-a',
       name: 'Wrong route',
@@ -252,28 +294,26 @@ void main() {
       waypoints: const [],
     );
 
-    await controller.publishRoute(route);
-    expect(controller.authoritativeRoute, isNull);
-    expect(controller.errorMessage, contains('Only the coordinator'));
+    await follower.publishRoute(route);
+    expect(follower.authoritativeRoute, isNull);
+    expect(follower.errorMessage, contains('Only the pilot'));
 
-    controller.clearError();
-    await controller.clearRoute();
-    expect(controller.authoritativeRouteState.hasDecision, isFalse);
-    expect(controller.errorMessage, contains('Only the coordinator'));
+    follower.clearError();
+    await follower.clearRoute();
+    expect(follower.authoritativeRouteState.hasDecision, isFalse);
+    expect(follower.errorMessage, contains('Only the pilot'));
   });
 
   test('a non-leader cannot start the ride', () async {
     await controller.createRide('Oliver');
-    await controller.setRole(RideRole.rider);
+    final follower = await joinedController(FlightRole.balloonCrew);
 
-    await controller.startRide();
+    await follower.startRide();
 
-    expect(controller.rideStarted, isFalse);
-    expect(controller.errorMessage, contains('Only the coordinator'));
+    expect(follower.rideStarted, isFalse);
+    expect(follower.errorMessage, contains('Only the pilot'));
     expect(
-      controller.events.where(
-        (event) => event.type == RideEventType.rideStarted,
-      ),
+      follower.events.where((event) => event.type == RideEventType.rideStarted),
       isEmpty,
     );
   });
@@ -348,7 +388,7 @@ void main() {
     expect(controller.session?.simulationRiderCount, 30);
     expect(controller.session?.displayName, 'Demo Lead');
     expect(controller.events.first.payload['simulation'], isTrue);
-    expect(controller.events, hasLength(1));
+    expect(controller.events, hasLength(4));
     expect(controller.rideStarted, isFalse);
 
     await controller.startRide();
@@ -382,7 +422,7 @@ void main() {
       InMemorySessionStore(),
       const _FakeNearbyBridge(),
       clock: () => DateTime.utc(2026, 7, 16, 12),
-      idFactory: () => 'follower-id',
+      idFactory: () => 'follower-${id++}',
       random: Random(7),
       rideCodeDirectory: rideCodes,
     );
@@ -404,7 +444,7 @@ void main() {
       InMemorySessionStore(),
       const _FakeNearbyBridge(),
       clock: () => DateTime.utc(2026, 7, 16, 12),
-      idFactory: () => 'follower-id',
+      idFactory: () => 'follower-${id++}',
       random: Random(7),
       rideCodeDirectory: rideCodes,
     );
@@ -415,10 +455,12 @@ void main() {
     expect(follower.session?.rideCode, leaderSession.rideCode);
     expect(follower.session?.inviteSecret, leaderSession.inviteSecret);
     expect(follower.session?.role, RideRole.rider);
+    expect(follower.session?.flightRole, FlightRole.chaseCrew);
+    expect(follower.localCraft?.isBalloon, isFalse);
     expect(
-      SituationEventFactory.verify(
-        follower.events.single,
-        leaderSession.inviteSecret,
+      follower.events.every(
+        (event) =>
+            SituationEventFactory.verify(event, leaderSession.inviteSecret),
       ),
       isTrue,
     );
@@ -437,7 +479,7 @@ void main() {
         InMemorySessionStore(),
         const _FakeNearbyBridge(),
         clock: () => DateTime.utc(2026, 7, 16, 12),
-        idFactory: () => 'follower-id',
+        idFactory: () => 'follower-${id++}',
         random: Random(7),
         rideCodeDirectory: rideCodes,
       );

--- a/apps/mobile/test/domain/forecast_plan_test.dart
+++ b/apps/mobile/test/domain/forecast_plan_test.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:balloon_crumbs/domain/forecast_plan.dart';
+import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/services/forecast_plan_importer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Map<String, Object?> fixture() => Map<String, Object?>.from(
+    jsonDecode(File('../../fixtures/forecast_plan_v1.json').readAsStringSync())
+        as Map,
+  );
+
+  test('parses every bounded version-one forecast field', () {
+    final json = fixture()..['futureAdditiveField'] = 'ignored';
+    final plan = ForecastPlanDocument.fromJson(json);
+
+    expect(plan.name, 'Tuckers Grave forecast');
+    expect(plan.altitudeStages, hasLength(6));
+    expect(plan.constraints.altitudeCeilingMetersMsl, 1200);
+    expect(plan.constraints.maximumDescentRateMetersPerSecond, 4);
+    expect(plan.landingEnvelope, hasLength(4));
+    expect(plan.wind.model, 'UKMO seamless');
+    expect(plan.operationalBoundaries, hasLength(1));
+    expect(plan.result.missDistanceMeters, 42);
+    expect(plan.toJson(), isNot(contains('futureAdditiveField')));
+  });
+
+  test('imports and persists structured evidence beside forecast geometry', () {
+    final plan = ForecastPlanDocument.fromJson(fixture());
+    final route = const ForecastPlanImporter().import(
+      plan,
+      importedAt: DateTime.utc(2026, 8, 23, 6),
+      sourceFileName: 'fixture.forecast-plan',
+    );
+    final restored = ImportedRoute.fromJsonString(route.toJsonString());
+
+    expect(restored.isBalloonForecast, isTrue);
+    expect(restored.pathPointCount, 3);
+    expect(restored.paths.single.points[1].elevationMeters, 700);
+    expect(
+      restored.paths.single.points.last.recordedAt,
+      DateTime.utc(2026, 8, 23, 7, 30),
+    );
+    expect(restored.forecastPlan?.altitudeStages, hasLength(6));
+    expect(restored.forecastPlan?.gpxFallback, plan.gpxFallback);
+  });
+
+  test('unknown schema and unordered geometry reject the complete plan', () {
+    expect(
+      () => ForecastPlanDocument.fromJson(fixture()..['schemaVersion'] = 2),
+      throwsFormatException,
+    );
+
+    final unordered = fixture();
+    final track = List<Map<String, Object?>>.from(
+      unordered['plannedTrack']! as List,
+    );
+    track[2] = {...track[2], 'elapsedSeconds': 100};
+    unordered['plannedTrack'] = track;
+    expect(
+      () => ForecastPlanDocument.fromJson(unordered),
+      throwsFormatException,
+    );
+  });
+}

--- a/apps/mobile/test/domain/imported_route_test.dart
+++ b/apps/mobile/test/domain/imported_route_test.dart
@@ -10,6 +10,7 @@ void main() {
       description: 'Dry run',
       importedAt: DateTime.utc(2026, 7, 16, 9),
       sourceFileName: 'loop.gpx',
+      purpose: ImportedRoutePurpose.balloonForecast,
       paths: [
         RoutePath(
           kind: RoutePathKind.track,
@@ -62,6 +63,7 @@ void main() {
     expect(restored.name, 'Saturday loop');
     expect(restored.pathPointCount, 2);
     expect(restored.paths.single.kind, RoutePathKind.track);
+    expect(restored.purpose, ImportedRoutePurpose.balloonForecast);
     expect(restored.paths.single.points.first.elevationMeters, 210);
     expect(
       restored.paths.single.points.first.altitudeSource,
@@ -124,6 +126,7 @@ void main() {
       restored.paths.single.points.first.altitudeDatum,
       AltitudeDatum.unknown,
     );
+    expect(restored.purpose, ImportedRoutePurpose.unspecified);
   });
 
   test('migrates the planned duration from a build 60 destination route', () {

--- a/apps/mobile/test/domain/live_route_state_test.dart
+++ b/apps/mobile/test/domain/live_route_state_test.dart
@@ -1,0 +1,68 @@
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/domain/live_route_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final forecast = _route('forecast');
+  final road = _route('road');
+
+  test('airborne roles follow the shared flight plan', () {
+    final state = LiveRouteState(
+      sharedFlightPlan: forecast,
+      vehicleRoadRoute: road,
+    );
+
+    expect(state.activeFor(FlightRole.pilot), same(forecast));
+    expect(state.activeFor(FlightRole.balloonCrew), same(forecast));
+  });
+
+  test('chase roles follow only their vehicle road route', () {
+    final state = LiveRouteState(
+      sharedFlightPlan: forecast,
+      vehicleRoadRoute: road,
+    );
+
+    expect(state.activeFor(FlightRole.chaseDriver), same(road));
+    expect(state.activeFor(FlightRole.chaseCrew), same(road));
+  });
+
+  test('a new forecast cannot overwrite local road guidance', () {
+    final replacement = _route('replacement');
+    final state = LiveRouteState(
+      sharedFlightPlan: forecast,
+      vehicleRoadRoute: road,
+    ).withSharedFlightPlan(replacement);
+
+    expect(state.sharedFlightPlan, same(replacement));
+    expect(state.vehicleRoadRoute, same(road));
+  });
+
+  test('a dynamic road reroute cannot overwrite the forecast', () {
+    final replacement = _route('replacement');
+    final state = LiveRouteState(
+      sharedFlightPlan: forecast,
+      vehicleRoadRoute: road,
+    ).withVehicleRoadRoute(replacement);
+
+    expect(state.sharedFlightPlan, same(forecast));
+    expect(state.vehicleRoadRoute, same(replacement));
+  });
+}
+
+ImportedRoute _route(String id) => ImportedRoute(
+  id: id,
+  name: id,
+  importedAt: DateTime.utc(2026, 8, 23),
+  sourceFileName: '$id.gpx',
+  paths: const [
+    RoutePath(
+      kind: RoutePathKind.track,
+      points: [
+        GeoPoint(latitude: 51.4, longitude: -2.7),
+        GeoPoint(latitude: 51.5, longitude: -2.6),
+      ],
+    ),
+  ],
+  waypoints: const [],
+);

--- a/apps/mobile/test/domain/ride_session_test.dart
+++ b/apps/mobile/test/domain/ride_session_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/ride_coordination_mode.dart';
 import 'package:balloon_crumbs/domain/ride_role.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
@@ -19,6 +20,37 @@ void main() {
 
   test('simulation marker survives session persistence', () {
     expect(RideSession.fromJson(session.toJson()).isSimulation, isTrue);
+  });
+
+  test('flight role and craft assignment survive session persistence', () {
+    final assigned = RideSession(
+      rideId: 'flight',
+      rideCode: '123456',
+      inviteSecret: 'secret',
+      joinToken: 'aTokenWithPlentyOfEntropy',
+      localRiderId: 'crew',
+      displayName: 'Alex',
+      role: RideRole.rider,
+      flightRole: FlightRole.chaseDriver,
+      localCraftId: 'vehicle-land-rover',
+      joinedAt: DateTime.utc(2026, 8, 23),
+    );
+
+    final restored = RideSession.fromJson(assigned.toJson());
+    expect(restored.flightRole, FlightRole.chaseDriver);
+    expect(restored.localCraftId, 'vehicle-land-rover');
+    expect(restored.requiresFlightAssignment, isFalse);
+  });
+
+  test('legacy sessions restore least-privileged and require assignment', () {
+    final legacy = session.toJson()
+      ..remove('flightRole')
+      ..remove('localCraftId');
+
+    final restored = RideSession.fromJson(legacy);
+    expect(restored.flightRole, FlightRole.observer);
+    expect(restored.localCraftId, isNull);
+    expect(restored.requiresFlightAssignment, isTrue);
   });
 
   test(

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -324,7 +324,78 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets('balloon map draws an advisory forecast without road controls', (
+    tester,
+  ) async {
+    final directory = Directory.systemTemp.createTempSync(
+      'balloon-forecast-map',
+    );
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final cache = OfflineTileCache(
+      rootDirectory: directory,
+      configuration: const BasemapConfiguration(),
+      httpClient: MockClient((_) async => http.Response('', 404)),
+    );
+    addTearDown(cache.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: RideMapScreen(
+          routeStore: InMemoryRouteStore(_forecastRoute),
+          routeImporter: RouteImporter(source: const _NoFileSource()),
+          offlineTileCache: cache,
+          perspective: RideMapPerspective.balloon,
+          rideStarted: false,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final layer = tester.widget<PolylineLayer>(find.byType(PolylineLayer));
+    expect(
+      layer.polylines.any(
+        (line) =>
+            line.color == RouteTrailStyle.routeAhead.color &&
+            line.points.length == 2,
+      ),
+      isTrue,
+      reason: 'the forecast line should remain visible to the pilot',
+    );
+    expect(find.byTooltip('Fit forecast plan'), findsOneWidget);
+    expect(find.byTooltip('Navigate or export route'), findsNothing);
+    expect(find.text('All turns for this route'), findsNothing);
+  });
 }
+
+final _forecastRoute = ImportedRoute(
+  id: 'balloon-forecast',
+  name: 'Bath forecast',
+  purpose: ImportedRoutePurpose.balloonForecast,
+  importedAt: DateTime.utc(2026, 8, 23),
+  sourceFileName: 'forecast.gpx',
+  paths: [
+    RoutePath(
+      kind: RoutePathKind.track,
+      points: [
+        GeoPoint(
+          latitude: 51.4459,
+          longitude: -2.6413,
+          elevationMeters: 120,
+          recordedAt: DateTime.utc(2026, 8, 23, 6),
+        ),
+        GeoPoint(
+          latitude: 51.4128,
+          longitude: -2.7585,
+          elevationMeters: 900,
+          recordedAt: DateTime.utc(2026, 8, 23, 7, 15),
+        ),
+      ],
+    ),
+  ],
+  waypoints: const [],
+);
 
 final _roadRoute = ImportedRoute(
   id: 'chase-road',

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -357,11 +357,12 @@ void main() {
     expect(
       layer.polylines.any(
         (line) =>
-            line.color == RouteTrailStyle.routeAhead.color &&
+            line.color == BalloonAltitudeStyle.colorForMeters(510) &&
             line.points.length == 2,
       ),
       isTrue,
-      reason: 'the forecast line should remain visible to the pilot',
+      reason:
+          'the forecast line should remain visible and altitude-coloured for the pilot',
     );
     expect(find.byTooltip('Fit forecast plan'), findsOneWidget);
     expect(find.byTooltip('Navigate or export route'), findsNothing);

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -19,6 +19,33 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
 void main() {
+  test(
+    'forecast context follows the assigned role rather than camera mode',
+    () {
+      expect(
+        rideMapShowsForecastContext(perspective: RideMapPerspective.balloon),
+        isTrue,
+        reason: 'airborne views default to forecast context',
+      );
+      expect(
+        rideMapShowsForecastContext(
+          perspective: RideMapPerspective.chase,
+          explicitPreference: true,
+        ),
+        isTrue,
+        reason: 'chase crew retain wind and airspace in the tactical camera',
+      );
+      expect(
+        rideMapShowsForecastContext(
+          perspective: RideMapPerspective.chase,
+          explicitPreference: false,
+        ),
+        isFalse,
+        reason: 'the driver road view explicitly suppresses forecast controls',
+      );
+    },
+  );
+
   testWidgets(
     'balloon map shows aircraft telemetry and suppresses driving chrome',
     (tester) async {

--- a/apps/mobile/test/features/map/ride_map_feature_test.dart
+++ b/apps/mobile/test/features/map/ride_map_feature_test.dart
@@ -526,7 +526,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Waiting for the leader’s route'), findsOneWidget);
+      expect(find.text('Waiting for the coordinator’s plan'), findsOneWidget);
       expect(find.text('Choose a route'), findsNothing);
       expect(
         find.byKey(const Key('plan-destination-empty-button')),
@@ -541,7 +541,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('dismiss-waiting-route-prompt')));
       await tester.pumpAndSettle();
-      expect(find.text('Waiting for the leader’s route'), findsNothing);
+      expect(find.text('Waiting for the coordinator’s plan'), findsNothing);
     },
   );
 
@@ -570,7 +570,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Waiting for the leader’s route'), findsNothing);
+    expect(find.text('Waiting for the coordinator’s plan'), findsNothing);
     expect(find.text('Choose a route'), findsNothing);
   });
 
@@ -1041,7 +1041,7 @@ void main() {
       allOf(
         contains('Mapped speed limit 30 miles per hour'),
         contains('Mapped, not live'),
-        contains('You are riding at 45 miles per hour by GPS'),
+        contains('You are travelling at 45 miles per hour by GPS'),
       ),
     );
     // 20 m/s is 45 mph, shown below the sign at the sign's own font size.
@@ -1953,6 +1953,101 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets(
+    'a balloon forecast is reviewed as a flight plan without road matching',
+    (tester) async {
+      final directory = Directory.systemTemp.createTempSync(
+        'map-balloon-forecast-test',
+      );
+      addTearDown(() => directory.deleteSync(recursive: true));
+      final forecast = ImportedRoute(
+        id: 'forecast-track',
+        name: 'Bath forecast',
+        description:
+            'Forecast-only wind drift. Not a controllable route or an aviation briefing.',
+        purpose: ImportedRoutePurpose.balloonForecast,
+        importedAt: DateTime.utc(2026, 8, 22),
+        sourceFileName: 'bath-forecast.gpx',
+        paths: [
+          RoutePath(
+            kind: RoutePathKind.track,
+            points: [
+              GeoPoint(
+                latitude: 51.38,
+                longitude: -2.36,
+                elevationMeters: 120,
+                recordedAt: DateTime.utc(2026, 8, 23, 6),
+              ),
+              GeoPoint(
+                latitude: 51.42,
+                longitude: -2.20,
+                elevationMeters: 900,
+                recordedAt: DateTime.utc(2026, 8, 23, 7, 15),
+              ),
+            ],
+          ),
+        ],
+        waypoints: const [],
+      );
+      final matcher = _StubImportedTrackMatcher(
+        ImportedTrackMatch(
+          route: forecast,
+          confidence: 1,
+          traceCoverage: 1,
+          meanDeviationMeters: 0,
+          maximumDeviationMeters: 0,
+        ),
+      );
+      final routeStore = _RecordingRouteStore();
+      final cache = OfflineTileCache(
+        rootDirectory: directory,
+        configuration: const BasemapConfiguration(),
+        httpClient: MockClient((_) async => http.Response('', 404)),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: RideMapScreen(
+            routeStore: routeStore,
+            routeImporter: RouteImporter(source: const _NoFileSource()),
+            offlineTileCache: cache,
+            demoRouteLoader: () async => forecast,
+            importedTrackMatcher: matcher,
+            rideStarted: false,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.ensureVisible(find.text('Use demo route'));
+      await tester.tap(find.text('Use demo route'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Add turn directions?'), findsNothing);
+      expect(find.text('Use this forecast plan?'), findsOneWidget);
+      expect(find.text('1h 15m'), findsOneWidget);
+      expect(find.text('Max 900 m MSL'), findsOneWidget);
+      expect(find.byKey(const Key('forecast-plan-time')), findsOneWidget);
+      expect(
+        find.textContaining('balloon cannot follow this line'),
+        findsOneWidget,
+      );
+      expect(matcher.originals, isEmpty);
+
+      await tester.tap(find.byKey(const Key('confirm-route-confirmation')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(routeStore.route?.purpose, ImportedRoutePurpose.balloonForecast);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    },
+  );
+
   testWidgets('a failed track match keeps the active route unchanged', (
     tester,
   ) async {
@@ -2728,7 +2823,7 @@ void main() {
 
     // Both roles are listed, by name and role.
     expect(find.byKey(const Key('emergency-contact-lead')), findsOneWidget);
-    expect(find.text('Oliver (leader)'), findsOneWidget);
+    expect(find.text('Oliver (coordinator)'), findsOneWidget);
 
     // The leader shared, so both dial controls are offered.
     expect(

--- a/apps/mobile/test/features/map/ride_map_feature_test.dart
+++ b/apps/mobile/test/features/map/ride_map_feature_test.dart
@@ -34,6 +34,21 @@ import 'package:balloon_crumbs/services/road_routing.dart';
 import 'package:balloon_crumbs/services/speed_limit.dart';
 
 void main() {
+  test('a chase craft trace can retain its identity colour', () {
+    const identity = Color(0xFF5AC8FA);
+    const trace = MapOverlayTrace(
+      id: 'trail-land-rover',
+      label: 'Land Rover trail',
+      points: [
+        GeoPoint(latitude: 51.4, longitude: -2.5),
+        GeoPoint(latitude: 51.41, longitude: -2.49),
+      ],
+      color: identity,
+    );
+
+    expect(trace.effectiveColor, identity);
+  });
+
   test('navigation panels preserve map context and rider clearance', () {
     expect(rideMapPrimaryPanelFill.toARGB32(), 0xD9252E39);
     expect(

--- a/apps/mobile/test/features/map/route_trail_style_test.dart
+++ b/apps/mobile/test/features/map/route_trail_style_test.dart
@@ -20,6 +20,7 @@ void main() {
       'travelled': (2.81, 6.52, 7.02),
       'leader trail': (4.22, 9.78, 10.53),
       'balloon ground track': (4.77, 11.06, 11.91),
+      'flight forecast': (4.77, 11.06, 11.91),
       'operational boundary': (3.39, 7.87, 8.47),
       'route start connector': (4.77, 11.06, 11.91),
     };

--- a/apps/mobile/test/features/map/route_trail_style_test.dart
+++ b/apps/mobile/test/features/map/route_trail_style_test.dart
@@ -22,6 +22,7 @@ void main() {
       'balloon ground track': (4.77, 11.06, 11.91),
       'flight forecast': (4.77, 11.06, 11.91),
       'operational boundary': (3.39, 7.87, 8.47),
+      'original landing envelope': (3.36, 7.78, 8.38),
       'route start connector': (4.77, 11.06, 11.91),
     };
 

--- a/apps/mobile/test/features/map/route_trail_style_test.dart
+++ b/apps/mobile/test/features/map/route_trail_style_test.dart
@@ -23,6 +23,8 @@ void main() {
       'flight forecast': (4.77, 11.06, 11.91),
       'operational boundary': (3.39, 7.87, 8.47),
       'original landing envelope': (3.36, 7.78, 8.38),
+      'live projection': (4.48, 10.38, 11.18),
+      'live landing envelope': (4.77, 11.06, 11.91),
       'route start connector': (4.77, 11.06, 11.91),
     };
 

--- a/apps/mobile/test/features/ride/active_ride_navigation_escape_test.dart
+++ b/apps/mobile/test/features/ride/active_ride_navigation_escape_test.dart
@@ -13,7 +13,6 @@ import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/completed_ride_store.dart';
 import 'package:balloon_crumbs/domain/recorded_route_store.dart';
-import 'package:balloon_crumbs/features/map/ride_map.dart';
 import 'package:balloon_crumbs/services/nearby_bridge.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -45,7 +44,7 @@ void main() {
     );
   });
 
-  testWidgets('a moving rider can still reach the other tabs (#404)', (
+  testWidgets('a moving pilot keeps the role navigation visible', (
     tester,
   ) async {
     // The defect: once a ride is under way on the map tab with a route and a
@@ -117,47 +116,19 @@ void main() {
     await tester.pump();
     expect(tester.takeException(), isNull, reason: 'map tab');
 
-    // Ride until the shell decides the rider is navigating and takes the bar
-    // away. That state is the whole point of the test: if it never arrives,
-    // the test is not exercising the defect and must say so rather than pass.
-    await pumpUntil(() => find.byType(NavigationBar).evaluate().isEmpty);
+    // A balloon role is not a road-navigation role. It keeps the main role
+    // destinations visible even while the replay is moving; only a chase
+    // driver's glance-limited road view may collapse this chrome.
+    await tester.pump(const Duration(seconds: 2));
     expect(
       find.byType(NavigationBar),
-      findsNothing,
-      reason: 'the moving-map state this regression is about was never reached',
+      findsOneWidget,
+      reason: 'a moving pilot must not inherit the driver-only chrome',
     );
+    expect(find.byKey(const Key('ride-menu-button')), findsNothing);
 
-    // Pre-fix this found nothing: ActiveRideShell never passed
-    // `onOpenRideMenu`, so the corner button existed only where a test supplied
-    // it and the rider had no way off the map at all.
-    final rideMenu = find.byKey(const Key('ride-menu-button'));
-    expect(rideMenu, findsOneWidget);
-    expect(
-      tester.getRect(rideMenu).top,
-      closeTo(portraitRideMenuTopOffset, 1),
-      reason: 'the menu should sit below the ETA/mini-map header',
-    );
-
-    // Bounded pumps, not pumpAndSettle: a running simulation never settles.
-    await tester.tap(rideMenu);
-    await pumpUntil(
-      () => find
-          .byKey(const Key('ride-menu-destination-2'))
-          .evaluate()
-          .isNotEmpty,
-    );
-    expect(tester.takeException(), isNull, reason: 'flight menu opening');
-    // The tile exists as soon as the sheet starts sliding up; tapping then
-    // lands on the barrier instead. Let it finish arriving.
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(tester.takeException(), isNull, reason: 'flight menu open');
-    expect(find.text('Flight'), findsWidgets);
-    expect(find.text('Settings'), findsWidgets);
-
-    // Leaving the map puts the rider's navigation back, because the condition
-    // that hid it required the map tab.
-    await tester.tap(find.byKey(const Key('ride-menu-destination-2')));
-    await pumpUntil(() => find.byType(NavigationBar).evaluate().isNotEmpty);
+    await tester.tap(find.text('Flight').last);
+    await tester.pump();
     expect(tester.takeException(), isNull, reason: 'flight tab');
     expect(find.byType(NavigationBar), findsOneWidget);
 

--- a/apps/mobile/test/features/ride/active_ride_shell_route_test.dart
+++ b/apps/mobile/test/features/ride/active_ride_shell_route_test.dart
@@ -1,6 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:balloon_crumbs/domain/altitude.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/domain/route_store.dart';
 import 'package:balloon_crumbs/features/ride/active_ride_shell.dart';
+import 'package:balloon_crumbs/features/map/ride_map.dart';
 
 void main() {
   test(
@@ -37,4 +41,61 @@ void main() {
       );
     },
   );
+
+  test('only stopped drivers and chase crew can change a vehicle target', () {
+    final now = DateTime.utc(2026, 8, 23, 12);
+    MapNavigationPosition navigation(
+      double? speed, {
+      Duration age = Duration.zero,
+    }) => MapNavigationPosition(
+      point: const GeoPoint(latitude: 51.5, longitude: -2.6),
+      recordedAt: now.subtract(age),
+      speedMetersPerSecond: speed,
+      accuracyMeters: 5,
+      altitudeSource: AltitudeSource.unknown,
+      altitudeDatum: AltitudeDatum.unknown,
+    );
+
+    expect(
+      canChangeChaseGuidanceTarget(
+        role: FlightRole.chaseCrew,
+        navigation: null,
+        now: now,
+      ),
+      isTrue,
+    );
+    expect(
+      canChangeChaseGuidanceTarget(
+        role: FlightRole.chaseDriver,
+        navigation: navigation(0.2),
+        now: now,
+      ),
+      isTrue,
+    );
+    expect(
+      canChangeChaseGuidanceTarget(
+        role: FlightRole.chaseDriver,
+        navigation: navigation(8),
+        now: now,
+      ),
+      isFalse,
+    );
+    expect(
+      canChangeChaseGuidanceTarget(
+        role: FlightRole.chaseDriver,
+        navigation: navigation(0, age: const Duration(seconds: 11)),
+        now: now,
+      ),
+      isFalse,
+      reason: 'an old zero-speed fix must not be treated as safely stopped',
+    );
+    expect(
+      canChangeChaseGuidanceTarget(
+        role: FlightRole.pilot,
+        navigation: navigation(0),
+        now: now,
+      ),
+      isFalse,
+    );
+  });
 }

--- a/apps/mobile/test/features/ride/flight_assignment_screen_test.dart
+++ b/apps/mobile/test/features/ride/flight_assignment_screen_test.dart
@@ -1,0 +1,97 @@
+import 'package:balloon_crumbs/controllers/ride_controller.dart';
+import 'package:balloon_crumbs/data/in_memory_event_store.dart';
+import 'package:balloon_crumbs/data/in_memory_session_store.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/features/ride/flight_assignment_screen.dart';
+import 'package:balloon_crumbs/services/nearby_bridge.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<RideController> restoreLegacy(RideRole role) async {
+    final sessions = InMemorySessionStore();
+    final persisted =
+        RideSession(
+            rideId: 'legacy-flight',
+            rideCode: '123456',
+            inviteSecret: 'legacy-secret-with-enough-entropy',
+            joinToken: 'legacy-token-with-enough-entropy',
+            localRiderId: 'legacy-device',
+            displayName: 'Alex',
+            role: role,
+            joinedAt: DateTime.utc(2026, 8, 1),
+          ).toJson()
+          ..remove('flightRole')
+          ..remove('localCraftId');
+    await sessions.save(RideSession.fromJson(persisted));
+    var id = 0;
+    final controller = RideController(
+      InMemoryEventStore(),
+      sessions,
+      const _FakeNearbyBridge(),
+      idFactory: () => 'event-${id++}',
+      clock: () => DateTime.utc(2026, 8, 23),
+    );
+    await controller.initialize();
+    return controller;
+  }
+
+  testWidgets('a legacy creator gets an explicit pilot restore gate', (
+    tester,
+  ) async {
+    final controller = await restoreLegacy(RideRole.lead);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: FlightAssignmentScreen(controller: controller)),
+    );
+
+    expect(find.text('Restore this phone as the pilot'), findsOneWidget);
+    expect(find.text('Restore pilot view'), findsOneWidget);
+    expect(find.byKey(const Key('repair-role-chaseDriver')), findsNothing);
+    await tester.tap(find.byKey(const Key('confirm-flight-assignment')));
+    await tester.pumpAndSettle();
+
+    expect(controller.localFlightRole, FlightRole.pilot);
+    expect(controller.hasFlightAuthority, isTrue);
+    expect(controller.session!.requiresFlightAssignment, isFalse);
+  });
+
+  testWidgets('a legacy participant chooses job and chase vehicle', (
+    tester,
+  ) async {
+    final controller = await restoreLegacy(RideRole.rider);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: FlightAssignmentScreen(controller: controller)),
+    );
+    await tester.tap(find.byKey(const Key('repair-role-chaseDriver')));
+    await tester.enterText(
+      find.byKey(const Key('repair-vehicle-label-field')),
+      'Recovery One',
+    );
+    await tester.tap(find.byKey(const Key('confirm-flight-assignment')));
+    await tester.pumpAndSettle();
+
+    expect(controller.localFlightRole, FlightRole.chaseDriver);
+    expect(controller.localCraft?.craft.label, 'Recovery One');
+    expect(controller.hasFlightAuthority, isFalse);
+  });
+}
+
+class _FakeNearbyBridge extends NearbyBridge {
+  const _FakeNearbyBridge();
+
+  @override
+  Future<NearbyCapabilities> capabilities() async => const NearbyCapabilities(
+    platform: 'test',
+    nativeBridgeReady: true,
+    nearbyApiLinked: false,
+    status: 'phase0',
+  );
+}

--- a/apps/mobile/test/features/ride/start_ride_instrumentation_test.dart
+++ b/apps/mobile/test/features/ride/start_ride_instrumentation_test.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// #441: "with CarPlay connected, the Start ride control on the phone does
+/// #441: "with CarPlay connected, the Start flight control on the phone does
 /// nothing."
 ///
 /// ## Why this is instrumentation and not a fix
@@ -17,20 +17,20 @@ import 'package:flutter_test/flutter_test.dart';
 /// So there is nothing to fix that I can point at, and guessing at a
 /// safety-relevant control is how #408 nearly shipped an illegal manoeuvre.
 ///
-/// What the log can settle in one ride:
+/// What the log can settle in one flight:
 ///
-/// - **no `start ride tapped` entry** — the tap never reached Dart, which points
+/// - **no `start flight tapped` entry** — the tap never reached Dart, which points
 ///   at the Flutter view not receiving touches while CarPlay is attached;
 /// - **tapped, then `refused before the dialog`** — the leadership or
 ///   already-started gate swallowed it, and the entry says which;
 /// - **tapped, then `decision: dismissed`** — the dialog appeared and was
 ///   dismissed, which would mean the control works and the dialog is the
 ///   problem;
-/// - **tapped, then `decision: chooseRoute`** — the phone demanded a route
+/// - **tapped, then `decision: chooseRoute`** — the phone demanded a plan
 ///   decision where CarPlay starts immediately, which is a real asymmetry
 ///   between the two surfaces and would be the thing to fix.
 ///
-/// The entries are asserted structurally because starting a ride needs a
+/// The entries are asserted structurally because starting a flight needs a
 /// session, a relay, a location stream and a map, and no test here constructs
 /// `ActiveRideShell`.
 void main() {
@@ -38,13 +38,13 @@ void main() {
     'lib/features/ride/active_ride_shell.dart',
   ).readAsStringSync();
 
-  group('the next ride can say what the start button did (#441)', () {
+  group('the next flight can say what the start button did (#441)', () {
     test('the tap is recorded before any gate can swallow it', () {
-      expect(source, contains('start ride tapped on the phone'));
+      expect(source, contains('start flight tapped on the phone'));
       // Before the early return, or a refused tap would leave no trace at all.
       expect(
-        source.indexOf('start ride tapped on the phone'),
-        lessThan(source.indexOf('start ride refused before the dialog')),
+        source.indexOf('start flight tapped on the phone'),
+        lessThan(source.indexOf('start flight refused before the dialog')),
       );
     });
 
@@ -56,13 +56,13 @@ void main() {
     });
 
     test('the outcome of the dialog is recorded', () {
-      expect(source, contains('start ride decision:'));
+      expect(source, contains('start flight decision:'));
     });
 
     test('a CarPlay start is distinguishable from a phone start', () {
       // The report is that only the car could start the ride, so a log has to
       // say which surface did.
-      expect(source, contains('start ride accepted from CarPlay'));
+      expect(source, contains('start flight accepted from CarPlay'));
     });
   });
 

--- a/apps/mobile/test/internet/internet_relay_worker_isolation_test.dart
+++ b/apps/mobile/test/internet/internet_relay_worker_isolation_test.dart
@@ -211,6 +211,13 @@ void main() {
           createdAt: _base.add(const Duration(seconds: 1)),
         ),
       );
+      await eventStore.append(
+        _event(
+          id: 'pilot-offer',
+          type: RideEventType.pilotHandoverOffered,
+          createdAt: _base.add(const Duration(seconds: 2)),
+        ),
+      );
       final api = _LegacyRelayApi();
       final worker = InternetRelayWorker(
         api: api,
@@ -225,7 +232,7 @@ void main() {
       await worker.start(_session);
       final status = await synced.timeout(const Duration(seconds: 2));
 
-      expect(status.unsupportedUploadCount, 1);
+      expect(status.unsupportedUploadCount, 2);
       expect(
         status.limitations.map((limitation) => limitation.kind),
         contains(PresenceLimitationKind.uploadCapabilityMissing),

--- a/apps/mobile/test/internet/plan_directory_test.dart
+++ b/apps/mobile/test/internet/plan_directory_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -64,6 +65,62 @@ void main() {
       expect(plan.name, isNull);
       directory.close();
     });
+
+    test('decodes a structured plan before exposing its geometry', () async {
+      final forecastPlan = jsonDecode(
+        File('../../fixtures/forecast_plan_v1.json').readAsStringSync(),
+      );
+      final directory = directoryFor((request) async {
+        return http.Response(
+          jsonEncode({
+            'code': 'ABC12345',
+            'name': 'Tuckers Grave forecast',
+            'gpx': forecastPlan['gpxFallback'],
+            'forecastPlan': forecastPlan,
+            'createdAt': '2026-08-23T05:45:00Z',
+            'expiresAt': '2026-09-23T05:45:00Z',
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final plan = await directory.fetch('ABC12345');
+
+      expect(plan.forecastPlan?.altitudeStages, hasLength(6));
+      expect(plan.forecastPlan?.wind.provider, 'Open-Meteo');
+      directory.close();
+    });
+
+    test(
+      'rejects an unknown structured schema without using GPX partially',
+      () async {
+        final forecastPlan = Map<String, Object?>.from(
+          jsonDecode(
+                File('../../fixtures/forecast_plan_v1.json').readAsStringSync(),
+              )
+              as Map,
+        )..['schemaVersion'] = 2;
+        final directory = directoryFor(
+          (request) async => http.Response(
+            jsonEncode({
+              'code': 'ABC12345',
+              'name': 'Future plan',
+              'gpx': forecastPlan['gpxFallback'],
+              'forecastPlan': forecastPlan,
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          ),
+        );
+
+        await expectLater(
+          directory.fetch('ABC12345'),
+          throwsA(isA<PlanDirectoryException>()),
+        );
+        directory.close();
+      },
+    );
 
     test('a 404 raises a clear not-found error', () async {
       final directory = directoryFor(

--- a/apps/mobile/test/services/carplay_bridge_test.dart
+++ b/apps/mobile/test/services/carplay_bridge_test.dart
@@ -228,6 +228,20 @@ void main() {
     expect(solo.warning, isNull);
 
     expect(project(isGroup: true)!.warning, isNull);
+
+    final forecast = CarPlayRideStart.project(
+      hasSession: true,
+      isLeader: true,
+      rideStarted: false,
+      rideEnded: false,
+      busy: false,
+      locationReady: true,
+      isGroup: true,
+      routeName: 'Bath forecast',
+      routeIsBalloonForecast: true,
+    )!;
+    expect(forecast.detail, contains('This is advisory'));
+    expect(forecast.detail, isNot(contains('navigation will start')));
   });
 
   test(

--- a/apps/mobile/test/services/chase_guidance_target_test.dart
+++ b/apps/mobile/test/services/chase_guidance_target_test.dart
@@ -1,5 +1,7 @@
+import 'package:balloon_crumbs/domain/craft.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart';
 import 'package:balloon_crumbs/domain/landing_zone.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
 import 'package:balloon_crumbs/domain/rider_location.dart';
 import 'package:balloon_crumbs/services/chase_guidance_target.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -79,7 +81,97 @@ void main() {
       isTrue,
     );
   });
+
+  test('devices aboard one vehicle share its latest target choice', () {
+    final events = [
+      _event('register', 'driver', RideEventType.craftRegistered, now, {
+        'craftId': 'rover',
+        'kind': CraftKind.vehicle.name,
+      }),
+      _event(
+        'attach-driver',
+        'driver',
+        RideEventType.deviceAttachedToCraft,
+        now.add(const Duration(seconds: 1)),
+        {'craftId': 'rover', 'deviceId': 'driver'},
+      ),
+      _event(
+        'attach-crew',
+        'crew',
+        RideEventType.deviceAttachedToCraft,
+        now.add(const Duration(seconds: 2)),
+        {'craftId': 'rover', 'deviceId': 'crew'},
+      ),
+      _event(
+        'driver-choice',
+        'driver',
+        RideEventType.chaseGuidanceTargetSelected,
+        now.add(const Duration(seconds: 3)),
+        {'craftId': 'rover', 'target': 'balloon'},
+      ),
+      _event(
+        'crew-choice',
+        'crew',
+        RideEventType.chaseGuidanceTargetSelected,
+        now.add(const Duration(seconds: 4)),
+        {'craftId': 'rover', 'target': 'landingArea'},
+      ),
+    ];
+
+    final selection = const ChaseGuidanceSelectionReducer().fromEvents(
+      events,
+    )['rover'];
+
+    expect(selection?.target, ChaseGuidanceTarget.landingArea);
+    expect(selection?.changedByDeviceId, 'crew');
+  });
+
+  test('a device cannot redirect a different chase vehicle', () {
+    final events = [
+      _event('register-a', 'driver-a', RideEventType.craftRegistered, now, {
+        'craftId': 'rover-a',
+        'kind': CraftKind.vehicle.name,
+      }),
+      _event('register-b', 'driver-b', RideEventType.craftRegistered, now, {
+        'craftId': 'rover-b',
+        'kind': CraftKind.vehicle.name,
+      }),
+      _event(
+        'attach-a',
+        'driver-a',
+        RideEventType.deviceAttachedToCraft,
+        now.add(const Duration(seconds: 1)),
+        {'craftId': 'rover-a', 'deviceId': 'driver-a'},
+      ),
+      _event(
+        'wrong-vehicle',
+        'driver-a',
+        RideEventType.chaseGuidanceTargetSelected,
+        now.add(const Duration(seconds: 2)),
+        {'craftId': 'rover-b', 'target': 'balloon'},
+      ),
+    ];
+
+    expect(const ChaseGuidanceSelectionReducer().fromEvents(events), isEmpty);
+  });
 }
+
+RideEvent _event(
+  String id,
+  String deviceId,
+  RideEventType type,
+  DateTime createdAt,
+  Map<String, Object?> payload,
+) => RideEvent(
+  id: id,
+  rideId: 'flight',
+  deviceId: deviceId,
+  type: type,
+  priority: EventPriority.important,
+  createdAt: createdAt,
+  payload: payload,
+  signature: '0' * 64,
+);
 
 LocationSample _fix(DateTime recordedAt) => LocationSample(
   position: const GeoPoint(latitude: 51.45, longitude: -2.61),

--- a/apps/mobile/test/services/craft_track_reducer_test.dart
+++ b/apps/mobile/test/services/craft_track_reducer_test.dart
@@ -1,0 +1,116 @@
+import 'package:balloon_crumbs/domain/craft.dart';
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
+import 'package:balloon_crumbs/domain/rider_location.dart';
+import 'package:balloon_crumbs/services/craft_track_reducer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final start = DateTime.utc(2026, 8, 23, 7);
+  var sequence = 0;
+
+  setUp(() => sequence = 0);
+
+  RideEvent event(
+    RideEventType type, {
+    required String deviceId,
+    required Duration at,
+    Map<String, Object?> payload = const {},
+  }) {
+    sequence += 1;
+    return RideEvent(
+      id: 'event-${sequence.toString().padLeft(3, '0')}',
+      rideId: 'flight',
+      deviceId: deviceId,
+      type: type,
+      priority: EventPriority.routine,
+      createdAt: start.add(at),
+      payload: payload,
+      signature: '0' * 64,
+    );
+  }
+
+  RideEvent register(String id, CraftKind kind, Duration at) => event(
+    RideEventType.craftRegistered,
+    deviceId: 'pilot',
+    at: at,
+    payload: {'craftId': id, 'kind': kind.name, 'label': id},
+  );
+
+  RideEvent attach(String device, String craft, Duration at) => event(
+    RideEventType.deviceAttachedToCraft,
+    deviceId: device,
+    at: at,
+    payload: {'deviceId': device, 'craftId': craft},
+  );
+
+  RideEvent fix(String device, Duration at, double longitude) => event(
+    RideEventType.riderLocationUpdated,
+    deviceId: device,
+    at: at,
+    payload: {
+      'sample': LocationSample(
+        position: GeoPoint(latitude: 51.4, longitude: longitude),
+        recordedAt: start.add(at),
+        accuracyMeters: 5,
+        altitudeMeters: device.startsWith('balloon') ? 300 : null,
+        altitudeSource: device.startsWith('balloon')
+            ? AltitudeSource.gnss
+            : AltitudeSource.unknown,
+      ).toJson(),
+    },
+  );
+
+  test('several basket phones reduce to one balloon track', () {
+    final tracks = const CraftTrackReducer().fromEvents([
+      register('Balloon', CraftKind.balloon, Duration.zero),
+      attach('balloon-a', 'Balloon', const Duration(seconds: 1)),
+      attach('balloon-b', 'Balloon', const Duration(seconds: 2)),
+      fix('balloon-a', const Duration(seconds: 10), -2.50),
+      fix('balloon-b', const Duration(seconds: 12), -2.49),
+      fix('balloon-a', const Duration(seconds: 20), -2.48),
+      fix('balloon-b', const Duration(seconds: 22), -2.47),
+    ]);
+
+    expect(tracks, hasLength(1));
+    expect(tracks.single.isBalloon, isTrue);
+    expect(
+      tracks.single.samples.map((sample) => sample.position.longitude),
+      [-2.50, -2.48],
+      reason: 'the incumbent phone produces one continuous craft path',
+    );
+  });
+
+  test('keeps independently elected tracks for separate vehicles', () {
+    final tracks = const CraftTrackReducer().fromEvents([
+      register('Land Rover', CraftKind.vehicle, Duration.zero),
+      register('Van', CraftKind.vehicle, const Duration(milliseconds: 100)),
+      attach('rover-phone', 'Land Rover', const Duration(seconds: 1)),
+      attach('van-phone', 'Van', const Duration(seconds: 2)),
+      fix('rover-phone', const Duration(seconds: 10), -2.5),
+      fix('van-phone', const Duration(seconds: 11), -2.6),
+      fix('rover-phone', const Duration(seconds: 20), -2.4),
+      fix('van-phone', const Duration(seconds: 21), -2.7),
+    ]);
+
+    expect(tracks, hasLength(2));
+    expect(tracks.map((track) => track.label), ['Land Rover', 'Van']);
+    expect(tracks.every((track) => track.samples.length == 2), isTrue);
+  });
+
+  test('ignores duplicate and out-of-order measurements', () {
+    final tracks = const CraftTrackReducer().fromEvents([
+      register('Balloon', CraftKind.balloon, Duration.zero),
+      attach('balloon-a', 'Balloon', const Duration(seconds: 1)),
+      fix('balloon-a', const Duration(seconds: 20), -2.4),
+      fix('balloon-a', const Duration(seconds: 10), -2.5),
+      fix('balloon-a', const Duration(seconds: 20), -2.3),
+    ]);
+
+    expect(tracks.single.samples, hasLength(2));
+    expect(tracks.single.samples.map((sample) => sample.recordedAt), [
+      start.add(const Duration(seconds: 10)).toLocal(),
+      start.add(const Duration(seconds: 20)).toLocal(),
+    ]);
+  });
+}

--- a/apps/mobile/test/services/flight_plan_summary_test.dart
+++ b/apps/mobile/test/services/flight_plan_summary_test.dart
@@ -1,4 +1,9 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:balloon_crumbs/domain/forecast_plan.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/services/forecast_plan_importer.dart';
 import 'package:balloon_crumbs/services/flight_plan_summary.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -100,6 +105,33 @@ void main() {
     expect(summary.duration, const Duration(hours: 1));
     expect(summary.startTime, isNull);
     expect(summary.hasTimedAltitudeProfile, isFalse);
+  });
+
+  test('prefers exact structured stages, limits and source evidence', () {
+    final plan = ForecastPlanDocument.fromJson(
+      Map<String, Object?>.from(
+        jsonDecode(
+              File('../../fixtures/forecast_plan_v1.json').readAsStringSync(),
+            )
+            as Map,
+      ),
+    );
+    final route = const ForecastPlanImporter().import(
+      plan,
+      importedAt: DateTime.utc(2026, 8, 23, 6),
+      sourceFileName: 'fixture.forecast-plan',
+    );
+
+    final summary = FlightPlanSummary.fromRoute(route)!;
+
+    expect(summary.stages, hasLength(6));
+    expect(summary.stages[2].altitudeMetersMsl, 600);
+    expect(summary.maximumAscentRateMetersPerSecond, 3);
+    expect(summary.maximumDescentRateMetersPerSecond, 4);
+    expect(summary.altitudeCeilingMetersMsl, 1200);
+    expect(summary.matchingWindowStart, DateTime.utc(2026, 8, 23, 6, 24));
+    expect(summary.windProvider, 'Open-Meteo');
+    expect(summary.landingEnvelope, hasLength(4));
   });
 
   test('does not interpret a road route as a flight plan', () {

--- a/apps/mobile/test/services/flight_plan_summary_test.dart
+++ b/apps/mobile/test/services/flight_plan_summary_test.dart
@@ -1,0 +1,122 @@
+import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/services/flight_plan_summary.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'summarises planner timing, altitude phases, rates and landing points',
+    () {
+      final start = DateTime.utc(2026, 8, 23, 6);
+      final route = ImportedRoute(
+        id: 'forecast',
+        name: 'Tuckers Grave forecast',
+        importedAt: start,
+        sourceFileName: 'forecast.gpx',
+        purpose: ImportedRoutePurpose.balloonForecast,
+        paths: [
+          RoutePath(
+            kind: RoutePathKind.track,
+            points: [
+              GeoPoint(
+                latitude: 51.2,
+                longitude: -2.4,
+                elevationMeters: 120,
+                recordedAt: start,
+              ),
+              GeoPoint(
+                latitude: 51.21,
+                longitude: -2.39,
+                elevationMeters: 300,
+                recordedAt: start.add(const Duration(minutes: 2)),
+              ),
+              GeoPoint(
+                latitude: 51.22,
+                longitude: -2.38,
+                elevationMeters: 600,
+                recordedAt: start.add(const Duration(minutes: 5)),
+              ),
+              GeoPoint(
+                latitude: 51.23,
+                longitude: -2.37,
+                elevationMeters: 300,
+                recordedAt: start.add(const Duration(minutes: 10)),
+              ),
+              GeoPoint(
+                latitude: 51.24,
+                longitude: -2.36,
+                elevationMeters: 130,
+                recordedAt: start.add(const Duration(minutes: 12)),
+              ),
+            ],
+          ),
+        ],
+        waypoints: const [
+          RouteWaypoint(
+            point: GeoPoint(latitude: 51.25, longitude: -2.35),
+            name: 'Pilot intended landing area',
+          ),
+        ],
+      );
+
+      final summary = FlightPlanSummary.fromRoute(route)!;
+
+      expect(summary.startTime, start);
+      expect(summary.landingTime, start.add(const Duration(minutes: 12)));
+      expect(summary.duration, const Duration(minutes: 12));
+      expect(summary.minimumAltitudeMetersMsl, 120);
+      expect(summary.maximumAltitudeMetersMsl, 600);
+      expect(summary.maximumAscentRateMetersPerSecond, closeTo(1.67, 0.01));
+      expect(summary.maximumDescentRateMetersPerSecond, closeTo(1.42, 0.01));
+      expect(summary.stages.first.phase, FlightPlanStagePhase.launch);
+      expect(summary.stages[2].phase, FlightPlanStagePhase.peak);
+      expect(summary.stages.last.phase, FlightPlanStagePhase.landing);
+      expect(summary.forecastLanding!.latitude, 51.24);
+      expect(summary.intendedLanding!.latitude, 51.25);
+    },
+  );
+
+  test('uses planned duration for an untimed forecast', () {
+    final route = ImportedRoute(
+      id: 'untimed',
+      name: 'Untimed forecast',
+      importedAt: DateTime.utc(2026, 8, 23),
+      sourceFileName: 'forecast.gpx',
+      purpose: ImportedRoutePurpose.balloonForecast,
+      paths: const [
+        RoutePath(
+          kind: RoutePathKind.track,
+          points: [
+            GeoPoint(latitude: 51, longitude: -2),
+            GeoPoint(latitude: 51.1, longitude: -1.9),
+          ],
+        ),
+      ],
+      waypoints: const [],
+      plannedDuration: Duration(hours: 1),
+    );
+
+    final summary = FlightPlanSummary.fromRoute(route)!;
+
+    expect(summary.duration, const Duration(hours: 1));
+    expect(summary.startTime, isNull);
+    expect(summary.hasTimedAltitudeProfile, isFalse);
+  });
+
+  test('does not interpret a road route as a flight plan', () {
+    final route = ImportedRoute(
+      id: 'road',
+      name: 'Road route',
+      importedAt: DateTime.utc(2026, 8, 23),
+      sourceFileName: 'road.gpx',
+      paths: const [
+        RoutePath(
+          kind: RoutePathKind.route,
+          points: [GeoPoint(latitude: 51, longitude: -2)],
+        ),
+      ],
+      waypoints: const [],
+    );
+
+    expect(FlightPlanSummary.fromRoute(route), isNull);
+  });
+}

--- a/apps/mobile/test/services/gpx_parser_test.dart
+++ b/apps/mobile/test/services/gpx_parser_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:balloon_crumbs/domain/altitude.dart';
+import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/services/gpx_parser.dart';
 
 void main() {
@@ -76,6 +77,37 @@ void main() {
     expect(point.altitudeSource, AltitudeSource.gnss);
     expect(point.altitudeDatum, AltitudeDatum.wgs84Ellipsoid);
     expect(point.altitudeAccuracyMeters, 7.25);
+  });
+
+  test('recognises a web-planner balloon forecast', () {
+    final route = parser.parse(
+      _bytes('''
+        <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+          <metadata>
+            <name>Bath forecast</name>
+            <desc>Forecast-only wind drift. Not a controllable route.</desc>
+          </metadata>
+          <trk>
+            <name>Bath forecast</name>
+            <type>balloon-flight-forecast</type>
+            <trkseg>
+              <trkpt lat="51.38" lon="-2.36">
+                <ele>120</ele><time>2026-08-23T06:00:00Z</time>
+              </trkpt>
+              <trkpt lat="51.42" lon="-2.20">
+                <ele>900</ele><time>2026-08-23T07:15:00Z</time>
+              </trkpt>
+            </trkseg>
+          </trk>
+        </gpx>
+      '''),
+      routeId: 'forecast',
+      sourceFileName: 'forecast.gpx',
+      importedAt: DateTime.utc(2026, 8, 22),
+    );
+
+    expect(route.purpose, ImportedRoutePurpose.balloonForecast);
+    expect(route.isBalloonForecast, isTrue);
   });
 
   test('malformed altitude evidence degrades without losing <ele>', () {

--- a/apps/mobile/test/services/live_flight_projection_test.dart
+++ b/apps/mobile/test/services/live_flight_projection_test.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:balloon_crumbs/domain/forecast_plan.dart';
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/rider_location.dart';
+import 'package:balloon_crumbs/services/live_flight_projection.dart';
+import 'package:balloon_crumbs/services/open_meteo_wind.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ForecastPlanDocument plan() => ForecastPlanDocument.fromJson(
+    Map<String, Object?>.from(
+      jsonDecode(
+            File('../../fixtures/forecast_plan_v1.json').readAsStringSync(),
+          )
+          as Map,
+    ),
+  );
+
+  const vectors = [
+    WindForecastVector(altitudeMetersMsl: 20, fromDegrees: 270, speedKmh: 18),
+    WindForecastVector(altitudeMetersMsl: 300, fromDegrees: 180, speedKmh: 25),
+    WindForecastVector(altitudeMetersMsl: 600, fromDegrees: 90, speedKmh: 32),
+    WindForecastVector(altitudeMetersMsl: 1000, fromDegrees: 45, speedKmh: 40),
+    WindForecastVector(altitudeMetersMsl: 2000, fromDegrees: 0, speedKmh: 45),
+  ];
+
+  test(
+    'projects from fresh telemetry and forms a possible landing envelope',
+    () {
+      final now = DateTime.utc(2026, 8, 23, 7, 5);
+      final result = const LiveFlightProjectionEngine().evaluate(
+        plan: plan(),
+        balloonFix: LocationSample(
+          position: const GeoPoint(latitude: 51.5, longitude: -2.6),
+          recordedAt: now.subtract(const Duration(seconds: 5)),
+          accuracyMeters: 6,
+          altitudeMeters: 100,
+          altitudeSource: AltitudeSource.gnss,
+          altitudeDatum: AltitudeDatum.relativeToLaunch,
+        ),
+        wind: WindForecastField(
+          columns: const [
+            WindForecastColumn(
+              position: GeoPoint(latitude: 51.5, longitude: -2.6),
+              vectors: vectors,
+            ),
+          ],
+          validAt: now,
+          fetchedAt: now.subtract(const Duration(minutes: 3)),
+          origin: WindForecastOrigin.openMeteoUkmo,
+          sourceLabel: OpenMeteoWindProvider.sourceLabel,
+        ),
+        now: now,
+      );
+
+      expect(result.status, LiveFlightProjectionStatus.available);
+      expect(result.projection?.track.length, greaterThan(20));
+      expect(result.projection?.track.first.elevationMeters, 192);
+      expect(result.projection?.track.last.elevationMeters, closeTo(92, 0.01));
+      expect(
+        result.projection?.landingEnvelope.length,
+        greaterThanOrEqualTo(4),
+      );
+      expect(
+        result.projection?.landingEnvelope.first.latitude,
+        result.projection?.landingEnvelope.last.latitude,
+      );
+      expect(result.projection?.windSource, contains('Open-Meteo'));
+    },
+  );
+
+  test('refuses stale fixes, stale wind and incompatible altitude data', () {
+    final now = DateTime.utc(2026, 8, 23, 7, 5);
+    final field = WindForecastField(
+      columns: const [
+        WindForecastColumn(
+          position: GeoPoint(latitude: 51.5, longitude: -2.6),
+          vectors: vectors,
+        ),
+      ],
+      validAt: now,
+      fetchedAt: now,
+      origin: WindForecastOrigin.openMeteoUkmo,
+      sourceLabel: OpenMeteoWindProvider.sourceLabel,
+    );
+    LocationSample fix({
+      DateTime? recordedAt,
+      AltitudeDatum datum = AltitudeDatum.wgs84Geoid,
+    }) => LocationSample(
+      position: const GeoPoint(latitude: 51.5, longitude: -2.6),
+      recordedAt: recordedAt ?? now,
+      accuracyMeters: 6,
+      altitudeMeters: 180,
+      altitudeSource: AltitudeSource.gnss,
+      altitudeDatum: datum,
+    );
+
+    expect(
+      const LiveFlightProjectionEngine()
+          .evaluate(
+            plan: plan(),
+            balloonFix: fix(
+              recordedAt: now.subtract(const Duration(minutes: 2)),
+            ),
+            wind: field,
+            now: now,
+          )
+          .status,
+      LiveFlightProjectionStatus.staleBalloonFix,
+    );
+    expect(
+      const LiveFlightProjectionEngine()
+          .evaluate(
+            plan: plan(),
+            balloonFix: fix(datum: AltitudeDatum.wgs84Ellipsoid),
+            wind: field,
+            now: now,
+          )
+          .status,
+      LiveFlightProjectionStatus.noCompatibleAltitude,
+    );
+    expect(
+      const LiveFlightProjectionEngine()
+          .evaluate(
+            plan: plan(),
+            balloonFix: fix(),
+            wind: WindForecastField(
+              columns: field.columns,
+              validAt: now,
+              fetchedAt: now.subtract(const Duration(hours: 1)),
+              origin: WindForecastOrigin.openMeteoUkmo,
+              sourceLabel: field.sourceLabel,
+            ),
+            now: now,
+          )
+          .status,
+      LiveFlightProjectionStatus.staleWind,
+    );
+  });
+}

--- a/apps/mobile/test/services/map_style_repository_test.dart
+++ b/apps/mobile/test/services/map_style_repository_test.dart
@@ -603,7 +603,11 @@ void main() {
         'travelled': 7.14,
         'leader trail': 10.71,
         'balloon ground track': 12.11,
+        'flight forecast': 12.11,
         'operational boundary': 8.61,
+        'original landing envelope': 8.51,
+        'live projection': 11.36,
+        'live landing envelope': 12.11,
         'route start connector': 12.11,
       };
 

--- a/apps/mobile/test/services/open_meteo_wind_test.dart
+++ b/apps/mobile/test/services/open_meteo_wind_test.dart
@@ -12,7 +12,7 @@ void main() {
     final client = MockClient((request) async {
       requestedUri = request.url;
       final entries = [
-        for (var index = 0; index < 9; index += 1)
+        for (var index = 0; index < 25; index += 1)
           {
             'latitude': 51.4 + index * 0.001,
             'longitude': -2.7 + index * 0.001,
@@ -44,7 +44,15 @@ void main() {
       requestedUri?.queryParameters['hourly'],
       allOf(contains('wind_speed_20m'), contains('wind_direction_2000m')),
     );
-    expect(field.columns, hasLength(9));
+    expect(field.columns, hasLength(25));
+    expect(
+      requestedUri?.queryParameters['latitude']?.split(','),
+      hasLength(25),
+    );
+    expect(
+      requestedUri?.queryParameters['longitude']?.split(','),
+      hasLength(25),
+    );
     expect(field.validAt, DateTime.utc(2026, 8, 21, 10));
     expect(field.origin, WindForecastOrigin.openMeteoUkmo);
     final vector = field.at(
@@ -94,8 +102,26 @@ void main() {
 
     expect(provider.fetchCount, 1);
     expect(controller.selectedAltitudeMetersMsl, 1250);
+    expect(controller.followBalloonAltitude, isFalse);
     expect(controller.enabled, isFalse);
     expect(controller.field, isNotNull);
+  });
+
+  test('follows balloon altitude until a layer is selected manually', () {
+    final controller = WindForecastController(_RecordingProvider());
+    addTearDown(controller.dispose);
+
+    controller.updateBalloonAltitude(780);
+    expect(controller.selectedAltitudeMetersMsl, 800);
+    expect(controller.followBalloonAltitude, isTrue);
+
+    controller.setSelectedAltitude(300);
+    controller.updateBalloonAltitude(1250);
+    expect(controller.selectedAltitudeMetersMsl, 300);
+
+    controller.setFollowBalloonAltitude(true);
+    controller.updateBalloonAltitude(1250);
+    expect(controller.selectedAltitudeMetersMsl, 1250);
   });
 }
 

--- a/apps/mobile/test/services/pilot_handover_test.dart
+++ b/apps/mobile/test/services/pilot_handover_test.dart
@@ -1,0 +1,202 @@
+import 'package:balloon_crumbs/domain/ride_event.dart';
+import 'package:balloon_crumbs/services/pilot_handover.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 23, 12);
+
+  test('authority changes only after the named balloon crew accepts', () {
+    final events = _setup(now);
+    const reducer = PilotAuthorityReducer();
+    final offered = reducer.fromEvents(events: events, now: now);
+    expect(offered.pilotDeviceId, 'pilot-a');
+    expect(offered.hasAcceptedHandover, isFalse);
+    expect(offered.pendingFor('crew-b')?.fromDeviceId, 'pilot-a');
+
+    final accepted = reducer.fromEvents(
+      events: [
+        ...events,
+        _event(
+          id: 'accept',
+          deviceId: 'crew-b',
+          type: RideEventType.pilotHandoverAccepted,
+          at: now.add(const Duration(minutes: 1)),
+          payload: const {
+            'transferId': 'transfer-1',
+            'fromDeviceId': 'pilot-a',
+            'toDeviceId': 'crew-b',
+          },
+        ),
+      ],
+      now: now.add(const Duration(minutes: 1)),
+    );
+    expect(accepted.pilotDeviceId, 'crew-b');
+    expect(accepted.hasAcceptedHandover, isTrue);
+    expect(accepted.pendingOffers, isEmpty);
+  });
+
+  test('wrong-device, expired and non-balloon acceptance are ignored', () {
+    const reducer = PilotAuthorityReducer();
+    for (final invalid in [
+      _event(
+        id: 'wrong-device',
+        deviceId: 'crew-c',
+        type: RideEventType.pilotHandoverAccepted,
+        at: now.add(const Duration(minutes: 1)),
+        payload: const {
+          'transferId': 'transfer-1',
+          'fromDeviceId': 'pilot-a',
+          'toDeviceId': 'crew-b',
+        },
+      ),
+      _event(
+        id: 'expired',
+        deviceId: 'crew-b',
+        type: RideEventType.pilotHandoverAccepted,
+        at: now.add(const Duration(minutes: 11)),
+        payload: const {
+          'transferId': 'transfer-1',
+          'fromDeviceId': 'pilot-a',
+          'toDeviceId': 'crew-b',
+        },
+      ),
+    ]) {
+      final state = reducer.fromEvents(
+        events: [..._setup(now), invalid],
+        now: invalid.createdAt,
+      );
+      expect(state.pilotDeviceId, 'pilot-a');
+    }
+
+    final groundTarget = [
+      ..._setup(now),
+      _event(
+        id: 'vehicle',
+        deviceId: 'pilot-a',
+        type: RideEventType.craftRegistered,
+        at: now.subtract(const Duration(minutes: 2)),
+        payload: const {
+          'craftId': 'vehicle-1',
+          'kind': 'vehicle',
+          'label': 'Land Rover',
+        },
+      ),
+      _event(
+        id: 'attach-ground',
+        deviceId: 'crew-c',
+        type: RideEventType.deviceAttachedToCraft,
+        at: now.subtract(const Duration(minutes: 1)),
+        payload: const {'deviceId': 'crew-c', 'craftId': 'vehicle-1'},
+      ),
+      _event(
+        id: 'offer-ground',
+        deviceId: 'pilot-a',
+        type: RideEventType.pilotHandoverOffered,
+        at: now,
+        expiresAt: now.add(const Duration(minutes: 10)),
+        payload: {
+          'transferId': 'ground-transfer',
+          'fromDeviceId': 'pilot-a',
+          'toDeviceId': 'crew-c',
+          'expiresAt': now.add(const Duration(minutes: 10)).toIso8601String(),
+        },
+      ),
+    ];
+    expect(
+      reducer.fromEvents(events: groundTarget, now: now).pendingFor('crew-c'),
+      isNull,
+    );
+  });
+
+  test(
+    'a recipient clock slightly behind the pilot does not lose handover',
+    () {
+      const reducer = PilotAuthorityReducer();
+      final state = reducer.fromEvents(
+        events: [
+          ..._setup(now),
+          _event(
+            id: 'accept-behind',
+            deviceId: 'crew-b',
+            type: RideEventType.pilotHandoverAccepted,
+            at: now.subtract(const Duration(minutes: 1)),
+            payload: const {
+              'transferId': 'transfer-1',
+              'fromDeviceId': 'pilot-a',
+              'toDeviceId': 'crew-b',
+            },
+          ),
+        ],
+        now: now,
+      );
+
+      expect(state.pilotDeviceId, 'crew-b');
+      expect(state.hasAcceptedHandover, isTrue);
+    },
+  );
+}
+
+List<RideEvent> _setup(DateTime now) => [
+  _event(
+    id: 'created',
+    deviceId: 'pilot-a',
+    type: RideEventType.rideCreated,
+    at: now.subtract(const Duration(hours: 1)),
+    payload: const {
+      'displayName': 'Alice',
+      'role': 'lead',
+      'flightRole': 'pilot',
+    },
+  ),
+  _event(
+    id: 'balloon',
+    deviceId: 'pilot-a',
+    type: RideEventType.craftRegistered,
+    at: now.subtract(const Duration(minutes: 59)),
+    payload: const {
+      'craftId': 'balloon-1',
+      'kind': 'balloon',
+      'label': 'Balloon',
+    },
+  ),
+  for (final deviceId in const ['pilot-a', 'crew-b'])
+    _event(
+      id: 'attach-$deviceId',
+      deviceId: deviceId,
+      type: RideEventType.deviceAttachedToCraft,
+      at: now.subtract(const Duration(minutes: 58)),
+      payload: {'deviceId': deviceId, 'craftId': 'balloon-1'},
+    ),
+  _event(
+    id: 'offer',
+    deviceId: 'pilot-a',
+    type: RideEventType.pilotHandoverOffered,
+    at: now,
+    expiresAt: now.add(const Duration(minutes: 10)),
+    payload: {
+      'transferId': 'transfer-1',
+      'fromDeviceId': 'pilot-a',
+      'toDeviceId': 'crew-b',
+      'expiresAt': now.add(const Duration(minutes: 10)).toIso8601String(),
+    },
+  ),
+];
+
+RideEvent _event({
+  required String id,
+  required String deviceId,
+  required RideEventType type,
+  required DateTime at,
+  required Map<String, Object?> payload,
+  DateTime? expiresAt,
+}) => RideEvent(
+  id: id,
+  rideId: 'flight-1',
+  deviceId: deviceId,
+  type: type,
+  priority: EventPriority.important,
+  createdAt: at,
+  expiresAt: expiresAt,
+  payload: payload,
+  signature: '',
+);

--- a/apps/mobile/test/services/ride_diagnostics_recorder_test.dart
+++ b/apps/mobile/test/services/ride_diagnostics_recorder_test.dart
@@ -328,12 +328,12 @@ void main() {
         hazardType: 'speedCamera',
         distanceMeters: 0,
         armed: false,
-        clearedBy: 'rider tap',
+        clearedBy: 'crew tap',
       );
 
       final report = recorder.render();
       expect(report, contains('ENFORCE    armed  speedCamera  1600 m'));
-      expect(report, contains('cleared by rider tap'));
+      expect(report, contains('cleared by crew tap'));
     });
 
     test('a recalculation is recorded either way (#414)', () {

--- a/apps/mobile/test/services/ride_summary_exporter_test.dart
+++ b/apps/mobile/test/services/ride_summary_exporter_test.dart
@@ -59,7 +59,7 @@ void main() {
 
     expect(summary.riderCount, 2);
     expect(summary.totalDistanceMeters, closeTo(1111.95, 1));
-    expect(exporter.toCsv(summary), contains('"rider_count","2"'));
+    expect(exporter.toCsv(summary), contains('"crew_count","2"'));
     expect(exporter.toPlainText(summary), contains('Crew in this flight: 2'));
   });
 

--- a/apps/mobile/test/services/stored_route_library_test.dart
+++ b/apps/mobile/test/services/stored_route_library_test.dart
@@ -147,6 +147,52 @@ void main() {
     expect(prepared.notes.single, contains('raw recorded track'));
   });
 
+  test(
+    'a stored balloon forecast keeps its meaning and cannot be reversed',
+    () async {
+      final recorded = InMemoryRecordedRouteStore();
+      await recorded.save(
+        ImportedRoute(
+          id: 'forecast',
+          name: 'Bath forecast',
+          description: 'Forecast-only wind drift.',
+          purpose: ImportedRoutePurpose.balloonForecast,
+          importedAt: DateTime.utc(2026, 8, 23),
+          sourceFileName: 'forecast.gpx',
+          paths: const [
+            RoutePath(
+              kind: RoutePathKind.track,
+              points: [
+                GeoPoint(latitude: 51.38, longitude: -2.36),
+                GeoPoint(latitude: 51.42, longitude: -2.20),
+              ],
+            ),
+          ],
+          waypoints: const [],
+        ),
+      );
+      final library = _library(recorded, InMemoryCompletedRideStore());
+      final candidate = (await library.list()).single;
+
+      expect(candidate.canReverse, isFalse);
+      final prepared = library.prepare(
+        StoredRouteSelection(
+          candidate: candidate,
+          variant: StoredRouteVariant.raw,
+        ),
+      );
+      expect(prepared.route.purpose, ImportedRoutePurpose.balloonForecast);
+      expect(prepared.route.description, 'Forecast-only wind drift.');
+      expect(prepared.notes.single, contains('advisory balloon forecast'));
+      expect(
+        () => library.prepare(
+          StoredRouteSelection(candidate: candidate, reversed: true),
+        ),
+        throwsFormatException,
+      );
+    },
+  );
+
   test('reversing runs the route the other way and drops its turns', () async {
     final rides = InMemoryCompletedRideStore();
     final planned = ImportedRoute(

--- a/apps/mobile/test/vocabulary/flight_vocabulary_test.dart
+++ b/apps/mobile/test/vocabulary/flight_vocabulary_test.dart
@@ -1,0 +1,197 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('production copy does not expose inherited motorcycle vocabulary', () {
+    final lib = Directory('lib');
+    final violations = <String>[];
+    for (final file
+        in lib
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((file) => file.path.endsWith('.dart'))) {
+      for (final literal in _dartStrings(file.readAsStringSync())) {
+        if (!_forbidden.hasMatch(literal.value)) continue;
+        if (_isDocumentedTechnicalLiteral(literal.value)) continue;
+        violations.add(
+          '${file.path}:${literal.line}: ${literal.value.replaceAll('\n', r'\n')}',
+        );
+      }
+    }
+
+    if (violations.isNotEmpty) {
+      fail(
+        'Use flight, crew member, pilot, balloon or chase vehicle in '
+        'production-facing copy. Lower-case protocol fields, route paths and '
+        'widget keys remain as documented compatibility identifiers.\n\n'
+        '${violations.join('\n')}',
+      );
+    }
+  });
+}
+
+final _forbidden = RegExp(
+  r'\b(?:ride|rider|leader|bike|motorcycle)s?\b',
+  caseSensitive: false,
+);
+
+final _technicalIdentifier = RegExp(r'^[a-z0-9_./:@?&=${}%-]+$');
+
+bool _isDocumentedTechnicalLiteral(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return true;
+  final withoutInterpolation = trimmed
+      .replaceAll(r'${…}', 'value')
+      .replaceAll(r'$…', 'value');
+  if (_technicalIdentifier.hasMatch(withoutInterpolation)) return true;
+  if (trimmed.startsWith('RideJoinPayload(')) return true;
+  if (trimmed == 'Ride:') return true;
+  if (trimmed.startsWith('tail-end-charlie-rider-v1')) return true;
+  // Diagnostic palette names are developer-facing assertions, not copy.
+  if (const {
+    'own rider',
+    'rider green',
+    'rider orange',
+    'rider yellow',
+    'rider teal',
+    'rider pink',
+    'rider cyan',
+    'rider amber',
+    'rider crimson',
+    'alerting rider',
+    'leader trail',
+  }.contains(trimmed.toLowerCase())) {
+    return true;
+  }
+  return false;
+}
+
+class _DartString {
+  const _DartString(this.value, this.line);
+
+  final String value;
+  final int line;
+}
+
+/// Extracts Dart string literals while skipping comments.
+///
+/// This deliberately small lexer is sufficient for the production sources and
+/// catches adjacent/multiline copy that a line-based grep misses. Interpolation
+/// is retained because its surrounding words are still user-visible copy.
+Iterable<_DartString> _dartStrings(String source) sync* {
+  var index = 0;
+  var line = 1;
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      final end = source.indexOf('\n', index + 2);
+      if (end == -1) return;
+      index = end;
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      final end = source.indexOf('*/', index + 2);
+      if (end == -1) return;
+      line += '\n'.allMatches(source.substring(index, end + 2)).length;
+      index = end + 2;
+      continue;
+    }
+
+    final character = source[index];
+    if (character == '\n') {
+      line += 1;
+      index += 1;
+      continue;
+    }
+    if (character != "'" && character != '"') {
+      index += 1;
+      continue;
+    }
+
+    final startedAtLine = line;
+    final quote = character;
+    final triple = source.startsWith(quote * 3, index);
+    final delimiter = triple ? quote * 3 : quote;
+    final raw = index > 0 && source[index - 1] == 'r';
+    index += delimiter.length;
+    final value = StringBuffer();
+    while (index < source.length) {
+      if (source.startsWith(delimiter, index)) {
+        index += delimiter.length;
+        break;
+      }
+      final current = source[index];
+      if (!raw && current == r'\' && index + 1 < source.length) {
+        value
+          ..write(current)
+          ..write(source[index + 1]);
+        index += 2;
+        continue;
+      }
+      if (!raw && current == r'$' && index + 1 < source.length) {
+        final next = source[index + 1];
+        if (next == '{') {
+          final skipped = _skipInterpolation(source, index + 2, line);
+          index = skipped.index;
+          line = skipped.line;
+          value.write(r'${…}');
+          continue;
+        }
+        if (RegExp(r'[A-Za-z_]').hasMatch(next)) {
+          index += 2;
+          while (index < source.length &&
+              RegExp(r'[A-Za-z0-9_]').hasMatch(source[index])) {
+            index += 1;
+          }
+          value.write(r'$…');
+          continue;
+        }
+      }
+      if (current == '\n') line += 1;
+      value.write(current);
+      index += 1;
+    }
+    yield _DartString(value.toString(), startedAtLine);
+  }
+}
+
+({int index, int line}) _skipInterpolation(String source, int index, int line) {
+  var depth = 1;
+  while (index < source.length && depth > 0) {
+    if (source.startsWith('//', index)) {
+      final end = source.indexOf('\n', index + 2);
+      if (end == -1) return (index: source.length, line: line);
+      index = end;
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      final end = source.indexOf('*/', index + 2);
+      if (end == -1) return (index: source.length, line: line);
+      line += '\n'.allMatches(source.substring(index, end + 2)).length;
+      index = end + 2;
+      continue;
+    }
+    final current = source[index];
+    if (current == "'" || current == '"') {
+      final delimiter = source.startsWith(current * 3, index)
+          ? current * 3
+          : current;
+      index += delimiter.length;
+      while (index < source.length && !source.startsWith(delimiter, index)) {
+        if (source[index] == r'\' && index + 1 < source.length) {
+          index += 2;
+          continue;
+        }
+        if (source[index] == '\n') line += 1;
+        index += 1;
+      }
+      index += delimiter.length;
+      continue;
+    }
+    if (current == '{') depth += 1;
+    if (current == '}') depth -= 1;
+    if (current == '\n') line += 1;
+    index += 1;
+  }
+  return (index: index, line: line);
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -14,6 +14,7 @@ import 'package:balloon_crumbs/controllers/speed_limit_display_controller.dart';
 import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/distance_unit.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/map_style_mode.dart';
 import 'package:balloon_crumbs/domain/completed_ride_store.dart';
 import 'package:balloon_crumbs/domain/recorded_route_store.dart';
@@ -511,8 +512,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Oliver'), findsOneWidget);
-    expect(find.text('Flight actions'), findsOneWidget);
-    expect(find.text('Alerts and reports'), findsOneWidget);
+    expect(find.text('Pilot flight deck'), findsOneWidget);
+    expect(find.byKey(const Key('airborne-live-telemetry')), findsOneWidget);
+    expect(find.byKey(const Key('role-wind-summary')), findsOneWidget);
+    expect(find.text('Pilot controls'), findsOneWidget);
+    expect(find.text('Road alerts and reports'), findsNothing);
     expect(find.text('Share flight summary'), findsOneWidget);
     expect(find.text('Flight crew'), findsWidgets);
     expect(find.text('Navigation map'), findsNothing);
@@ -544,7 +548,7 @@ void main() {
     controller.dispose();
   });
 
-  testWidgets('alerts are a Ride action rather than a primary destination', (
+  testWidgets('road alerts are hidden from the pilot flight view', (
     tester,
   ) async {
     final controller = await _controller();
@@ -557,19 +561,40 @@ void main() {
     expect(find.text('Alerts'), findsNothing);
     await tester.tap(find.byIcon(Icons.air_outlined));
     await tester.pumpAndSettle();
-    final alerts = find.byKey(const Key('ride-actions-alerts'));
-    await tester.scrollUntilVisible(
-      alerts,
-      260,
-      scrollable: find.byType(Scrollable).first,
+    expect(find.byKey(const Key('ride-actions-alerts')), findsNothing);
+    expect(find.text('Pilot controls'), findsOneWidget);
+  });
+
+  testWidgets('a chase driver gets road controls instead of airborne data', (
+    tester,
+  ) async {
+    final controller = await _controller(
+      rideCodeDirectory: const _SuccessfulRideCodeDirectory(),
     );
-    await tester.tap(alerts);
+    await controller.joinRide(
+      '123456',
+      'Nigel',
+      flightRole: FlightRole.chaseDriver,
+      vehicleLabel: 'Land Rover',
+    );
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(_app(controller));
     await tester.pumpAndSettle();
 
-    expect(find.text('Alerts'), findsOneWidget);
-    expect(find.text('ROAD ALERTS'), findsOneWidget);
-    expect(find.text('EXTERNAL SOURCES'), findsNothing);
-    expect(find.text('RIDER STATUS'), findsNothing);
+    await tester.tap(find.byIcon(Icons.air_outlined));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Driver navigation'), findsOneWidget);
+    expect(find.text('Driver controls'), findsOneWidget);
+    expect(find.byKey(const Key('role-chase-target')), findsOneWidget);
+    expect(find.byKey(const Key('role-road-route-summary')), findsOneWidget);
+    expect(find.byKey(const Key('ride-actions-alerts')), findsOneWidget);
+    expect(find.byKey(const Key('airborne-live-telemetry')), findsNothing);
+    expect(find.byKey(const Key('role-wind-summary')), findsNothing);
+    expect(
+      find.byKey(const Key('flight-menu-change-landing-zone')),
+      findsNothing,
+    );
   });
 
   testWidgets('embedded Settings keeps the active ride behind nested editors', (

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -217,7 +217,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('planned-route-code-field')), findsOneWidget);
-    expect(find.text('Planned route code (optional)'), findsOneWidget);
+    expect(find.text('Forecast plan code (optional)'), findsOneWidget);
     await tester.enterText(
       find.byKey(const Key('planned-route-code-field')),
       'AB12CD34',
@@ -607,7 +607,7 @@ void main() {
     await tester.pumpWidget(_app(controller));
     await tester.pumpAndSettle();
 
-    expect(find.text('Waiting to start'), findsOneWidget);
+    expect(find.text('Waiting for launch'), findsOneWidget);
     expect(find.textContaining('Current positions only'), findsOneWidget);
     expect(find.byKey(const Key('pre-start-roster')), findsOneWidget);
     expect(find.textContaining('Oliver (you)'), findsOneWidget);
@@ -620,13 +620,16 @@ void main() {
     await tester.tap(find.byKey(const Key('start-ride-button')));
     await tester.pumpAndSettle();
     expect(find.text('Start this flight?'), findsOneWidget);
-    expect(find.textContaining('No route is selected'), findsOneWidget);
+    expect(
+      find.textContaining('No forecast plan or chase route is selected'),
+      findsOneWidget,
+    );
 
     await tester.tap(find.byKey(const Key('start-without-route-button')));
     await tester.pumpAndSettle();
 
     expect(controller.rideStarted, isTrue);
-    expect(find.text('Waiting to start'), findsNothing);
+    expect(find.text('Waiting for launch'), findsNothing);
     expect(find.text('Navigation map'), findsOneWidget);
   });
 

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -4,6 +4,7 @@ import {
   WIND_LEVELS_METRES_MSL,
   altitudeForFlightFraction,
   buildFlightPlanGpx,
+  buildForecastPlanDocument,
   circlePolygon,
   forecastDistanceMetres,
   forecastLandingEnvelope,
@@ -1228,6 +1229,23 @@ function optionalNumber(element) {
   return value;
 }
 
+function windFieldDigest(field) {
+  const input = JSON.stringify({
+    validAt: field?.validAt,
+    requestedAt: field?.requestedAt,
+    columns: (field?.columns ?? []).map((column) => ({
+      position: column.position,
+      vectors: column.vectors,
+    })),
+  });
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a32:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
 function addAltitudeBoundary() {
   try {
     const { label, source } = boundaryLabelAndSource();
@@ -1283,10 +1301,38 @@ async function generatePlanCode() {
       forecastLanding: state.forecastLanding,
       intendedLanding: state.intendedLanding,
     });
+    const forecastTimes = (state.field.timeSlices ?? [])
+      .map((slice) => slice.validAt)
+      .filter((value) => value instanceof Date && !Number.isNaN(value.getTime()))
+      .sort((first, second) => first - second);
+    const forecastPlan = buildForecastPlanDocument({
+      id: globalThis.crypto?.randomUUID?.() ?? `plan-${Date.now()}`,
+      name,
+      createdAt: new Date(),
+      launch: state.launch,
+      launchElevationMetresMsl: Number(elements.launch_elevation.value),
+      intendedLanding: state.intendedLanding,
+      intendedLandingRadiusMetres: INTENDED_AREA_RADIUS_METRES,
+      forecastLanding: state.forecastLanding,
+      routePlan: state.routePlan,
+      landingEnvelope: state.landingEnvelope,
+      wind: {
+        provider: "Open-Meteo",
+        model: "UKMO seamless",
+        requestedAt: state.field.requestedAt,
+        validFrom: forecastTimes[0] ?? state.field.validAt,
+        validTo: forecastTimes.at(-1) ?? state.field.validAt,
+        attribution: "Weather data by Open-Meteo",
+        licence: "CC BY 4.0",
+        fieldDigest: windFieldDigest(state.field),
+      },
+      operationalBoundaries: state.operationalBoundaries,
+      gpxFallback: gpx,
+    });
     const response = await fetch("/api/v1/plans", {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ name, gpx }),
+      body: JSON.stringify({ name, gpx, forecastPlan }),
     });
     const body = await response.json().catch(() => ({}));
     if (!response.ok) throw new Error(body.error || `Relay returned ${response.status}.`);

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -1226,6 +1226,173 @@ export function buildFlightPlanGpx({
   );
 }
 
+function isoDate(value, label) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) throw new TypeError(`${label} is invalid.`);
+  return date.toISOString();
+}
+
+/// Builds the versioned evidence document consumed by the mobile app.
+///
+/// GPX remains inside the document and beside it in the relay request so older
+/// clients can still import the forecast line. The structured fields retain
+/// the choices and provenance that GPX cannot express.
+export function buildForecastPlanDocument({
+  id,
+  name,
+  createdAt = new Date(),
+  launch,
+  launchElevationMetresMsl,
+  intendedLanding,
+  intendedLandingRadiusMetres,
+  forecastLanding,
+  routePlan,
+  landingEnvelope = [],
+  wind,
+  operationalBoundaries = [],
+  gpxFallback,
+}) {
+  if (!routePlan?.track || routePlan.track.length < 2) {
+    throw new Error("A planned forecast track is required.");
+  }
+  if (typeof gpxFallback !== "string" || !gpxFallback) {
+    throw new Error("A GPX fallback is required.");
+  }
+  const safeName = String(name || "Forecast balloon flight").trim().slice(0, 200);
+  const created = isoDate(createdAt, "Plan creation time");
+  const departureAt = new Date(routePlan.departureAt);
+  if (Number.isNaN(departureAt.getTime())) throw new TypeError("Departure time is invalid.");
+  const launchPoint = validPoint(launch, "launch");
+  const intendedPoint = validPoint(intendedLanding, "intended landing");
+  const forecastPoint = validPoint(forecastLanding, "forecast landing");
+  const launchAltitude = finiteNumber(launchElevationMetresMsl, "launch elevation");
+  const durationMinutes = finiteNumber(routePlan.durationMinutes, "flight duration");
+  const fractions = ROUTE_CONTROL_FRACTIONS;
+  const stageAltitudes =
+    routePlan.kind === "representative"
+      ? fractions.map((fraction) =>
+          altitudeForFlightFraction({
+            fraction,
+            launchElevationMetresMsl: launchAltitude,
+            maximumAltitudeMetresMsl: routePlan.peakAltitudeMetresMsl,
+          }),
+        )
+      : [launchAltitude, ...routePlan.controlAltitudesMetresMsl, launchAltitude];
+  const altitudeStages = fractions.map((fraction, index) => {
+    const altitudeMsl = finiteNumber(stageAltitudes[index], `stage ${index + 1} altitude`);
+    const previous = index === 0 ? altitudeMsl : stageAltitudes[index - 1];
+    const stageSeconds = index === 0 ? 1 : durationMinutes * 60 * 0.2;
+    return {
+      fraction,
+      plannedAt: new Date(
+        departureAt.getTime() + durationMinutes * fraction * 60_000,
+      ).toISOString(),
+      altitudeMsl,
+      changeRateMps: index === 0 ? 0 : (altitudeMsl - previous) / stageSeconds,
+    };
+  });
+  const constraints = {
+    altitudeCeilingMsl: finiteNumber(routePlan.altitudeCeilingMetresMsl, "altitude ceiling"),
+    maximumAscentRateMps: finiteNumber(
+      routePlan.maximumAscentRateMetresPerSecond,
+      "maximum ascent rate",
+    ),
+    maximumDescentRateMps: finiteNumber(
+      routePlan.maximumDescentRateMetresPerSecond,
+      "maximum descent rate",
+    ),
+    minimumDurationMinutes: finiteNumber(
+      routePlan.minimumDurationMinutes ?? durationMinutes,
+      "minimum duration",
+    ),
+    maximumDurationMinutes: finiteNumber(
+      routePlan.maximumDurationMinutes ?? durationMinutes,
+      "maximum duration",
+    ),
+  };
+  const normalisedWind = {
+    provider: String(wind?.provider ?? "").trim(),
+    model: String(wind?.model ?? "").trim(),
+    requestedAt: isoDate(wind?.requestedAt, "Wind request time"),
+    validFrom: isoDate(wind?.validFrom, "Wind validity start"),
+    validTo: isoDate(wind?.validTo, "Wind validity end"),
+    attribution: String(wind?.attribution ?? "").trim(),
+    licence: String(wind?.licence ?? "").trim(),
+    forecastOnly: true,
+    fieldDigest: String(wind?.fieldDigest ?? "").trim(),
+  };
+  if (
+    !normalisedWind.provider ||
+    !normalisedWind.model ||
+    !normalisedWind.attribution ||
+    !normalisedWind.licence ||
+    !normalisedWind.fieldDigest
+  ) {
+    throw new Error("Wind provenance is incomplete.");
+  }
+  const updatedAt = created;
+  const boundaries = operationalBoundaries.map((boundary) => ({
+    ...normaliseOperationalBoundary(boundary),
+    updatedAt: isoDate(boundary.updatedAt ?? updatedAt, "Boundary update time"),
+  }));
+  const reachesDestination = routePlan.reachesDestination;
+  const missDistanceMetres = routePlan.missDistanceMetres;
+  return Object.freeze({
+    schemaVersion: 1,
+    id: String(id || "").trim().slice(0, 128),
+    name: safeName,
+    createdAt: created,
+    source: "Balloon Crumbs web planner",
+    launch: {
+      point: launchPoint,
+      elevationMsl: launchAltitude,
+      datum: "wgs84Geoid",
+    },
+    destination: {
+      point: intendedPoint,
+      toleranceMetres: routePlan.acceptedMissDistanceMetres ?? 100,
+    },
+    intendedLandingArea: {
+      centre: intendedPoint,
+      radiusMetres: finiteNumber(intendedLandingRadiusMetres, "landing area radius"),
+      polygon: [],
+      updatedAt,
+    },
+    forecastLanding: forecastPoint,
+    departure: {
+      selectedAt: departureAt.toISOString(),
+      ...(routePlan.departureWindow
+        ? {
+            matchingWindowStart: isoDate(
+              routePlan.departureWindow.startAt,
+              "Matching window start",
+            ),
+            matchingWindowEnd: isoDate(
+              routePlan.departureWindow.endAt,
+              "Matching window end",
+            ),
+          }
+        : {}),
+    },
+    constraints,
+    altitudeStages,
+    plannedTrack: routePlan.track.map((point) => ({
+      ...validPoint(point, "planned track point"),
+      altitudeMsl: finiteNumber(point.altitudeMetresMsl, "planned track altitude"),
+      elapsedSeconds: finiteNumber(point.elapsedSeconds, "planned track time"),
+    })),
+    landingEnvelope: landingEnvelope.map((point) => validPoint(point, "landing envelope")),
+    wind: normalisedWind,
+    operationalBoundaries: boundaries,
+    result: {
+      kind: routePlan.kind === "representative" ? "representative" : "optimised",
+      ...(typeof reachesDestination === "boolean" ? { reachesDestination } : {}),
+      ...(Number.isFinite(missDistanceMetres) ? { missDistanceMetres } : {}),
+    },
+    gpxFallback,
+  });
+}
+
 export function forecastDistanceMetres(track) {
   let total = 0;
   for (let index = 1; index < track.length; index += 1) {

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -9,6 +9,7 @@ import {
   altitudeForProfileFraction,
   altitudeForStrategyFraction,
   buildFlightPlanGpx,
+  buildForecastPlanDocument,
   circlePolygon,
   forecastAltitudeProfileTrack,
   forecastLandingEnvelope,
@@ -23,6 +24,79 @@ import {
   vectorAtPosition,
   windForecastGrid,
 } from "./planner-core.mjs";
+
+test("structured plans retain constraints, stages, envelope and wind provenance", () => {
+  const departureAt = new Date("2026-08-23T07:00:00Z");
+  const routePlan = {
+    kind: "optimised",
+    departureAt,
+    departureWindow: {
+      startAt: new Date("2026-08-23T06:55:00Z"),
+      endAt: new Date("2026-08-23T07:05:00Z"),
+    },
+    durationMinutes: 60,
+    altitudeCeilingMetresMsl: 1200,
+    maximumAscentRateMetresPerSecond: 3,
+    maximumDescentRateMetresPerSecond: 4,
+    minimumDurationMinutes: 10,
+    maximumDurationMinutes: 180,
+    acceptedMissDistanceMetres: 100,
+    reachesDestination: true,
+    missDistanceMetres: 42,
+    controlAltitudesMetresMsl: [200, 400, 600, 300],
+    track: [
+      { latitude: 51.5, longitude: -2.6, altitudeMetresMsl: 80, elapsedSeconds: 0 },
+      { latitude: 51.6, longitude: -2.4, altitudeMetresMsl: 80, elapsedSeconds: 3600 },
+    ],
+  };
+  const gpxFallback = buildFlightPlanGpx({
+    name: "Sunday flight",
+    track: routePlan.track,
+    departureAt,
+    launch: routePlan.track[0],
+    forecastLanding: routePlan.track[1],
+    intendedLanding: routePlan.track[1],
+  });
+  const document = buildForecastPlanDocument({
+    id: "plan-1",
+    name: "Sunday flight",
+    createdAt: new Date("2026-08-23T06:00:00Z"),
+    launch: routePlan.track[0],
+    launchElevationMetresMsl: 80,
+    intendedLanding: routePlan.track[1],
+    intendedLandingRadiusMetres: 400,
+    forecastLanding: routePlan.track[1],
+    routePlan,
+    landingEnvelope: [
+      { latitude: 51.59, longitude: -2.41 },
+      { latitude: 51.61, longitude: -2.41 },
+      { latitude: 51.60, longitude: -2.39 },
+    ],
+    wind: {
+      provider: "Open-Meteo",
+      model: "UKMO seamless",
+      requestedAt: new Date("2026-08-23T06:00:00Z"),
+      validFrom: new Date("2026-08-23T06:00:00Z"),
+      validTo: new Date("2026-08-24T06:00:00Z"),
+      attribution: "Weather data by Open-Meteo",
+      licence: "CC BY 4.0",
+      fieldDigest: "fnv1a32:12345678",
+    },
+    operationalBoundaries: [],
+    gpxFallback,
+  });
+
+  assert.equal(document.schemaVersion, 1);
+  assert.equal(document.altitudeStages.length, 6);
+  assert.deepEqual(
+    document.altitudeStages.map((stage) => stage.altitudeMsl),
+    [80, 200, 400, 600, 300, 80],
+  );
+  assert.equal(document.constraints.maximumDescentRateMps, 4);
+  assert.equal(document.landingEnvelope.length, 3);
+  assert.equal(document.wind.forecastOnly, true);
+  assert.equal(document.gpxFallback, gpxFallback);
+});
 
 function payload({ direction = 270, speed = 36 } = {}) {
   const hourly = { time: ["2026-08-21T08:00", "2026-08-21T09:00"] };

--- a/apps/server/src/balloon_crumbs_server/app.py
+++ b/apps/server/src/balloon_crumbs_server/app.py
@@ -518,7 +518,19 @@ def create_app(
         except (ValidationError, json.JSONDecodeError, UnicodeDecodeError) as error:
             raise RelayServiceError(400, "Malformed plan request") from error
 
-        result = service.create_plan(session, name=parsed.name, gpx=parsed.gpx)
+        result = service.create_plan(
+            session,
+            name=parsed.name,
+            gpx=parsed.gpx,
+            forecast_plan=(
+                parsed.forecastPlan.model_dump(mode="json")
+                if parsed.forecastPlan is not None
+                else None
+            ),
+            forecast_plan_point_count=(
+                parsed.forecastPlan.geometry_point_count() if parsed.forecastPlan is not None else 0
+            ),
+        )
         plan_requests.labels(outcome="created").inc()
         return JSONResponse(content=CreatePlanResponse.model_validate(result).model_dump())
 

--- a/apps/server/src/balloon_crumbs_server/config.py
+++ b/apps/server/src/balloon_crumbs_server/config.py
@@ -93,6 +93,10 @@ class Settings(BaseSettings):
             # nobody shares one carries no numbers at all. Named so a client can
             # report the limitation instead of appearing to have shared.
             "rider-contact-sharing-v1",
+            # Explicit two-party balloon pilot transfer. Older relays reject
+            # the additive event names, so this is negotiated rather than
+            # letting a client appear to complete a local-only handover.
+            "pilot-handover-v1",
             # The leader un-ending a ride that ended by mistake. Named so a
             # client facing an older relay hides the action rather than putting
             # its leader back on the map while every other rider still sees a

--- a/apps/server/src/balloon_crumbs_server/models.py
+++ b/apps/server/src/balloon_crumbs_server/models.py
@@ -78,7 +78,7 @@ class RideJoinCode(Base):
 
 
 class RidePlan(Base):
-    """An encrypted, pre-ride GPX route behind a short lookup code.
+    """An encrypted, pre-ride forecast plan behind a short lookup code.
 
     Unrelated to the live ride/join-code tables: a plan never carries a ride
     secret and a fetched plan never claims a ride. The phone that loads one
@@ -90,6 +90,9 @@ class RidePlan(Base):
 
     code: Mapped[str] = mapped_column(String(16), primary_key=True)
     name: Mapped[str | None] = mapped_column(String(200))
+    # Kept under its deployed column name. Older rows decrypt to a GPX string;
+    # structured rows decrypt to {gpx, forecastPlan}, so no plaintext migration
+    # or compatibility-breaking schema change is required.
     gpx_ciphertext: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/apps/server/src/balloon_crumbs_server/schemas.py
+++ b/apps/server/src/balloon_crumbs_server/schemas.py
@@ -230,11 +230,183 @@ class TrafficRerouteRequest(BaseModel):
         return cleaned
 
 
+class ForecastPlanPoint(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    latitude: float = Field(ge=-90, le=90)
+    longitude: float = Field(ge=-180, le=180)
+
+
+class ForecastPlanLaunch(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    point: ForecastPlanPoint
+    elevationMsl: float = Field(ge=-500, le=20_000)
+    datum: str = Field(min_length=1, max_length=64)
+
+
+class ForecastPlanDestination(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    point: ForecastPlanPoint
+    toleranceMetres: float = Field(gt=0, le=100_000)
+
+
+class ForecastPlanLandingArea(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    centre: ForecastPlanPoint
+    radiusMetres: float | None = Field(default=None, gt=0, le=100_000)
+    polygon: list[ForecastPlanPoint] = Field(default_factory=list, max_length=512)
+    updatedAt: datetime
+
+    @model_validator(mode="after")
+    def has_bounded_area(self) -> ForecastPlanLandingArea:
+        if self.radiusMetres is None and len(self.polygon) < 3:
+            raise ValueError("An intended landing area needs a radius or polygon")
+        return self
+
+
+class ForecastPlanDeparture(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    selectedAt: datetime
+    matchingWindowStart: datetime | None = None
+    matchingWindowEnd: datetime | None = None
+
+    @model_validator(mode="after")
+    def window_is_ordered(self) -> ForecastPlanDeparture:
+        if (
+            self.matchingWindowStart is not None
+            and self.matchingWindowEnd is not None
+            and self.matchingWindowEnd < self.matchingWindowStart
+        ):
+            raise ValueError("The matching departure window is reversed")
+        return self
+
+
+class ForecastPlanConstraints(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    altitudeCeilingMsl: float = Field(ge=-500, le=20_000)
+    maximumAscentRateMps: float = Field(gt=0, le=30)
+    maximumDescentRateMps: float = Field(gt=0, le=30)
+    minimumDurationMinutes: float = Field(gt=0, le=24 * 60)
+    maximumDurationMinutes: float = Field(gt=0, le=24 * 60)
+
+    @model_validator(mode="after")
+    def durations_are_ordered(self) -> ForecastPlanConstraints:
+        if self.maximumDurationMinutes < self.minimumDurationMinutes:
+            raise ValueError("Maximum duration must not precede minimum duration")
+        return self
+
+
+class ForecastPlanStage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    fraction: float = Field(ge=0, le=1)
+    plannedAt: datetime
+    altitudeMsl: float = Field(ge=-500, le=20_000)
+    changeRateMps: float = Field(ge=-30, le=30)
+
+
+class ForecastPlanTrackPoint(ForecastPlanPoint):
+    altitudeMsl: float = Field(ge=-500, le=20_000)
+    elapsedSeconds: float = Field(ge=0, le=24 * 60 * 60)
+
+
+class ForecastPlanWind(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    provider: str = Field(min_length=1, max_length=120)
+    model: str = Field(min_length=1, max_length=120)
+    requestedAt: datetime
+    validFrom: datetime
+    validTo: datetime
+    attribution: str = Field(min_length=1, max_length=500)
+    licence: str = Field(min_length=1, max_length=500)
+    forecastOnly: Literal[True]
+    fieldDigest: str = Field(min_length=1, max_length=128)
+
+
+class ForecastPlanBoundary(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1, max_length=96)
+    label: str = Field(min_length=1, max_length=96)
+    kind: Literal["line", "area", "altitudeBand"]
+    points: list[ForecastPlanPoint] = Field(default_factory=list, max_length=512)
+    source: str = Field(min_length=1, max_length=160)
+    updatedAt: datetime
+    lowerAltitudeMeters: float | None = Field(default=None, ge=-500, le=20_000)
+    upperAltitudeMeters: float | None = Field(default=None, ge=-500, le=20_000)
+    altitudeDatum: str = Field(min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def geometry_matches_kind(self) -> ForecastPlanBoundary:
+        if self.kind == "line" and len(self.points) < 2:
+            raise ValueError("A boundary line needs two points")
+        if self.kind == "area" and len(self.points) < 3:
+            raise ValueError("A boundary area needs three points")
+        if self.kind == "altitudeBand" and self.points:
+            raise ValueError("An altitude band cannot contain points")
+        if (
+            self.lowerAltitudeMeters is not None
+            and self.upperAltitudeMeters is not None
+            and self.lowerAltitudeMeters >= self.upperAltitudeMeters
+        ):
+            raise ValueError("Boundary altitude limits are reversed")
+        return self
+
+
+class ForecastPlanResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    kind: str = Field(min_length=1, max_length=80)
+    reachesDestination: bool | None = None
+    missDistanceMetres: float | None = Field(default=None, ge=0, le=50_000_000)
+
+
+class ForecastPlanDocument(BaseModel):
+    """Bounded version-one planner evidence; additive fields are ignored."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    schemaVersion: Literal[1]
+    id: str = Field(min_length=1, max_length=128)
+    name: str = Field(min_length=1, max_length=200)
+    createdAt: datetime
+    expiresAt: datetime | None = None
+    source: Literal["Balloon Crumbs web planner"]
+    launch: ForecastPlanLaunch
+    destination: ForecastPlanDestination | None = None
+    intendedLandingArea: ForecastPlanLandingArea
+    forecastLanding: ForecastPlanPoint
+    departure: ForecastPlanDeparture
+    constraints: ForecastPlanConstraints
+    altitudeStages: list[ForecastPlanStage] = Field(min_length=2, max_length=32)
+    plannedTrack: list[ForecastPlanTrackPoint] = Field(min_length=2, max_length=20_000)
+    landingEnvelope: list[ForecastPlanPoint] = Field(default_factory=list, max_length=512)
+    wind: ForecastPlanWind
+    operationalBoundaries: list[ForecastPlanBoundary] = Field(default_factory=list, max_length=64)
+    result: ForecastPlanResult
+    gpxFallback: str = Field(min_length=1)
+
+    def geometry_point_count(self) -> int:
+        return (
+            len(self.plannedTrack)
+            + len(self.landingEnvelope)
+            + len(self.intendedLandingArea.polygon)
+            + sum(len(boundary.points) for boundary in self.operationalBoundaries)
+        )
+
+
 class CreatePlanRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = Field(default=None, max_length=200)
     gpx: str = Field(min_length=1)
+    forecastPlan: ForecastPlanDocument | None = None
 
 
 class CreatePlanResponse(BaseModel):
@@ -250,6 +422,7 @@ class GetPlanResponse(BaseModel):
     code: str
     name: str | None
     gpx: str
+    forecastPlan: dict[str, Any] | None = None
     createdAt: str
     expiresAt: str
 

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -563,6 +563,8 @@ class RelayService:
         *,
         name: str | None,
         gpx: str,
+        forecast_plan: dict[str, Any] | None = None,
+        forecast_plan_point_count: int = 0,
         now: datetime | None = None,
     ) -> dict[str, str]:
         """A plan is unrelated to the live ride/join-code tables: it never
@@ -580,12 +582,22 @@ class RelayService:
             )
         except GpxValidationError as error:
             raise RelayServiceError(400, str(error)) from error
+        if forecast_plan is not None:
+            if forecast_plan.get("gpxFallback") != gpx:
+                raise RelayServiceError(400, "Structured plan GPX fallback does not match")
+            if forecast_plan_point_count > self._settings.maximum_plan_points:
+                raise RelayServiceError(400, "Structured plan has too many geometry points")
         expires_at = now + timedelta(days=self._settings.plan_retention_days)
         with session.begin():
             session.execute(delete(RidePlan).where(RidePlan.expires_at <= now))
             for _ in range(8):
                 code = self._generate_plan_code()
-                ciphertext = self._cipher.encrypt_json(gpx, associated_data=self._plan_aad(code))
+                encrypted_value: str | dict[str, Any] = (
+                    gpx if forecast_plan is None else {"gpx": gpx, "forecastPlan": forecast_plan}
+                )
+                ciphertext = self._cipher.encrypt_json(
+                    encrypted_value, associated_data=self._plan_aad(code)
+                )
                 try:
                     with session.begin_nested():
                         session.add(
@@ -620,18 +632,29 @@ class RelayService:
                     session.delete(record)
                 raise RelayServiceError(404, "Plan not found")
             try:
-                gpx = self._cipher.decrypt_json(
+                decrypted = self._cipher.decrypt_json(
                     record.gpx_ciphertext,
                     associated_data=self._plan_aad(code),
                 )
             except ValueError as error:
                 raise RelayServiceError(500, "Plan record is invalid") from error
-            if not isinstance(gpx, str):
+            if isinstance(decrypted, str):
+                gpx = decrypted
+                forecast_plan = None
+            elif isinstance(decrypted, dict):
+                gpx = decrypted.get("gpx")
+                forecast_plan = decrypted.get("forecastPlan")
+            else:
+                raise RelayServiceError(500, "Plan record is invalid")
+            if not isinstance(gpx, str) or (
+                forecast_plan is not None and not isinstance(forecast_plan, dict)
+            ):
                 raise RelayServiceError(500, "Plan record is invalid")
             return {
                 "code": record.code,
                 "name": record.name,
                 "gpx": gpx,
+                "forecastPlan": forecast_plan,
                 "createdAt": self._as_utc(record.created_at).isoformat(),
                 "expiresAt": self._as_utc(record.expires_at).isoformat(),
             }

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -76,6 +76,9 @@ EVENT_TYPES = {
     "windContextNoted",
     "operationalBoundaryUpserted",
     "operationalBoundaryRemoved",
+    # One shared navigation target per chase vehicle. The relay carries the
+    # choice; each vehicle still computes and validates its own road route.
+    "chaseGuidanceTargetSelected",
     # Issues #206/#207. The leader saying a ride that ended has not finished
     # after all. Deliberately not "rideResumed", which is the other half of
     # "ridePaused"; conflating them would make a pause look like a resurrection.
@@ -1016,6 +1019,7 @@ class RelayService:
             "windContextNoted": timedelta(hours=72),
             "operationalBoundaryUpserted": timedelta(hours=72),
             "operationalBoundaryRemoved": timedelta(hours=72),
+            "chaseGuidanceTargetSelected": timedelta(hours=72),
             # Who was asked to cover the back of the group, and what they said.
             # Ride-scoped coordination, not history worth keeping for days.
         }.get(event_type, timedelta(hours=72))

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -79,6 +79,11 @@ EVENT_TYPES = {
     # One shared navigation target per chase vehicle. The relay carries the
     # choice; each vehicle still computes and validates its own road route.
     "chaseGuidanceTargetSelected",
+    # Pilot authority changes only after a signed offer from the current pilot
+    # and a signed acceptance from the named balloon-crew device. The relay is
+    # deliberately payload-opaque; clients validate and reduce the pair.
+    "pilotHandoverOffered",
+    "pilotHandoverAccepted",
     # Issues #206/#207. The leader saying a ride that ended has not finished
     # after all. Deliberately not "rideResumed", which is the other half of
     # "ridePaused"; conflating them would make a pause look like a resurrection.
@@ -1043,6 +1048,8 @@ class RelayService:
             "operationalBoundaryUpserted": timedelta(hours=72),
             "operationalBoundaryRemoved": timedelta(hours=72),
             "chaseGuidanceTargetSelected": timedelta(hours=72),
+            "pilotHandoverOffered": timedelta(hours=72),
+            "pilotHandoverAccepted": timedelta(hours=72),
             # Who was asked to cover the back of the group, and what they said.
             # Ride-scoped coordination, not history worth keeping for days.
         }.get(event_type, timedelta(hours=72))

--- a/apps/server/tests/test_additive_event_types.py
+++ b/apps/server/tests/test_additive_event_types.py
@@ -210,6 +210,27 @@ def test_craft_events_are_accepted_and_relayed(client, synchronize, make_event) 
             event_type="chaseGuidanceTargetSelected",
             payload={"craftId": "v1", "target": "landingArea"},
         ),
+        make_event(
+            ride_id,
+            "event-pilot-offer",
+            event_type="pilotHandoverOffered",
+            payload={
+                "transferId": "transfer-1",
+                "fromDeviceId": "device-a",
+                "toDeviceId": "device-b",
+                "expiresAt": "2026-08-23T12:10:00Z",
+            },
+        ),
+        make_event(
+            ride_id,
+            "event-pilot-accept",
+            event_type="pilotHandoverAccepted",
+            payload={
+                "transferId": "transfer-1",
+                "fromDeviceId": "device-a",
+                "toDeviceId": "device-b",
+            },
+        ),
     ]
 
     uploaded = synchronize(client, ride_id=ride_id, secret=SECRET, events=shared)
@@ -232,6 +253,8 @@ def test_craft_structure_outlives_a_position_report() -> None:
         "craftPrimaryDeviceNominated",
         "craftChaseAssigned",
         "chaseGuidanceTargetSelected",
+        "pilotHandoverOffered",
+        "pilotHandoverAccepted",
     ):
         assert retention(event_type) > retention("riderLocationUpdated")
 

--- a/apps/server/tests/test_additive_event_types.py
+++ b/apps/server/tests/test_additive_event_types.py
@@ -204,6 +204,12 @@ def test_craft_events_are_accepted_and_relayed(client, synchronize, make_event) 
             event_type="craftChaseAssigned",
             payload={"craftId": "v1", "chasing": "balloon"},
         ),
+        make_event(
+            ride_id,
+            "event-chase-target",
+            event_type="chaseGuidanceTargetSelected",
+            payload={"craftId": "v1", "target": "landingArea"},
+        ),
     ]
 
     uploaded = synchronize(client, ride_id=ride_id, secret=SECRET, events=shared)
@@ -225,6 +231,7 @@ def test_craft_structure_outlives_a_position_report() -> None:
         "deviceAttachedToCraft",
         "craftPrimaryDeviceNominated",
         "craftChaseAssigned",
+        "chaseGuidanceTargetSelected",
     ):
         assert retention(event_type) > retention("riderLocationUpdated")
 

--- a/apps/server/tests/test_compatibility.py
+++ b/apps/server/tests/test_compatibility.py
@@ -10,6 +10,7 @@ CURRENT_CAPABILITIES = [
     "live-presence-v2",
     "membership-v1",
     "observer-access-v1",
+    "pilot-handover-v1",
     "pre-start-presence-v1",
     "push-notifications-v1",
     "ride-reopen-v1",

--- a/apps/server/tests/test_plans.py
+++ b/apps/server/tests/test_plans.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -17,10 +18,106 @@ GPX_TWO_POINTS = """<?xml version="1.0" encoding="UTF-8"?>
 </trkseg></trk></gpx>"""
 
 
-def _create(client, *, name: str | None = "Sunday loop", gpx: str = GPX_TWO_POINTS):
-    body: dict[str, str] = {"gpx": gpx}
+def _forecast_plan(gpx: str = GPX_TWO_POINTS) -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "id": "plan-2026-08-23",
+        "name": "Sunday flight",
+        "createdAt": "2026-08-23T06:00:00Z",
+        "source": "Balloon Crumbs web planner",
+        "launch": {
+            "point": {"latitude": 51.5, "longitude": -2.6},
+            "elevationMsl": 80,
+            "datum": "wgs84Geoid",
+        },
+        "destination": {
+            "point": {"latitude": 51.6, "longitude": -2.4},
+            "toleranceMetres": 100,
+        },
+        "intendedLandingArea": {
+            "centre": {"latitude": 51.6, "longitude": -2.4},
+            "radiusMetres": 400,
+            "updatedAt": "2026-08-23T06:00:00Z",
+        },
+        "forecastLanding": {"latitude": 51.599, "longitude": -2.401},
+        "departure": {
+            "selectedAt": "2026-08-23T07:00:00Z",
+            "matchingWindowStart": "2026-08-23T06:55:00Z",
+            "matchingWindowEnd": "2026-08-23T07:05:00Z",
+        },
+        "constraints": {
+            "altitudeCeilingMsl": 1200,
+            "maximumAscentRateMps": 3,
+            "maximumDescentRateMps": 4,
+            "minimumDurationMinutes": 10,
+            "maximumDurationMinutes": 180,
+        },
+        "altitudeStages": [
+            {
+                "fraction": 0,
+                "plannedAt": "2026-08-23T07:00:00Z",
+                "altitudeMsl": 80,
+                "changeRateMps": 0,
+            },
+            {
+                "fraction": 1,
+                "plannedAt": "2026-08-23T08:00:00Z",
+                "altitudeMsl": 80,
+                "changeRateMps": -1,
+            },
+        ],
+        "plannedTrack": [
+            {
+                "latitude": 51.5,
+                "longitude": -2.6,
+                "altitudeMsl": 80,
+                "elapsedSeconds": 0,
+            },
+            {
+                "latitude": 51.599,
+                "longitude": -2.401,
+                "altitudeMsl": 80,
+                "elapsedSeconds": 3600,
+            },
+        ],
+        "landingEnvelope": [
+            {"latitude": 51.59, "longitude": -2.41},
+            {"latitude": 51.61, "longitude": -2.41},
+            {"latitude": 51.60, "longitude": -2.39},
+        ],
+        "wind": {
+            "provider": "Open-Meteo",
+            "model": "UKMO seamless",
+            "requestedAt": "2026-08-23T06:00:00Z",
+            "validFrom": "2026-08-23T06:00:00Z",
+            "validTo": "2026-08-24T06:00:00Z",
+            "attribution": "Open-Meteo",
+            "licence": "CC BY 4.0",
+            "forecastOnly": True,
+            "fieldDigest": "sha256:test",
+        },
+        "operationalBoundaries": [],
+        "result": {
+            "kind": "optimised",
+            "reachesDestination": True,
+            "missDistanceMetres": 42,
+        },
+        "gpxFallback": gpx,
+    }
+
+
+def _create(
+    client,
+    *,
+    name: str | None = "Sunday loop",
+    gpx: str = GPX_TWO_POINTS,
+    forecast_plan: dict[str, Any] | None = None,
+):
+    body: dict[str, Any] = {"gpx": gpx}
     if name is not None:
         body["name"] = name
+    if forecast_plan is not None:
+        body["forecastPlan"] = forecast_plan
     return client.post("/api/v1/plans", json=body)
 
 
@@ -94,6 +191,31 @@ def test_plan_without_a_name_round_trips(client) -> None:
     assert fetched.json()["name"] is None
 
 
+def test_structured_forecast_plan_round_trips_with_gpx_fallback(client) -> None:
+    forecast_plan = _forecast_plan()
+    forecast_plan["futureAdditiveField"] = "ignored"
+    created = _create(client, forecast_plan=forecast_plan)
+    assert created.status_code == 200
+
+    fetched = client.get(f"/api/v1/plans/{created.json()['code']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["gpx"] == GPX_TWO_POINTS
+    assert fetched.json()["forecastPlan"]["schemaVersion"] == 1
+    assert fetched.json()["forecastPlan"]["constraints"]["altitudeCeilingMsl"] == 1200
+    assert "futureAdditiveField" not in fetched.json()["forecastPlan"]
+
+
+def test_structured_plan_rejects_unknown_schema_and_mismatched_fallback(client) -> None:
+    future = _forecast_plan()
+    future["schemaVersion"] = 2
+    assert _create(client, forecast_plan=future).status_code == 400
+
+    mismatched = _forecast_plan("<gpx>different</gpx>")
+    response = _create(client, forecast_plan=mismatched)
+    assert response.status_code == 400
+    assert "fallback" in response.json()["error"].lower()
+
+
 def test_unknown_plan_code_is_not_found(client) -> None:
     assert client.get("/api/v1/plans/ZZZZZZZZ").status_code == 404
 
@@ -113,13 +235,14 @@ def test_create_rejects_overlong_name(client) -> None:
 
 
 def test_plan_gpx_is_encrypted_at_rest(client) -> None:
-    created = _create(client)
+    created = _create(client, forecast_plan=_forecast_plan())
     factory = client.app.state.session_factory
     with factory() as session:
         stored = session.get(RidePlan, created.json()["code"])
         assert stored is not None
         assert b"51.5" not in stored.gpx_ciphertext
         assert b"Loop" not in stored.gpx_ciphertext
+        assert b"altitudeCeilingMsl" not in stored.gpx_ciphertext
 
 
 def test_expired_plan_is_not_found_and_purge_removes_it(client) -> None:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,11 @@
 # Initial Backlog
 
+The next coordinated implementation is specified in
+[role-specific live flight experience](role-specific-live-flight-experience.md).
+Its slices supersede implementing WP3/WP5/WP6/WP7/WP10b/WP11 independently:
+role and craft assignment, route-state separation and role-specific shells are
+prerequisites for bringing planner evidence into the live app safely.
+
 The GitHub issues mirror this ordered backlog. Priority is a product priority,
 not a claim that every P0 item is small. Work packages are defined in
 [delivery-plan.md](delivery-plan.md).

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -778,14 +778,14 @@ and a UI rebuild cannot change authority.
 
 ### P0.6 Airborne forecast context
 
-- [ ] Pilot/balloon crew see actual track, original forecast and intended area
+- [x] Pilot/balloon crew see actual track, original forecast and intended area
       with distinct non-colour styles.
-- [ ] Wind defaults to the balloon's altitude and can be changed/hidden.
-- [ ] Wind source, model, fetch/valid time, altitude, units and forecast warning
+- [x] Wind defaults to the balloon's altitude and can be changed/hidden.
+- [x] Wind source, model, fetch/valid time, altitude, units and forecast warning
       remain visible.
-- [ ] Planned altitude stages list time, height and rate and highlights the
+- [x] Planned altitude stages list time, height and rate and highlights the
       current stage without issuing a control command.
-- [ ] OpenAIP is role-gated, attributed and explicitly advisory/unavailable.
+- [x] OpenAIP is role-gated, attributed and explicitly advisory/unavailable.
 
 ### P0.7 Per-vehicle chase guidance
 
@@ -802,7 +802,7 @@ and a UI rebuild cannot change authority.
 ## P1 requirements
 
 - Live projected track and possible-landing envelope from current telemetry and
-  fresh wind, with JavaScript/Dart golden parity.
+  fresh wind are implemented in mobile; JavaScript/Dart golden parity remains.
 - Actual-versus-planned altitude chart and time-by-altitude wind table.
 - Intended-area divergence trend and explicit alternative comparison.
 - Landing inference and declared/inferred state presentation.
@@ -1020,10 +1020,10 @@ re-cutting authority or state ownership:
 
 Implementation can start when:
 
-- [ ] The seven decisions above are accepted or amended.
-- [ ] The role and permission matrix is accepted.
-- [ ] The four view definitions are accepted.
-- [ ] The structured `ForecastPlan` boundary is accepted.
-- [ ] The original/actual/live visual language is accepted.
-- [ ] The per-vehicle target model and initial reroute thresholds are accepted.
-- [ ] The slice order and P0/P1 boundary are accepted.
+- [x] The seven decisions above are accepted or amended.
+- [x] The role and permission matrix is accepted.
+- [x] The four view definitions are accepted.
+- [x] The structured `ForecastPlan` boundary is accepted.
+- [x] The original/actual/live visual language is accepted.
+- [x] The per-vehicle target model and initial reroute thresholds are accepted.
+- [x] The slice order and P0/P1 boundary are accepted.

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -728,13 +728,13 @@ and a UI rebuild cannot change authority.
 
 ### P0.1 Production roles and crafts
 
-- [ ] Creating a flight writes pilot role, balloon registration and device
+- [x] Creating a flight writes pilot role, balloon registration and device
       attachment before opening the flight view.
-- [ ] Joining requires an airborne/vehicle assignment and a compatible role.
-- [ ] Vehicle creation/selection is idempotent and persists through restart.
-- [ ] Three devices in one balloon produce one craft marker and track.
-- [ ] Invalid role/craft combinations open a repair flow, never a guessed view.
-- [ ] Pilot handover is explicit, accepted and journalled.
+- [x] Joining requires an airborne/vehicle assignment and a compatible role.
+- [x] Vehicle creation/selection is idempotent and persists through restart.
+- [x] Three devices in one balloon produce one craft marker and track.
+- [x] Invalid role/craft combinations open a repair flow, never a guessed view.
+- [x] Pilot handover is explicit, accepted and journalled.
 
 ### P0.2 Vocabulary migration
 
@@ -748,24 +748,24 @@ and a UI rebuild cannot change authority.
 
 ### P0.3 Distinct live experiences
 
-- [ ] Pilot and balloon crew never render speed limits, road alerts, turn
+- [x] Pilot and balloon crew never render speed limits, road alerts, turn
       guidance, road progress or navigation export.
-- [ ] Pilot can update landing intent; balloon crew sees it without authority.
-- [ ] Driver view keeps road instructions and speed information reachable at a
+- [x] Pilot can update landing intent; balloon crew sees it without authority.
+- [x] Driver view keeps road instructions and speed information reachable at a
       glance and hides airborne editing controls.
-- [ ] Chase crew sees the full tactical map and can control only its attached
+- [x] Chase crew sees the full tactical map and can control only its attached
       vehicle's target.
-- [ ] Role change updates the shell without losing flight or craft state.
+- [x] Role change updates the shell without losing flight or craft state.
 
 ### P0.4 Shared craft telemetry and tracks
 
-- [ ] Balloon and every chase vehicle location appears on every authorised
+- [x] Balloon and every chase vehicle location appears on every authorised
       device with fix age and live/relayed/stale/unknown state.
-- [ ] Each craft's actual track is shared and survives disconnect/reconnect.
-- [ ] Balloon track segments use the common altitude palette; missing altitude
+- [x] Each craft's actual track is shared and survives disconnect/reconnect.
+- [x] Balloon track segments use the common altitude palette; missing altitude
       is grey and described accessibly.
-- [ ] Chase tracks use craft identity styling and never inherit altitude colour.
-- [ ] Out-of-order or duplicate fixes cannot regress a craft position or track.
+- [x] Chase tracks use craft identity styling and never inherit altitude colour.
+- [x] Out-of-order or duplicate fixes cannot regress a craft position or track.
 
 ### P0.5 Structured planner plan
 

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -738,12 +738,12 @@ and a UI rebuild cannot change authority.
 
 ### P0.2 Vocabulary migration
 
-- [ ] A test scans all production user-visible strings and fails on whole-word
+- [x] A test scans all production user-visible strings and fails on whole-word
       `ride`, `rider`, `leader`, `bike` or `motorcycle`, excluding documented
       compatibility/debug fixtures.
-- [ ] Navigation labels, dialogs, snackbars, notifications, accessibility text,
+- [x] Navigation labels, dialogs, snackbars, notifications, accessibility text,
       CarPlay/Android projections and exports use flight/craft roles.
-- [ ] Internal legacy field names are documented and cannot be accidentally
+- [x] Internal legacy field names are documented and cannot be accidentally
       rendered directly.
 
 ### P0.3 Distinct live experiences

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -1,0 +1,1030 @@
+# Role-specific live flight experience
+
+Status: **Proposed implementation plan — no implementation starts until the
+decisions at the end of this document are accepted**
+
+Date: 23 August 2026
+
+Scope: iOS and Android live-flight experience, its shared domain state, and the
+contract used to bring web-planner forecasts into a running flight.
+
+## Executive summary
+
+Balloon Crumbs currently has pieces of a balloon product, but the production
+journey still runs through Tail End Charlie's two-role `lead` / `rider` session.
+The proper `FlightRole` and `Craft` models exist, yet no production create or
+join flow registers a balloon, registers a chase vehicle, attaches a device to
+a craft, or persists its flight role. As a result, real users do not reliably
+reach different balloon and chase experiences, and legacy terminology remains
+visible.
+
+The implementation must begin with the domain and assignment flow, not another
+layer of screen conditionals. Once every device has a real flight role and a
+craft, the app will provide four deliberately different live experiences:
+
+1. **Pilot:** an austere flight deck with actual telemetry, current forecast
+   wind, airspace context, the altitude-coloured track, the planned altitude
+   profile, landing intent and flight authority.
+2. **Balloon crew:** the same airborne information with more room for inspection
+   and communication, but without pilot-authority actions.
+3. **Chase driver:** voice-first road navigation, road safety information and a
+   glanceable flight context, without airborne planning controls.
+4. **Chase crew:** a tactical ground view containing the balloon, every chase
+   vehicle, all shared tracks, landing intent, possible landing areas, and the
+   controls for the vehicle's chosen chase target.
+
+The web planner remains the pre-flight planning surface. Its output must become
+a structured flight plan rather than only a GPX line so the mobile app can show
+the start window, altitude stages, wind provenance, landing envelope,
+operational boundaries and planning constraints. During a live flight the app
+will preserve that original plan, show actual progress separately, and—when a
+fresh Open-Meteo forecast is available—calculate a clearly labelled live
+projection from the balloon's current position and altitude.
+
+## Problem statement
+
+The current app does not give a user confidence that it knows whether they are
+flying the balloon, assisting in the basket, driving a chase vehicle, or working
+as chase crew. It still exposes inherited `leader`, `rider`, `ride` and road
+concepts because the live surfaces are driven by the legacy session role rather
+than the new flight-role and craft models.
+
+This is more than a wording problem. Forecast geometry and a vehicle's road
+route are both held in the same active-route slot, and the useful data produced
+by the web planner is reduced to a GPX track during sharing. Without separating
+those concepts, the pilot can be offered road behaviours and the chaser can lose
+their personal navigation when the shared balloon plan changes.
+
+## Evidence in the current repository
+
+- `FlightRole` already defines pilot, balloon crew, chase driver, chase crew and
+  observer, including authority and road-furniture rules.
+- `Craft` and the craft-roster reducer already model one balloon and several
+  vehicles, including several devices attached to one craft and deterministic
+  craft telemetry election.
+- Production features do not currently create those craft/role events. The
+  production `resolveCraftRoster()` is therefore normally empty.
+- The live shell decides balloon versus chase presentation from `localCraft`,
+  but falls back to the inherited `RideRole.lead` in simulation and many
+  authority, roster and copy paths still consume `RideRole` directly.
+- The server plan directory stores only an encrypted GPX string. GPX preserves
+  geometry, time and elevation, but loses the web planner's departure window,
+  altitude ceiling, ascent/descent limits, altitude control stages, landing
+  envelope, wind model metadata and operational boundaries.
+- One `_activeRoute` currently represents both a shared forecast plan and a
+  device-local chase road route. These have different owners, lifetimes,
+  consumers and safety rules and must not share a state slot.
+- Open-Meteo wind, OpenAIP chart context, altitude telemetry, landing intent,
+  dynamic chase target selection and craft-track reducers already exist in
+  partial form. The plan should compose and complete them rather than replace
+  them.
+
+## Goals
+
+1. Every live device has an explicit `FlightRole` and is attached to exactly one
+   craft before entering the live-flight shell.
+2. No user-facing production string uses `ride`, `rider`, `leader`, `bike` or
+   `motorcycle` for the balloon workflow.
+3. Airborne roles never see speed limits, road hazards, turn-by-turn directions
+   or road-route progress.
+4. Chase roles never mistake forecast balloon geometry for their road route.
+5. The pilot and balloon crew can compare the original forecast, actual flight,
+   current forecast wind and a live possible-landing projection without any of
+   those being presented as measured certainty or aircraft control.
+6. Each chase vehicle can independently choose either the pilot's current
+   intended landing area or a road rendezvous near the latest fresh balloon fix,
+   and receive lawful road guidance that dynamically recalculates.
+7. Balloon and vehicle locations and actual tracks converge across all flight
+   devices after temporary connectivity loss, with source, age and freshness
+   visible.
+8. Planner and app calculations remain behaviourally compatible through shared
+   versioned fixtures and contract tests.
+
+## Non-goals
+
+- The app will not claim to provide certified aviation navigation, clearance,
+  terrain clearance, NOTAM completeness or an official aviation briefing.
+- The altitude profile will not be phrased as a command to climb or descend.
+  It is a forecast strategy that a qualified pilot may compare with conditions.
+- A chase route will never terminate at a raw airborne coordinate or direct a
+  vehicle off-road. “Near balloon” means a validated road-network rendezvous.
+- Open-Meteo will not be described as measured “live wind”. It is numerical
+  forecast data valid for the displayed time and altitude.
+- The first implementation will not optimise several chase vehicles into a
+  fleet strategy or support several balloons in one flight.
+- Observer and public tracking experiences are not part of this delivery, but
+  the role and event model must continue to degrade observers safely.
+- Official UK flight-plan generation or filing is not included.
+
+## Canonical terminology
+
+| Concept | Meaning | User-facing term |
+|---|---|---|
+| Flight | One private balloon operation from pre-launch to end | Flight |
+| Person | A human participant | Person or crew member |
+| Device | One phone participating in the flight | Device |
+| Craft | One balloon or one chase vehicle | Balloon / vehicle label |
+| Pilot | The person with flight authority | Pilot |
+| Balloon crew | A non-pilot person in the balloon | Balloon crew |
+| Chase driver | The person currently driving a chase vehicle | Driver |
+| Chase crew | A non-driving person in a chase vehicle | Chase crew |
+| Flight plan | Original advisory web-planner output | Forecast plan |
+| Actual track | Where a craft was measured to have travelled | Track |
+| Live projection | Recalculation from current telemetry and forecast wind | Live projection |
+| Intended landing area | The pilot's current stated intent | Intended landing area |
+| Road rendezvous | A router-validated road endpoint serving a target | Road rendezvous |
+
+`RideRole`, `RideSession`, `riderId` and related API fields may remain as
+temporary internal compatibility identifiers while old builds are supported.
+They must not leak into visible labels, accessibility text, notifications,
+diagnostics intended for testers, release notes or exported flight summaries.
+
+## Personas and role permissions
+
+### Permission matrix
+
+| Capability | Pilot | Balloon crew | Chase driver | Chase crew |
+|---|:---:|:---:|:---:|:---:|
+| Start/end flight | Yes | No | No | No |
+| Transfer pilot role | Yes | Accept only | No | No |
+| Set/replace intended landing area | Yes | No | No | No |
+| Declare commitment to landing | Yes | No | No | No |
+| Register the balloon | Yes | No | No | No |
+| Nominate balloon telemetry device | Yes | No | No | No |
+| Inspect altitude profile/wind/airspace | Yes | Yes | Glanceable context only | Yes |
+| Change wind display altitude locally | Yes | Yes | No | Yes |
+| Create/select a chase vehicle | No | No | Yes | Yes |
+| Select that vehicle's chase target | No | No | Yes when stopped | Yes |
+| Edit that vehicle's road preferences | No | No | Yes when stopped | Yes |
+| Receive turn guidance and road alerts | No | No | Yes | Optional overview, no alerts by default |
+| Add ground/access notes | No | No | Voice/quick action | Yes |
+| Send/receive flight messages | Yes | Yes | Voice/quick action | Yes |
+
+The pilot is the sole flight authority in the first release. Balloon crew may
+operate local inspection controls and may be elected as the balloon's telemetry
+source, but cannot silently change flight intent. A later delegated-authority
+capability can be additive if field testing proves it is needed.
+
+### User stories
+
+#### Pilot
+
+- As the pilot, I want the app to enter a flight-specific cockpit view so road
+  speed and turn information cannot distract me.
+- As the pilot, I want my altitude, vertical trend, telemetry age and quality at
+  a glance so I know what the team is actually receiving.
+- As the pilot, I want to see forecast wind at my current altitude and inspect
+  other levels so I can compare the plan with current forecast conditions.
+- As the pilot, I want the planned altitude stages and their times visible so I
+  can understand what produced the forecast track.
+- As the pilot, I want to replace or clear the intended landing area during the
+  flight so every chase vehicle receives my latest intent.
+- As the pilot, I want actual, planned and live-projected tracks to look
+  different so I cannot confuse forecast geometry with measured travel.
+
+#### Balloon crew
+
+- As balloon crew, I want the same airborne map, altitude profile, wind and
+  airspace context as the pilot, with room to inspect details and communicate.
+- As balloon crew, I want my phone to contribute telemetry without creating a
+  second balloon or a second track.
+- As balloon crew, I want authority-only actions visibly identified as pilot
+  actions rather than disabled without explanation.
+
+#### Chase driver
+
+- As a driver, I want voice-first lawful road guidance while keeping the
+  balloon, intended area and other vehicles visible in a small context map.
+- As a driver, I want to choose whether my vehicle is pursuing the intended
+  landing area or a road rendezvous near the balloon while safely stopped.
+- As a driver, I want speed limits and road alerts but no altitude-planning
+  controls or editable tactical panels while moving.
+- As a driver, I want a clear spoken warning when the pilot changes the intended
+  area, the balloon fix becomes stale, or the selected target materially moves.
+
+#### Chase crew
+
+- As chase crew, I want a tactical all-team map showing the balloon, its actual
+  and projected tracks, the intended and possible landing areas, every vehicle
+  and every actual vehicle track.
+- As chase crew, I want to select and review my vehicle's target and route so I
+  can support the driver without changing another vehicle's guidance.
+- As chase crew, I want to see whether the balloon is closing on or diverging
+  from the intended area so I can make a deliberate retargeting decision.
+
+## Role and craft assignment journey
+
+The live-flight shell must not render until assignment is complete.
+
+### Creating a flight
+
+1. The creator is explicitly told: **“You are creating this flight as the
+   pilot.”**
+2. The app creates the flight and dual-writes the legacy creator role only for
+   mixed-version compatibility.
+3. It registers one balloon craft with a stable flight-scoped ID and label.
+4. It assigns `FlightRole.pilot` to the device and attaches the device to the
+   balloon.
+5. It nominates this device as the initial preferred telemetry source, without
+   preventing the existing quality election from choosing a better usable
+   device later.
+6. Only after those local journal events commit does the pilot enter the
+   pre-launch pilot view and receive the join invitation.
+
+### Joining a flight
+
+After the code or QR is validated, the person answers two short questions:
+
+1. **Where are you?**
+   - In the balloon
+   - In a chase vehicle
+2. **What are you doing?**
+   - Balloon: Balloon crew
+   - Vehicle: Driving / Chase crew
+
+Vehicle participants then select an existing vehicle or create a named vehicle
+such as “Land Rover” or “Van”. Creating a vehicle registers it and attaches the
+device atomically from the user's perspective. The first release supports role
+changes between driver and chase crew for devices attached to the same vehicle,
+but only while the app considers the vehicle stopped.
+
+A second pilot cannot be selected during ordinary join. Pilot handover is an
+explicit pilot-authorised flow that writes a role transfer and updates flight
+authority after the recipient accepts.
+
+### Resume and recovery
+
+- Device assignment and `FlightRole` are stored with the local session and
+  recoverable from the journal.
+- A resumed device reattaches to the same craft idempotently.
+- If its craft no longer exists, it is stopped at an assignment-repair screen;
+  it is never silently treated as a chase vehicle.
+- A legacy flight with no craft events receives a one-time migration gate. The
+  legacy creator is offered Pilot; every other participant must choose balloon
+  crew or a chase vehicle before continuing.
+- Mixed-version peers remain visible, but an unassigned old device is labelled
+  “Unassigned device” and cannot be elected as the balloon merely because it
+  once held `lead`.
+
+## View selection and information architecture
+
+View selection is derived from `FlightRole` plus `CraftKind`. It is not a manual
+theme toggle and is not inferred from the legacy leader flag.
+
+```text
+No assignment          -> assignment/recovery gate
+Pilot + balloon        -> pilot flight deck
+Balloon crew + balloon -> airborne crew view
+Driver + vehicle       -> chase driver navigation
+Chase crew + vehicle   -> chase tactical view
+Observer               -> existing restricted observer view
+Invalid combination    -> repair gate, never a guessed view
+```
+
+A person may change map framing inside their allowed view—for example, balloon,
+own vehicle or all team—but that never changes their role or reveals controls
+belonging to another role.
+
+### Common shell
+
+Every live view contains:
+
+- current local time at the top;
+- flight status: pre-launch, live, paused, landing inferred, landed or ended;
+- local role and craft label, for example “Pilot · Balloon” or “Driver · Land
+  Rover”;
+- connectivity state and last successful relay time;
+- emergency and leave controls appropriate to the role;
+- a participant/vehicle count that opens a craft-based roster.
+
+The navigation destination is named **Flight**, not Ride. Roster rows are
+grouped by craft, then show people/devices aboard. Craft location and freshness
+are primary; duplicate device fixes are not drawn as duplicate craft markers.
+
+### Pilot flight deck
+
+Primary surface: a wide, north-up or track-up aeronautical map with restrained
+chrome.
+
+Always visible:
+
+- balloon altitude, datum, source, accuracy and fix age;
+- vertical speed and trend arrow;
+- ground speed and track only as flight telemetry, never in a road speed-limit
+  treatment;
+- “Crew can see this fix” / “Position has not relayed” state;
+- actual altitude-coloured ground track;
+- current intended landing area and its age;
+- current forecast wind vector at balloon position and altitude, with valid
+  time and model source.
+
+One-tap or one-sheet actions:
+
+- update/clear intended landing area;
+- declare commitment to landing;
+- open forecast altitude profile;
+- show/hide wind and choose wind altitude;
+- show/hide OpenAIP chart and open its key/limitations;
+- inspect chase vehicles and messages;
+- end or privacy-stop sharing.
+
+Never present:
+
+- speed limits, enforcement/camera alerts, turn banners, lane guidance, road
+  ETA, route progress, “off route”, road target selection or CarPlay actions.
+
+### Balloon crew view
+
+The balloon crew view uses the same map semantics as the pilot view, including
+no road controls. It can use a denser bottom sheet because a crew member may be
+the person holding the phone.
+
+Additional inspection:
+
+- full planned altitude-stage table;
+- actual-versus-plan telemetry history;
+- time-by-altitude wind table;
+- possible landing areas and the evidence used to calculate them;
+- all chase craft, tracks, target choices and ETA summaries;
+- message composition and operational-boundary detail.
+
+Pilot-only actions remain visible only where their absence would be confusing,
+and explain “Only the pilot can publish a new intended area” rather than using
+leader/coordinator language.
+
+### Chase driver navigation
+
+Primary surface: heading-up road navigation with spoken instructions and large,
+glanceable controls.
+
+Always visible while guidance is active:
+
+- next manoeuvre, road name, distance and route ETA;
+- mapped speed limit and the driver's GPS speed;
+- selected target: intended landing area or road rendezvous near balloon;
+- target age/freshness and road-endpoint separation;
+- a mini-map containing own vehicle, balloon, recent balloon track, intended
+  area and other chase vehicles;
+- rerouting/stale state in words.
+
+While moving, target changes and route preferences are voice or passenger
+actions only. Touch editing reappears when stopped. Wind and airspace layers are
+off by default and the altitude profile is not placed in the driving hierarchy.
+
+### Chase crew tactical view
+
+Primary surface: an interactive all-team map plus a collapsible vehicle route
+panel.
+
+The map shows:
+
+- latest balloon location, altitude and freshness;
+- actual altitude-coloured balloon track;
+- original planned forecast track;
+- live projected track and possible landing envelope when available;
+- pilot intended landing area with revision age;
+- every chase vehicle, its fresh/stale state and its actual shared track;
+- this vehicle's selected road rendezvous and route;
+- other vehicles' selected target category and rendezvous summary, without
+  copying their full turn geometry.
+
+The tactical panel provides target selection, route rationale, divergence from
+the intended area, vehicle constraints, road ETA, access notes and messages.
+
+## Visual language for tracks and areas
+
+The app and planner use one shared altitude palette:
+
+| Altitude MSL | Colour |
+|---:|---|
+| 0 m | `#00C8FF` cyan |
+| 500 m | `#00F5A0` green |
+| 1,000 m | `#FFE600` yellow |
+| 2,000 m | `#FF245D` red |
+
+Values interpolate continuously between stops. The legend follows the selected
+altitude unit, while the underlying calculation remains metres MSL. Unknown or
+incompatible altitude is grey and never treated as zero.
+
+Geometry is distinguished by more than colour:
+
+| Geometry | Style |
+|---|---|
+| Actual balloon track | Solid altitude gradient, strong casing, direction arrows |
+| Original forecast track | Dashed altitude gradient, thinner casing |
+| Live projected track | Dotted/faded altitude gradient with forecast timestamp |
+| Chase vehicle track | Solid craft identity colour, vehicle direction arrows |
+| Intended landing area | Green outline/fill, labelled “Pilot intent” and aged |
+| Original landing envelope | Purple dashed boundary, labelled with plan validity |
+| Live possible-landing envelope | Amber dotted boundary, labelled with forecast validity |
+| Road rendezvous | Blue road pin connected to its target by a faint straight evidence line |
+
+The non-colour differences and accessible descriptions are mandatory. An
+altitude-gradient renderer must be shared by actual and forecast paths in both
+FlutterMap and MapLibre so one renderer cannot silently fall back to one colour.
+
+## Web-planner capability map
+
+“Bring planner features into the app” means preserving the planning evidence
+and making the relevant parts live. It does not mean placing every pre-flight
+editing control over an active pilot map.
+
+| Web-planner capability | Mobile pre-launch | Mobile live flight |
+|---|---|---|
+| Place search | Open planning mode / planner | Not on primary live surfaces |
+| Draggable launch/destination | Review/edit before launch | Original points locked; pilot updates intended area separately |
+| Departure date/start window | Review and import | Show original window and actual launch time |
+| Launch elevation | Import with datum | Compare with actual launch reference |
+| Maximum altitude | Import constraint | Show planned ceiling and actual max; never auto-command |
+| Max ascent/descent rates | Import constraints | Show beside planned/actual vertical rate |
+| Optimised altitude stages | Import structured stages | Highlight current planned stage and actual deviation |
+| Forecast track | Import | Preserve as original dashed altitude-coloured line |
+| Landing envelope | Import polygon | Preserve original; optionally add live envelope |
+| Destination reachability/miss | Import result | Show as pre-flight evidence, not a live promise |
+| Wind altitude slider/toggle | Available | Pilot/balloon crew/chase crew; role-specific defaults |
+| Wind grid | Import metadata, fetch locally | Re-centre on balloon/viewport and interpolate for displayed time |
+| OpenAIP chart/key | Available | Default on for airborne roles, optional for chase crew, off for driver |
+| Operational boundaries | Import/share | Draw, age and alert without claiming official restriction data |
+| Light/dark map | Same preference | Same preference and renderer parity |
+| Plan code | Load structured plan | Plan remains attached to flight and available offline |
+| Timed flight profile | Import | Live stage list with original and actual times separated |
+
+## Structured forecast-plan contract
+
+GPX remains an export and backward-compatible fallback. It is not the canonical
+contract for a Balloon Crumbs planner plan.
+
+Introduce a versioned `ForecastPlan` document with these bounded fields:
+
+```text
+ForecastPlan
+  schemaVersion
+  id, name, createdAt, expiresAt
+  source = Balloon Crumbs web planner
+  launch { point, elevationMsl, datum }
+  destination? { point, toleranceMetres }
+  intendedLandingArea { centre, radius/polygon, updatedAt }
+  forecastLanding { point }
+  departure { selectedAt, matchingWindowStart?, matchingWindowEnd? }
+  constraints {
+    altitudeCeilingMsl
+    maximumAscentRateMps
+    maximumDescentRateMps
+    minimum/maximumDurationMinutes
+  }
+  altitudeStages[] { fraction, plannedAt, altitudeMsl, changeRateMps }
+  plannedTrack[] { point, altitudeMsl, elapsedSeconds }
+  landingEnvelope[]
+  wind {
+    provider, model, requestedAt, validFrom, validTo
+    attribution, licence, forecastOnly = true
+    fieldDigest
+  }
+  operationalBoundaries[]
+  result { kind, reachesDestination?, missDistanceMetres? }
+  gpxFallback
+```
+
+Bounds must cover maximum byte size, points, stages, polygon vertices, string
+lengths and timestamps. Unknown additive fields are ignored; unknown schema
+major versions are rejected with a readable error. Exact plan contents remain
+encrypted at rest as today.
+
+### API compatibility and rollout
+
+1. Relay accepts and returns both existing GPX-only plans and structured plans.
+2. Web planner writes `ForecastPlan` plus GPX fallback after server support is
+   deployed.
+3. Mobile reads structured plans first and falls back to typed GPX semantics.
+4. Old mobile builds continue receiving a valid GPX field.
+5. Once the supported tester population has migrated, GPX-only plan creation
+   can be deprecated but not removed from file import/export.
+
+## Planned altitude profile in real time
+
+The airborne profile sheet lists the same six control positions as the web
+planner: Launch, 20%, 40%, 60%, 80% and Landing. Each row contains:
+
+- planned local time;
+- planned altitude and datum;
+- change from the previous stage;
+- planned rate, constrained by the imported ascent/descent limits;
+- forecast wind direction and speed used at that stage;
+- whether the row is past, current or future.
+
+Above the table the app shows original plan start, actual launch time, original
+landing time, elapsed time, planned ceiling and actual maximum altitude. Actual
+altitude and vertical rate are adjacent but never overwrite the plan.
+
+If the flight starts outside the matching window, the original plan is marked
+out of window. The user can request **Reforecast from current position** while
+stationary/pre-launch or from the balloon crew inspection sheet. Reforecasting
+creates a new live projection revision; it does not mutate history or relabel
+the original plan as current.
+
+## Wind grid and forecast freshness
+
+- Open-Meteo UKMO remains the selected advisory forecast provider for tester
+  builds.
+- The field is a 5 × 5 grid spanning approximately 120 km, matching the planner.
+- In planning mode it is centred on launch. During flight it re-centres when the
+  balloon approaches the useful edge or after a material displacement, with
+  request throttling and cancellation of superseded requests.
+- Airborne views default to **Follow balloon altitude**. The slider can inspect
+  20–2,000 m MSL without making another request because the complete vertical
+  profile is held in memory.
+- Chase crew may inspect wind; the driver view does not render the grid.
+- Every display includes provider, model, requested/fetched time, valid time,
+  altitude, speed unit and “forecast model—not an aviation briefing”.
+- If refresh fails, the last field remains only with an explicit age/stale
+  state. It is not extended beyond its validity and no guessed wind is used for
+  a real live projection.
+- A plan's original track remains available offline even when live reforecasting
+  is unavailable.
+
+The plan deliberately calls this “forecast wind valid now”, not “current wind”.
+Observed balloon drift is not a direct wind measurement and is not promoted to
+one in this scope.
+
+## Live projection and possible landing areas
+
+Three forecast products coexist and must remain named:
+
+1. **Original forecast:** immutable planner output from the planned launch,
+   start time and constraints.
+2. **Live projection:** recomputed from the latest usable balloon fix, its
+   current altitude, the remaining planning constraints and a fresh forecast
+   field.
+3. **Actual track:** measured craft telemetry after filtering/election.
+
+The live projection:
+
+- starts only from a usable fresh balloon fix;
+- uses measurement time, not relay receipt time;
+- uses the same altitude interpolation, wind interpolation, rate constraints
+  and feasibility rules as the web planner;
+- displays its forecast/model validity and computation time;
+- stops updating when telemetry or wind is stale;
+- never replaces the pilot's intended landing area;
+- produces a live possible-landing envelope rather than claiming a landing
+  site is safe, permitted or accessible.
+
+The mobile forecast engine will be a Dart implementation because live operation
+must not depend on running browser JavaScript. Planner-core JSON fixtures become
+language-neutral golden tests consumed by JavaScript and Dart. The two engines
+must agree within documented tolerances for track points, stage altitudes,
+landing envelopes, reachability, duration and miss distance before the live
+projection ships.
+
+## Airspace and operational context
+
+- OpenAIP is advisory chart context, not authoritative airspace or NOTAM data.
+- The chart defaults on for pilot and balloon crew, is optional for chase crew,
+  and is absent from the chase driver hierarchy.
+- Its attribution, build/configuration age and limitations remain in the map
+  information sheet; the chart key is accessible without covering telemetry.
+- A stale/missing OpenAIP configuration produces a clear unavailable state and
+  never leaves an unlabelled blank layer.
+- Planner operational boundaries are carried in the structured plan and shared
+  into the flight journal. They retain name, source, update time, geometry,
+  optional altitude band and datum.
+- Boundary alerts state source and age and are advisory. Official temporary
+  restrictions and current NOTAM briefing remain an external pilot task.
+
+## Intended landing area and landing state
+
+The following remain distinct:
+
+- **Planner intended area:** intent saved before the flight.
+- **Current pilot intended area:** latest pilot-published revision during the
+  flight; this supersedes planner intent for chase decisions.
+- **Original landing envelope:** all feasible forecast endpoints calculated
+  pre-flight.
+- **Live possible-landing envelope:** endpoints calculated from current state.
+- **Declared landing:** pilot says the balloon is committing to land.
+- **Inferred landing:** telemetry indicates sustained descent/stopping.
+
+The pilot edits an area, not a precision point. Every revision includes author,
+measurement/update time and radius/polygon, commits locally first, then relays.
+All chase devices update the area immediately on replay. The UI shows its age,
+distance from the balloon and whether recent balloon travel is closing on or
+opening from it.
+
+## Chase target and dynamic road guidance
+
+Target choice is **per chase vehicle** and shared between devices attached to
+that vehicle. It is not one group route.
+
+### Target choices
+
+1. **Intended landing area** — default when the pilot has published a valid
+   area. Route to a legal road endpoint serving the area.
+2. **Road rendezvous near balloon** — use a fresh balloon fix as the evidence
+   target, then validate a legal road endpoint near it. The UI never says it is
+   routing directly to the airborne balloon.
+
+Changing one vehicle's target does not change another vehicle. The latest
+authorised target event for that craft wins; both driver and chase crew attached
+to the craft see who changed it and when.
+
+### Rerouting policy
+
+Initial bounded policy values remain:
+
+- balloon fix must be no more than 45 seconds old to create a new near-balloon
+  target;
+- ordinary moving-target reroutes require at least two minutes since the last
+  request and at least 300 m target movement;
+- a pilot landing-area revision, an explicit target change, or recovery from a
+  stale fix can force immediate reconsideration;
+- a road endpoint for a balloon target must be within 1,200 m of the evidence
+  point;
+- a landing-area endpoint must be within the area's radius plus a 500 m road
+  margin.
+
+These values are field-test defaults, not hidden constants. Route rationale
+must record them so simulation and diagnostics can reproduce the decision.
+
+The road router must use the selected vehicle profile, legal road network,
+provider travel speeds and current traffic only when that provider legitimately
+supplies it. It must not simulate progress at an arbitrary constant speed in a
+live session. If the route cannot be built or its endpoint fails validation,
+the previous route freezes and the app states why.
+
+The driver receives one spoken announcement for a material target change or
+stale state. The app does not nag and does not silently switch from pilot intent
+to near-balloon pursuit when divergence grows.
+
+## Shared location, tracks and intent
+
+### Shared event/read-model contract
+
+| State | Producer | Shared scope | Notes |
+|---|---|---|---|
+| Craft registration | Pilot or vehicle crew | Flight | One balloon, many vehicles |
+| Device attachment | Local device | Flight | Idempotent; latest attachment wins |
+| Flight-role assignment | Creator/pilot for authority; participant for own non-pilot role | Flight | Driver/crew changes require the vehicle to be stopped |
+| Device location sample | Each device | Flight | Locally journalled before relay |
+| Elected craft telemetry | Derived on every peer | Flight read model | One marker/track per craft |
+| Forecast plan revision | Pilot | Flight | Structured plan plus GPX fallback |
+| Intended landing revision | Pilot | Flight | Latest valid revision wins |
+| Vehicle target choice | Driver/chase crew aboard vehicle | Vehicle + flight summary | Per craft |
+| Vehicle road route | Each vehicle device | Device local | Full manoeuvres are not group authority |
+| Road rendezvous/ETA summary | Vehicle guidance controller | Flight | Allows team awareness without route copying |
+| Operational boundary | Pilot | Flight | Advisory source/age retained |
+| Message/ground note | Permitted participant | Flight or addressed craft | Existing bounded event model |
+
+Actual tracks are derived from accepted location events; they are not a second
+independent stream that can disagree with telemetry. Every peer runs the same
+craft election and track reducer. Several phones in one basket therefore create
+one balloon track, while several chase vehicles create distinct vehicle tracks.
+
+### Track retention and rendering
+
+- Continue locally journalling the complete active-flight evidence within the
+  configured privacy window.
+- Render a performance-bounded recent window by default, with an explicit
+  whole-flight view when stopped.
+- Never drop older points merely because the vehicle has travelled beyond a
+  short fixed distance.
+- A stale craft keeps its last marker and completed track with a stale visual;
+  it does not extend the track until a newer accepted fix arrives.
+- Track sharing follows the existing offline-first relay/replay path, including
+  deduplication and measurement-versus-receipt timestamps.
+
+## State and controller separation
+
+Replace the single active-route concept with explicit state owners:
+
+```text
+SharedForecastPlanController
+  original structured plan
+  planner geometry/profile/envelope
+  current pilot plan revision
+
+LiveFlightProjectionController
+  fresh telemetry + fresh wind
+  projected track + possible landing envelope
+  source/validity/failure state
+
+VehicleGuidanceController (one per local vehicle)
+  selected target mode
+  resolved road rendezvous
+  device-local road route and manoeuvres
+  reroute policy, ETA and failure state
+
+CraftFlightState
+  craft roster, elected telemetry, actual tracks, freshness
+
+FlightAuthorityController
+  pilot role, start/end, landing intent and handover
+```
+
+The map receives a role-specific presentation model rather than a collection of
+booleans such as `isBalloonView`. The large active shell should be decomposed
+around these state owners so forecast updates cannot replace road navigation
+and a UI rebuild cannot change authority.
+
+## P0 requirements and acceptance criteria
+
+### P0.1 Production roles and crafts
+
+- [ ] Creating a flight writes pilot role, balloon registration and device
+      attachment before opening the flight view.
+- [ ] Joining requires an airborne/vehicle assignment and a compatible role.
+- [ ] Vehicle creation/selection is idempotent and persists through restart.
+- [ ] Three devices in one balloon produce one craft marker and track.
+- [ ] Invalid role/craft combinations open a repair flow, never a guessed view.
+- [ ] Pilot handover is explicit, accepted and journalled.
+
+### P0.2 Vocabulary migration
+
+- [ ] A test scans all production user-visible strings and fails on whole-word
+      `ride`, `rider`, `leader`, `bike` or `motorcycle`, excluding documented
+      compatibility/debug fixtures.
+- [ ] Navigation labels, dialogs, snackbars, notifications, accessibility text,
+      CarPlay/Android projections and exports use flight/craft roles.
+- [ ] Internal legacy field names are documented and cannot be accidentally
+      rendered directly.
+
+### P0.3 Distinct live experiences
+
+- [ ] Pilot and balloon crew never render speed limits, road alerts, turn
+      guidance, road progress or navigation export.
+- [ ] Pilot can update landing intent; balloon crew sees it without authority.
+- [ ] Driver view keeps road instructions and speed information reachable at a
+      glance and hides airborne editing controls.
+- [ ] Chase crew sees the full tactical map and can control only its attached
+      vehicle's target.
+- [ ] Role change updates the shell without losing flight or craft state.
+
+### P0.4 Shared craft telemetry and tracks
+
+- [ ] Balloon and every chase vehicle location appears on every authorised
+      device with fix age and live/relayed/stale/unknown state.
+- [ ] Each craft's actual track is shared and survives disconnect/reconnect.
+- [ ] Balloon track segments use the common altitude palette; missing altitude
+      is grey and described accessibly.
+- [ ] Chase tracks use craft identity styling and never inherit altitude colour.
+- [ ] Out-of-order or duplicate fixes cannot regress a craft position or track.
+
+### P0.5 Structured planner plan
+
+- [ ] Relay and mobile remain backward-compatible with GPX-only plan codes.
+- [ ] Structured plans retain all web-planner inputs, stages, envelopes, source
+      metadata and operational boundaries.
+- [ ] The app displays original forecast, profile and limitations offline after
+      one successful import.
+- [ ] Unknown schema versions fail safely and do not activate partial geometry.
+
+### P0.6 Airborne forecast context
+
+- [ ] Pilot/balloon crew see actual track, original forecast and intended area
+      with distinct non-colour styles.
+- [ ] Wind defaults to the balloon's altitude and can be changed/hidden.
+- [ ] Wind source, model, fetch/valid time, altitude, units and forecast warning
+      remain visible.
+- [ ] Planned altitude stages list time, height and rate and highlights the
+      current stage without issuing a control command.
+- [ ] OpenAIP is role-gated, attributed and explicitly advisory/unavailable.
+
+### P0.7 Per-vehicle chase guidance
+
+- [ ] Each chase vehicle independently selects intended-area or near-balloon
+      road guidance.
+- [ ] A pilot landing-area update reaches every vehicle and triggers bounded
+      route reconsideration for vehicles following that area.
+- [ ] Near-balloon mode refuses a stale balloon fix and never routes to a raw
+      airborne coordinate.
+- [ ] Reroutes use provider road geometry, speeds and vehicle constraints and
+      preserve the last valid route on failure.
+- [ ] Target selection, road endpoint, target age and reroute reason are visible.
+
+## P1 requirements
+
+- Live projected track and possible-landing envelope from current telemetry and
+  fresh wind, with JavaScript/Dart golden parity.
+- Actual-versus-planned altitude chart and time-by-altitude wind table.
+- Intended-area divergence trend and explicit alternative comparison.
+- Landing inference and declared/inferred state presentation.
+- Ground/access notes associated with landing/rendezvous areas.
+- Whole-flight multi-craft replay with wind/plan/target revisions time-aligned.
+- Physical CarPlay/Android Auto driver companion after role/view separation.
+
+## P2 and explicitly deferred work
+
+- Restricted observer and revocable public-tracking views built on the same
+  craft read model.
+- Multi-balloon operations, shared vehicle pools and dynamic reassignment.
+- Fleet-level chase optimisation across several vehicles.
+- Delegated landing-intent authority for balloon crew, if field evidence shows
+  that pilot-only publication creates too much workload.
+- Certified or official aviation briefing, NOTAM and flight-plan integration;
+  these require separate provider, regulatory and liability decisions.
+
+## Implementation slices and dependency order
+
+Each slice must be independently reviewable, keep mixed-version behaviour safe,
+and end with a tester-observable outcome.
+
+### Slice 0 — Contract and migration scaffolding
+
+- Add `FlightRole` to persisted session and event projection.
+- Define dual-write/read compatibility with `RideRole`.
+- Add assignment validation and a role/craft presentation model.
+- Introduce string-lint allowlists for internal compatibility names.
+
+Exit: production code can represent every target persona without changing the
+existing screens yet.
+
+### Slice 1 — Production craft/role assignment
+
+- Implement create, join, resume, repair, vehicle selection and pilot handover.
+- Register/attach crafts through the existing journal APIs.
+- Move roster and local-view selection to craft state.
+
+Exit: one balloon with multiple devices and several vehicles is correctly
+formed in a real flight and survives restart/replay.
+
+### Slice 2 — Separate forecast and road state
+
+- Introduce shared forecast-plan and per-vehicle guidance controllers.
+- Migrate landing intent and operational boundaries to flight authority.
+- Ensure forecast changes cannot replace vehicle road routes.
+- Include the forecast-purpose import fix if it has not already merged.
+
+Exit: a pilot can load/change a forecast while a chaser retains independent
+road guidance.
+
+### Slice 3 — Role-specific shells and terminology
+
+- Build pilot, balloon crew, chase driver and chase crew compositions.
+- Replace user-facing legacy vocabulary and craft-inappropriate icons.
+- Add role contract widget tests and small-screen/landscape overlap tests.
+
+Exit: testers can identify their role from the first screen and no role sees an
+inappropriate control.
+
+### Slice 4 — Structured planner parity
+
+- Version the plan API and encrypted storage.
+- Extend the web planner writer and mobile reader.
+- Persist altitude stages, constraints, envelopes, wind metadata and boundaries.
+- Add GPX fallback and mixed-client contract tests.
+
+Exit: one plan code reproduces the web planner's complete evidence in the app.
+
+### Slice 5 — Airborne live-flight information
+
+- Use the shared altitude renderer for original and actual paths.
+- Build profile, wind-grid, airspace and landing-area layers for airborne roles.
+- Add current-stage and actual-versus-plan presentation.
+- Add Dart planner-core parity fixtures and the live projection behind a tester
+  feature flag.
+
+Exit: the pilot/balloon crew can understand original plan, actual flight and
+fresh forecast context without road UI.
+
+### Slice 6 — Chase target and tactical workflow
+
+- Make target choice vehicle-scoped and shared between its devices.
+- Complete dynamic road routing, endpoint validation, route rationale and ETA.
+- Add chase mini-map/tactical map, all craft tracks and landing divergence.
+- Add moving/stale/landing-revision voice events.
+
+Exit: two chase vehicles can choose different targets and reroute independently
+while sharing their positions and tracks.
+
+### Slice 7 — Replay, failure and field evidence
+
+- Extend simulator and flight archive to all roles, crafts, tracks, wind and
+  target revisions.
+- Exercise offline recovery, stale providers, clock skew, role changes and
+  mixed app versions.
+- Validate on physical iOS/Android devices and in a moving vehicle where lawful.
+
+Exit: the acceptance matrix passes and the feature is ready for tester rollout.
+
+## Test strategy
+
+### Unit and contract tests
+
+- Role/craft compatibility, authority and handover.
+- Event replay, idempotent registration, attachment and migration.
+- Craft telemetry election and complete track reduction.
+- Forecast-plan schema bounds and backward compatibility.
+- JavaScript/Dart forecast golden fixtures across wind direction wrap,
+  interpolation, ascent/descent constraints, start windows and impossible
+  destinations.
+- Landing intent revisions, divergence and reroute hysteresis.
+- Road endpoint separation and stale-fix refusal.
+
+### Widget tests
+
+For every role, portrait/landscape and small/large phone:
+
+- required controls exist;
+- forbidden controls do not exist;
+- critical controls do not overlap;
+- map legend and source/freshness information are reachable;
+- driver moving mode cannot expose touch-heavy editing;
+- role changes preserve shared state and select the correct shell.
+
+### Integration and simulation matrix
+
+Minimum simulated flight:
+
+- pilot plus two balloon-crew phones attached to one balloon;
+- two chase vehicles, each with driver and chase-crew devices;
+- ascent, two level wind layers, descent and landing;
+- pilot landing-area revision mid-flight;
+- one vehicle follows intended area and one follows near-balloon rendezvous;
+- relay loss/recovery, stale balloon fix, stale wind, route provider failure and
+  out-of-order events;
+- distinct shared tracks for the balloon and both vehicles;
+- restart one device of every role and verify assignment recovery.
+
+### Physical field gates
+
+- iOS and Android background location and altitude behaviour.
+- Battery/thermal behaviour over a representative two-hour operation.
+- Voice interruption, Bluetooth and vehicle audio.
+- Real routing speed/ETA behaviour and safe road endpoints.
+- Glove/sunlight/readability checks for pilot controls.
+- Driver distraction review and physical CarPlay/Android Auto only when enabled.
+- OpenAIP/Open-Meteo attribution and stale/unavailable states without network.
+
+## Success metrics
+
+Leading indicators:
+
+- 100% of tester devices enter a view matching their explicit role/craft.
+- Zero role-contract failures in automated UI tests.
+- Zero user-visible forbidden legacy terms in the production string scan.
+- 95% of accepted craft fixes reach a connected peer within 10 seconds.
+- 100% of balloon fixes from several basket devices resolve to one craft track.
+- At least 95% of structured plans reproduce planner stages and geometry within
+  documented tolerances on both mobile platforms.
+- Fewer than one unnecessary automatic chase reroute per five minutes in the
+  reference simulation.
+
+Field-test indicators:
+
+- At least 90% of testers identify their role and main action without help.
+- At least 80% of pilots/balloon crew rate plan-versus-actual distinction 4/5.
+- At least 80% of chase crews rate target/rendezvous clarity 4/5.
+- No report of an airborne role receiving road directions or a chaser treating
+  forecast geometry as its road route.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Legacy and new roles disagree in mixed builds | Dual-write, deterministic migration and mixed-version tests |
+| Several phones create duplicate craft tracks | Craft-level telemetry election and one reducer per craft |
+| Forecast and road route overwrite one another | Separate controllers and storage contracts before UI work |
+| JavaScript and Dart forecast engines drift | Shared golden fixtures and explicit numeric tolerances |
+| Forecast wind is mistaken for observation | Persistent provider/validity/forecast-only labels |
+| Original and live forecasts are confused | Immutable original plan plus named, revisioned live projection |
+| Pilot controls become crowded again | Role-specific shells, one primary action band, sheet-based inspection and overlap tests |
+| Driver becomes distracted by tactical features | Separate driver/crew roles; moving lockout and voice-first design |
+| Stale landing intent is trusted | Age, distance/divergence and explicit degradation |
+| OpenAIP is treated as official/current NOTAM data | Advisory label, configuration validity and official briefing reminder |
+| Provider loss removes all context | Original plan remains offline; stale state freezes rather than guesses |
+
+## Decisions required before implementation
+
+The following recommended decisions make the plan implementable without later
+re-cutting authority or state ownership:
+
+1. **Pilot authority:** only the pilot publishes landing intent and starts/ends
+   the flight. Balloon crew inspect and communicate but do not mutate authority.
+   **Recommendation: accept.**
+2. **Vehicle target ownership:** driver and chase crew aboard the same vehicle
+   share one vehicle target; the latest valid choice wins and identifies its
+   author. **Recommendation: accept.**
+3. **Wind wording:** Open-Meteo is displayed as forecast wind valid for the
+   current time, never measured live wind. **Recommendation: accept.**
+4. **Forecast preservation:** always show the immutable original plan separately
+   from any live projection. **Recommendation: accept.**
+5. **Forecast implementation:** port the calculation core to Dart and enforce
+   parity with shared fixtures rather than depend on browser JavaScript or a
+   network calculation service during flight. **Recommendation: accept.**
+6. **Scope of “all planner features”:** pre-flight editing remains in planning
+   mode; active views receive the plan evidence and real-time adaptations, not
+   place search and draggable launch controls over the live map.
+   **Recommendation: accept.**
+7. **First release roles:** deliver pilot, balloon crew, chase driver and chase
+   crew; keep observer behaviour unchanged. **Recommendation: accept.**
+
+## Ready-to-implement checklist
+
+Implementation can start when:
+
+- [ ] The seven decisions above are accepted or amended.
+- [ ] The role and permission matrix is accepted.
+- [ ] The four view definitions are accepted.
+- [ ] The structured `ForecastPlan` boundary is accepted.
+- [ ] The original/actual/live visual language is accepted.
+- [ ] The per-vehicle target model and initial reroute thresholds are accepted.
+- [ ] The slice order and P0/P1 boundary are accepted.

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -1,7 +1,6 @@
 # Role-specific live flight experience
 
-Status: **Proposed implementation plan — no implementation starts until the
-decisions at the end of this document are accepted**
+Status: **Accepted — implementation in progress**
 
 Date: 23 August 2026
 
@@ -770,12 +769,12 @@ and a UI rebuild cannot change authority.
 
 ### P0.5 Structured planner plan
 
-- [ ] Relay and mobile remain backward-compatible with GPX-only plan codes.
-- [ ] Structured plans retain all web-planner inputs, stages, envelopes, source
+- [x] Relay and mobile remain backward-compatible with GPX-only plan codes.
+- [x] Structured plans retain all web-planner inputs, stages, envelopes, source
       metadata and operational boundaries.
-- [ ] The app displays original forecast, profile and limitations offline after
+- [x] The app displays original forecast, profile and limitations offline after
       one successful import.
-- [ ] Unknown schema versions fail safely and do not activate partial geometry.
+- [x] Unknown schema versions fail safely and do not activate partial geometry.
 
 ### P0.6 Airborne forecast context
 

--- a/fixtures/forecast_plan_v1.json
+++ b/fixtures/forecast_plan_v1.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 1,
+  "id": "fixture-flight-plan",
+  "name": "Tuckers Grave forecast",
+  "createdAt": "2026-08-23T05:45:00Z",
+  "source": "Balloon Crumbs web planner",
+  "launch": {
+    "point": { "latitude": 51.2829, "longitude": -2.3677 },
+    "elevationMsl": 92,
+    "datum": "wgs84Geoid"
+  },
+  "destination": {
+    "point": { "latitude": 51.413, "longitude": -2.212 },
+    "toleranceMetres": 100
+  },
+  "intendedLandingArea": {
+    "centre": { "latitude": 51.413, "longitude": -2.212 },
+    "radiusMetres": 400,
+    "updatedAt": "2026-08-23T05:45:00Z"
+  },
+  "forecastLanding": { "latitude": 51.4127, "longitude": -2.2124 },
+  "departure": {
+    "selectedAt": "2026-08-23T06:30:00Z",
+    "matchingWindowStart": "2026-08-23T06:24:00Z",
+    "matchingWindowEnd": "2026-08-23T06:38:00Z"
+  },
+  "constraints": {
+    "altitudeCeilingMsl": 1200,
+    "maximumAscentRateMps": 3,
+    "maximumDescentRateMps": 4,
+    "minimumDurationMinutes": 10,
+    "maximumDurationMinutes": 180
+  },
+  "altitudeStages": [
+    { "fraction": 0, "plannedAt": "2026-08-23T06:30:00Z", "altitudeMsl": 92, "changeRateMps": 0 },
+    { "fraction": 0.2, "plannedAt": "2026-08-23T06:42:00Z", "altitudeMsl": 300, "changeRateMps": 0.289 },
+    { "fraction": 0.4, "plannedAt": "2026-08-23T06:54:00Z", "altitudeMsl": 600, "changeRateMps": 0.417 },
+    { "fraction": 0.6, "plannedAt": "2026-08-23T07:06:00Z", "altitudeMsl": 900, "changeRateMps": 0.417 },
+    { "fraction": 0.8, "plannedAt": "2026-08-23T07:18:00Z", "altitudeMsl": 500, "changeRateMps": -0.556 },
+    { "fraction": 1, "plannedAt": "2026-08-23T07:30:00Z", "altitudeMsl": 92, "changeRateMps": -0.567 }
+  ],
+  "plannedTrack": [
+    { "latitude": 51.2829, "longitude": -2.3677, "altitudeMsl": 92, "elapsedSeconds": 0 },
+    { "latitude": 51.3401, "longitude": -2.2932, "altitudeMsl": 700, "elapsedSeconds": 1800 },
+    { "latitude": 51.4127, "longitude": -2.2124, "altitudeMsl": 92, "elapsedSeconds": 3600 }
+  ],
+  "landingEnvelope": [
+    { "latitude": 51.39, "longitude": -2.24 },
+    { "latitude": 51.43, "longitude": -2.24 },
+    { "latitude": 51.44, "longitude": -2.19 },
+    { "latitude": 51.4, "longitude": -2.18 }
+  ],
+  "wind": {
+    "provider": "Open-Meteo",
+    "model": "UKMO seamless",
+    "requestedAt": "2026-08-23T05:40:00Z",
+    "validFrom": "2026-08-23T05:00:00Z",
+    "validTo": "2026-08-24T05:00:00Z",
+    "attribution": "Weather data by Open-Meteo",
+    "licence": "CC BY 4.0",
+    "forecastOnly": true,
+    "fieldDigest": "fnv1a32:9a7f1042"
+  },
+  "operationalBoundaries": [
+    {
+      "id": "fixture-advisory-line",
+      "label": "Briefed advisory edge",
+      "kind": "line",
+      "points": [
+        { "latitude": 51.31, "longitude": -2.33 },
+        { "latitude": 51.37, "longitude": -2.25 }
+      ],
+      "source": "Pilot briefing fixture",
+      "updatedAt": "2026-08-23T05:30:00Z",
+      "altitudeDatum": "wgs84Geoid"
+    }
+  ],
+  "result": {
+    "kind": "optimised",
+    "reachesDestination": true,
+    "missDistanceMetres": 42
+  },
+  "gpxFallback": "<gpx version=\"1.1\"><trk><trkseg><trkpt lat=\"51.2829\" lon=\"-2.3677\"/><trkpt lat=\"51.4127\" lon=\"-2.2124\"/></trkseg></trk></gpx>"
+}


### PR DESCRIPTION
## Summary
- assign explicit pilot, balloon crew, chase driver, and chase crew roles and crafts
- separate forecast flight geometry from per-vehicle road guidance
- import structured planner evidence and show altitude stages, wind, tracks, projections, and landing envelopes
- share craft tracks and chase targets, with explicit accepted pilot handover
- remove inherited motorcycle terminology from production surfaces

## Verification
- flutter analyze
- flutter test: 1779 passed, 24 skipped
- relay pytest: 137 passed
- Dart and Ruff formatting/lint checks