### PR TITLE
fix: preserve relay host through Oracle proxy

### DIFF
--- a/deploy/Caddyfile.oracle
+++ b/deploy/Caddyfile.oracle
@@ -8,18 +8,24 @@
 		request_body {
 			max_size 12MB
 		}
-		reverse_proxy server:8080
+		reverse_proxy server:8080 {
+			header_up Host {$BALLOON_CRUMBS_DOMAIN}
+		}
 	}
 
 	handle /api/* {
 		request_body {
 			max_size 64KB
 		}
-		reverse_proxy server:8080
+		reverse_proxy server:8080 {
+			header_up Host {$BALLOON_CRUMBS_DOMAIN}
+		}
 	}
 
 	handle /health/live {
-		reverse_proxy server:8080
+		reverse_proxy server:8080 {
+			header_up Host {$BALLOON_CRUMBS_DOMAIN}
+		}
 	}
 
 	@private_health path /health/*


### PR DESCRIPTION
## Summary
- preserve the configured public hostname while Oracle Caddy proxies API and liveness requests to the relay
- prevent TrustedHostMiddleware from rejecting all public app and planner traffic as `server:8080`

## Verification
- Caddy 2.11.4 config validation
- Oracle overlay `docker compose config`
- reproduced that direct API requests with the configured host succeed while the previous inner-proxy path returned 400