### PR TITLE
feat: prioritise field recovery operations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,17 +1,20 @@
 # Balloon Crumbs — Product Requirements and Delivery Plan
 
-Status: concept scaffold
+Status: private field-test iteration
 
 Working title: **Balloon Crumbs**
 
 Platforms: iOS and Android
 Initial users: UK hot-air-balloon pilots, ground crew, and chase drivers
 
-Active implementation specification:
-[role-specific live flight experience](docs/role-specific-live-flight-experience.md).
-This defines the production role/craft assignment, four distinct live views,
-planner-to-app contract, shared tracks and per-vehicle chase guidance that must
-land before the next broad live-flight UI implementation.
+Active product specification:
+[field operations and recovery coordination](docs/field-operations-recovery-plan.md).
+It is based on a complete launch-to-recovery field observation and makes crew
+assembly, live team tracking, CarPlay guidance, landing confirmation and land
+access the core product. The earlier
+[role-specific live flight experience](docs/role-specific-live-flight-experience.md)
+remains the technical foundation for role/craft assignment and shared tracks,
+but its pilot/planner emphasis no longer defines product priority.
 
 ## Problem statement
 
@@ -30,8 +33,10 @@ flight.
    is relayed over nearby or internet transport.
 3. **No false certainty.** Position, altitude, weather, and routing display a
    source, fix time, freshness, and uncertainty where available.
-4. **No account required.** A six-digit code or QR creates temporary,
-   operation-scoped membership for all participants.
+4. **No account required.** A memorable reusable crew-room alias identifies a
+   regular team, while a private stored credential, QR/link or explicit approval
+   grants access to each fresh operation. A guessable alias is never sufficient
+   authority on its own.
 5. **The road and the balloon are different systems.** Chase guidance chooses a
    legal road-accessible rendezvous; it never asks a vehicle to follow the raw
    airborne coordinate.

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -704,6 +704,7 @@ class RideController extends ChangeNotifier {
   static bool _affectsLifecycleOrRoute(RideEventType type) => switch (type) {
     RideEventType.rideCreated ||
     RideEventType.rideStarted ||
+    RideEventType.flightStartedByCrew ||
     RideEventType.ridePaused ||
     RideEventType.rideResumed ||
     RideEventType.rideEnded ||
@@ -1235,6 +1236,18 @@ class RideController extends ChangeNotifier {
         session.flightRole.hasFlightAuthority;
   }
 
+  /// Whether this device may record balloon release and begin live tracking.
+  ///
+  /// Field operations put the normal action with the chase team, while the
+  /// pilot remains an available fallback and retains separate authority over
+  /// balloon-only decisions.
+  bool get canStartFlight {
+    final session = _session;
+    return session != null &&
+        !session.requiresFlightAssignment &&
+        session.flightRole.mayStartFlight;
+  }
+
   /// Registers a balloon or vehicle in this ride.
   ///
   /// Idempotent by craft id: re-registering updates the label rather than
@@ -1603,16 +1616,26 @@ class RideController extends ChangeNotifier {
     if (rideStarted || rideEnded) return;
     await _run(() async {
       final session = _requireSession();
-      if (!hasFlightAuthority) {
-        throw const FormatException('Only the pilot can start the flight.');
+      if (!canStartFlight) {
+        throw const FormatException(
+          'Only the pilot or chase crew can start live tracking.',
+        );
       }
       await _record(
-        type: RideEventType.rideStarted,
+        type: hasFlightAuthority
+            ? RideEventType.rideStarted
+            : RideEventType.flightStartedByCrew,
         priority: EventPriority.important,
-        payload: {
-          'leaderRiderId': session.localRiderId,
-          'leaderDisplayName': session.displayName,
-        },
+        payload: hasFlightAuthority
+            ? {
+                'leaderRiderId': session.localRiderId,
+                'leaderDisplayName': session.displayName,
+              }
+            : {
+                'crewRiderId': session.localRiderId,
+                'crewDisplayName': session.displayName,
+                'flightRole': session.flightRole.name,
+              },
       );
     });
   }

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -403,6 +403,7 @@ class SituationalAwarenessController extends ChangeNotifier {
       case RideEventType.riderLeft:
       case RideEventType.roleChanged:
       case RideEventType.rideStarted:
+      case RideEventType.flightStartedByCrew:
       case RideEventType.statusMessage:
       case RideEventType.ridePaused:
       case RideEventType.rideResumed:

--- a/apps/mobile/lib/domain/flight_role.dart
+++ b/apps/mobile/lib/domain/flight_role.dart
@@ -52,9 +52,19 @@ extension FlightRoleLabel on FlightRole {
   /// warning is noise to a pilot and attention taken from flying.
   bool get seesRoadFurniture => this == FlightRole.chaseDriver;
 
-  /// Whether this role may start and end the flight, nominate the balloon's
-  /// primary device, or declare a landing.
+  /// Whether this role holds pilot-only authority over the balloon and shared
+  /// forecast. Starting live recovery is deliberately a separate permission:
+  /// field testing showed that the ground crew are the people free to do it at
+  /// release, while the pilot is occupied with the aircraft.
   bool get hasFlightAuthority => this == FlightRole.pilot;
+
+  /// Whether this role may begin live tracking when the balloon is released.
+  ///
+  /// The pilot remains a fallback for compatibility and unusual operations,
+  /// but both chase roles can take the normal field action. Balloon crew stay
+  /// out of this path for the same workload reason as the pilot, and observers
+  /// are always read-only.
+  bool get mayStartFlight => hasFlightAuthority || isChasing;
 }
 
 /// Reads a role name that another build may have written.

--- a/apps/mobile/lib/domain/landing_zone.dart
+++ b/apps/mobile/lib/domain/landing_zone.dart
@@ -121,6 +121,7 @@ class LandingZoneReducer {
           if (candidate != null) latest = candidate;
         case RideEventType.riderLeft:
         case RideEventType.rideStarted:
+        case RideEventType.flightStartedByCrew:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/domain/operational_boundary.dart
+++ b/apps/mobile/lib/domain/operational_boundary.dart
@@ -170,6 +170,7 @@ class OperationalBoundaryReducer {
           if (id is String) boundaries.remove(id);
         case RideEventType.riderLeft:
         case RideEventType.rideStarted:
+        case RideEventType.flightStartedByCrew:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/domain/ride_event.dart
+++ b/apps/mobile/lib/domain/ride_event.dart
@@ -100,6 +100,14 @@ enum RideEventType {
   /// The named recipient accepts a still-valid handover offer. Reducers apply
   /// the demotion and promotion atomically from this one shared journal fact.
   pilotHandoverAccepted,
+
+  /// A chase driver or chase-crew device records balloon release and begins
+  /// live recovery tracking.
+  ///
+  /// Additive rather than changing [rideStarted]: current pilot devices retain
+  /// the legacy event for mixed-build flights, while a relay can negotiate this
+  /// new ground-crew authority explicitly.
+  flightStartedByCrew,
 }
 
 enum EventPriority { routine, important, critical }

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -832,6 +832,8 @@ class _PreStartRidePanel extends StatelessWidget {
     required this.participants,
     required this.coordinationMode,
     required this.isLeader,
+    required this.canStartFlight,
+    required this.startBlockedReason,
     required this.busy,
     required this.routeName,
     required this.routeIsForecast,
@@ -844,6 +846,8 @@ class _PreStartRidePanel extends StatelessWidget {
   final List<RideParticipant> participants;
   final RideCoordinationMode coordinationMode;
   final bool isLeader;
+  final bool canStartFlight;
+  final String? startBlockedReason;
   final bool busy;
   final String? routeName;
   final bool routeIsForecast;
@@ -878,13 +882,13 @@ class _PreStartRidePanel extends StatelessWidget {
                       Text(
                         coordinationMode == RideCoordinationMode.solo
                             ? 'Ready for solo flight'
-                            : 'Waiting for launch',
+                            : 'Crew room ready',
                         style: TextStyle(fontWeight: FontWeight.w800),
                       ),
                       Text(
                         coordinationMode == RideCoordinationMode.solo
                             ? 'Tracking begins when you start'
-                            : 'Flight $rideCode · Current positions only until the coordinator starts',
+                            : 'Flight $rideCode · Live crew positions before release',
                         style: const TextStyle(
                           color: Color(0xFFA9B4C2),
                           fontSize: 12,
@@ -893,10 +897,12 @@ class _PreStartRidePanel extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (!isLeader)
-                  const Text(
-                    'COORDINATOR STARTS',
-                    style: TextStyle(
+                if (!canStartFlight)
+                  Text(
+                    startBlockedReason == null
+                        ? 'CHASE CREW STARTS'
+                        : 'SERVICE UPDATE NEEDED',
+                    style: const TextStyle(
                       color: Color(0xFFFFC857),
                       fontWeight: FontWeight.w800,
                       fontSize: 11,
@@ -904,7 +910,7 @@ class _PreStartRidePanel extends StatelessWidget {
                   ),
               ],
             ),
-            if (isLeader) ...[
+            if (canStartFlight) ...[
               const SizedBox(height: 10),
               Row(
                 children: [
@@ -924,11 +930,17 @@ class _PreStartRidePanel extends StatelessWidget {
                     child: FilledButton.icon(
                       key: const Key('start-ride-button'),
                       onPressed: busy ? null : onStartRide,
-                      icon: const Icon(Icons.play_arrow),
-                      label: const Text('Start flight'),
+                      icon: const Icon(Icons.flight_takeoff),
+                      label: const Text('Balloon released'),
                     ),
                   ),
                 ],
+              ),
+            ] else if (startBlockedReason != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                startBlockedReason!,
+                style: const TextStyle(color: Color(0xFFFFC857), fontSize: 12),
               ),
             ],
             const SizedBox(height: 9),
@@ -1774,6 +1786,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           ),
         );
         _internetRelayController = internetRelayController;
+        internetRelayController.addListener(_onInternetRelayChanged);
         _internetReceivedEventSubscription = internetRelayController
             .receivedEvents
             .listen(
@@ -3793,6 +3806,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (changed && mounted) setState(() {});
   }
 
+  void _onInternetRelayChanged() {
+    if (mounted) setState(() {});
+  }
+
   /// One reconciled live-position model: the durable journal, the internet
   /// presence channel, the nearby presence channel and the relay's
   /// cursor-independent roster, merged newest-sample-wins.
@@ -3997,6 +4014,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 participants: widget.rideController.liveParticipants,
                 coordinationMode: widget.rideController.coordinationMode,
                 isLeader: widget.rideController.hasFlightAuthority,
+                canStartFlight: _canStartFlightFromThisDevice,
+                startBlockedReason: _crewStartBlockedReason,
                 busy: widget.rideController.busy || _loading,
                 routeName: _activeRoute?.name,
                 routeIsForecast: _activeRoute?.isBalloonForecast == true,
@@ -4958,7 +4977,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   /// Offers only the final pre-departure decision on CarPlay. Ride creation,
   /// joining and route selection remain phone setup; this projection exists
-  /// only after that work is complete and only for the local leader.
+  /// only after that work is complete and only for an authorised local role.
   CarPlayRideStart? get _carPlayRideStart {
     final controller = widget.rideController;
     final locationReady =
@@ -4967,7 +4986,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         (_locationController?.status.canSample ?? false);
     return CarPlayRideStart.project(
       hasSession: controller.session != null,
-      isLeader: controller.isLocalRideLeader,
+      canStartFlight: _canStartFlightFromThisDevice,
       rideStarted: controller.rideStarted,
       rideEnded: controller.rideEnded,
       busy: controller.busy,
@@ -4979,13 +4998,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   /// Handles the confirmed native action. The snapshot that drew the button
-  /// may be stale, so leader, lifecycle, busy and location state are checked
+  /// may be stale, so role, lifecycle, busy and location state are checked
   /// again before the durable start event is recorded.
   Future<void> _startPreparedRideFromCarPlay() async {
     if (!mounted) return;
     final controller = widget.rideController;
     if (controller.session == null ||
-        !controller.isLocalRideLeader ||
+        !_canStartFlightFromThisDevice ||
         controller.rideStarted ||
         controller.rideEnded ||
         controller.busy ||
@@ -5359,24 +5378,25 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     }
     _rideStartFlowInProgress = true;
     try {
-      if (!controller.hasFlightAuthority || controller.rideStarted) {
+      if (!_canStartFlightFromThisDevice || controller.rideStarted) {
         _diagnostics?.recordNote(
-          'start flight refused before the dialog: no pilot authority, or already '
-          'started',
+          'start flight refused before the dialog: role or relay cannot start, '
+          'or already started',
         );
+        final reason = _crewStartBlockedReason;
+        if (reason != null && mounted) _showRideSnackBar(reason);
         return;
       }
       final route = _activeRoute;
       final decision = await showDialog<_StartRideDecision>(
         context: context,
         builder: (dialogContext) => AlertDialog(
-          title: const Text('Start this flight?'),
+          title: const Text('Balloon released?'),
           content: Text(
             route == null
-                ? 'No forecast plan or chase route is selected. You can '
-                      'choose one now, or start without one. Live location '
-                      'sharing and flight '
-                      'recording begin only after you start.'
+                ? 'Start live recovery tracking now. A forecast plan is '
+                      'optional; crew and balloon locations will continue to '
+                      'share without one.'
                 : route.isBalloonForecast
                 ? 'Forecast plan: ${route.name}\n\nThis is an advisory '
                       'wind-drift forecast, not a route the balloon can '
@@ -5393,19 +5413,19 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             ),
             if (route == null) ...[
               TextButton(
-                key: const Key('start-without-route-button'),
-                onPressed: () =>
-                    Navigator.pop(dialogContext, _StartRideDecision.start),
-                child: const Text('Start without a plan'),
-              ),
-              FilledButton.icon(
                 key: const Key('choose-route-before-start-button'),
                 onPressed: () => Navigator.pop(
                   dialogContext,
                   _StartRideDecision.chooseRoute,
                 ),
-                icon: const Icon(Icons.route_outlined),
-                label: const Text('Choose plan'),
+                child: const Text('Choose optional plan'),
+              ),
+              FilledButton.icon(
+                key: const Key('start-without-route-button'),
+                onPressed: () =>
+                    Navigator.pop(dialogContext, _StartRideDecision.start),
+                icon: const Icon(Icons.flight_takeoff),
+                label: const Text('Start tracking'),
               ),
             ] else
               FilledButton.icon(
@@ -5413,7 +5433,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 onPressed: () =>
                     Navigator.pop(dialogContext, _StartRideDecision.start),
                 icon: const Icon(Icons.play_arrow),
-                label: const Text('Start flight'),
+                label: const Text('Start tracking'),
               ),
           ],
         ),
@@ -6165,6 +6185,30 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       ) ??
       true;
 
+  bool get _relayCanCarryCrewFlightLifecycle =>
+      _internetRelayController?.supportsCapability(
+        RelayProtocolCapabilities.crewFlightLifecycle,
+      ) ??
+      true;
+
+  bool get _canStartFlightFromThisDevice {
+    final controller = widget.rideController;
+    if (!controller.canStartFlight) return false;
+    // Pilot start retains the legacy event and therefore does not depend on the
+    // additive crew-lifecycle capability.
+    return controller.hasFlightAuthority || _relayCanCarryCrewFlightLifecycle;
+  }
+
+  String? get _crewStartBlockedReason {
+    final controller = widget.rideController;
+    if (!controller.canStartFlight || controller.hasFlightAuthority) {
+      return null;
+    }
+    if (_relayCanCarryCrewFlightLifecycle) return null;
+    return 'This flight service cannot yet share a chase-crew start. Update the '
+        'service before using this device to begin live tracking.';
+  }
+
   List<RideDestination> get _rideDestinations =>
       rideDestinations(simulation: _isSimulation);
 
@@ -6650,6 +6694,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     _simulationLandingZone.dispose();
     _sharedLandingZone.dispose();
     _preStartPresenceController?.removeListener(_onPreStartPresenceChanged);
+    _internetRelayController?.removeListener(_onInternetRelayChanged);
     unawaited(_spokenGuidance?.stop());
     _awarenessController?.removeListener(_onAwarenessChanged);
     if (_awarenessController case final awareness?) {

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -1230,6 +1230,7 @@ class _EventRow extends StatelessWidget {
       RideEventType.riderLeft => 'Left flight',
       RideEventType.roleChanged => 'Role changed',
       RideEventType.rideStarted => 'Flight started',
+      RideEventType.flightStartedByCrew => 'Tracking started by chase crew',
       // Also the acknowledgement of another rider's message, which is a
       // `statusMessage` carrying `acknowledgesQuickMessageEventId` and the label
       // "Seen: <what they raised>" (#151). One row either way: the log records

--- a/apps/mobile/lib/internet/internet_relay_client.dart
+++ b/apps/mobile/lib/internet/internet_relay_client.dart
@@ -91,6 +91,10 @@ abstract final class RelayProtocolCapabilities {
   /// be done.
   static const rideReopen = 'ride-reopen-v1';
 
+  /// A chase-role device starting live tracking at balloon release. Kept
+  /// additive because older clients understand only pilot-authored rideStarted.
+  static const crewFlightLifecycle = 'crew-flight-lifecycle-v1';
+
   static const current = {
     rideStart,
     membership,
@@ -104,6 +108,7 @@ abstract final class RelayProtocolCapabilities {
     riderContactSharing,
     pilotHandover,
     rideReopen,
+    crewFlightLifecycle,
   };
 }
 

--- a/apps/mobile/lib/internet/internet_relay_worker.dart
+++ b/apps/mobile/lib/internet/internet_relay_worker.dart
@@ -452,6 +452,8 @@ class InternetRelayWorker {
       RideEventType.pilotHandoverAccepted =>
         RelayProtocolCapabilities.pilotHandover,
       RideEventType.rideReopened => RelayProtocolCapabilities.rideReopen,
+      RideEventType.flightStartedByCrew =>
+        RelayProtocolCapabilities.crewFlightLifecycle,
       _ => null,
     };
     return capability == null || compatibility.supports(capability);

--- a/apps/mobile/lib/services/carplay_bridge.dart
+++ b/apps/mobile/lib/services/carplay_bridge.dart
@@ -630,8 +630,9 @@ class CarPlayBridge {
   }
 }
 
-/// A leader-owned ride that has already been configured on the phone and can
-/// therefore be started without moving route or group setup onto CarPlay.
+/// A flight that has already been configured on the phone and can therefore be
+/// started by an authorised pilot or chase device without moving setup onto
+/// CarPlay.
 class CarPlayRideStart {
   const CarPlayRideStart({
     required this.enabled,
@@ -647,7 +648,7 @@ class CarPlayRideStart {
 
   static CarPlayRideStart? project({
     required bool hasSession,
-    required bool isLeader,
+    required bool canStartFlight,
     required bool rideStarted,
     required bool rideEnded,
     required bool busy,
@@ -656,7 +657,7 @@ class CarPlayRideStart {
     String? routeName,
     bool routeIsBalloonForecast = false,
   }) {
-    if (!hasSession || !isLeader || rideStarted || rideEnded) return null;
+    if (!hasSession || !canStartFlight || rideStarted || rideEnded) return null;
     return CarPlayRideStart(
       enabled: !busy && locationReady,
       detail: routeIsBalloonForecast

--- a/apps/mobile/lib/services/chase_guidance_target.dart
+++ b/apps/mobile/lib/services/chase_guidance_target.dart
@@ -85,6 +85,7 @@ class ChaseGuidanceSelectionReducer {
         case RideEventType.riderLeft:
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
+        case RideEventType.flightStartedByCrew:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/services/craft_roster.dart
+++ b/apps/mobile/lib/services/craft_roster.dart
@@ -152,6 +152,7 @@ class CraftRosterReducer {
         case RideEventType.riderLeft:
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
+        case RideEventType.flightStartedByCrew:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -77,6 +77,7 @@ class CraftTrackReducer {
         case RideEventType.riderLeft:
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
+        case RideEventType.flightStartedByCrew:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/flight_replay_archiver.dart
+++ b/apps/mobile/lib/services/flight_replay_archiver.dart
@@ -112,6 +112,7 @@ class FlightReplayArchiver {
         case RideEventType.riderLeft:
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
+        case RideEventType.flightStartedByCrew:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/ride_lifecycle.dart
+++ b/apps/mobile/lib/services/ride_lifecycle.dart
@@ -1,4 +1,5 @@
 import '../domain/ride_event.dart';
+import '../domain/flight_role.dart';
 import '../domain/ride_role.dart';
 import 'ride_event_authenticator.dart';
 
@@ -17,8 +18,9 @@ class RideLifecycle {
 ///
 /// Events are ordered by timestamp and then ID so every device chooses the
 /// same start after offline delivery, retries, or duplicate start taps. A
-/// start is accepted only from a rider whose latest signed role at that point
-/// is lead, and the event must identify its author as that leader.
+/// legacy pilot start is accepted only from a rider whose latest signed role at
+/// that point is lead. The additive ground-crew start is accepted only when the
+/// same journal already identifies its author as chase driver or chase crew.
 class RideLifecycleReducer {
   const RideLifecycleReducer._();
 
@@ -37,6 +39,9 @@ class RideLifecycleReducer {
             .toList(growable: false)
           ..sort(compareEvents);
     final roles = <String, RideRole>{};
+    final flightRoles = <String, FlightRole>{};
+    final vehicleCraftIds = <String>{};
+    final craftByDevice = <String, String>{};
 
     for (final event in ordered) {
       switch (event.type) {
@@ -45,11 +50,35 @@ class RideLifecycleReducer {
         case RideEventType.roleChanged:
           final role = _roleFromPayload(event.payload['role']);
           if (role != null) roles[event.deviceId] = role;
+          final flightRole = _flightRoleFromPayload(
+            event.payload['flightRole'],
+          );
+          if (flightRole != null) flightRoles[event.deviceId] = flightRole;
           break;
         case RideEventType.rideStarted:
           if (roles[event.deviceId] == RideRole.lead &&
               event.payload['leaderRiderId'] == event.deviceId) {
             return RideLifecycle(startEvent: event);
+          }
+        case RideEventType.flightStartedByCrew:
+          final recordedRole = flightRoles[event.deviceId];
+          if (recordedRole != null &&
+              recordedRole.isChasing &&
+              vehicleCraftIds.contains(craftByDevice[event.deviceId]) &&
+              event.payload['crewRiderId'] == event.deviceId &&
+              event.payload['flightRole'] == recordedRole.name) {
+            return RideLifecycle(startEvent: event);
+          }
+        case RideEventType.craftRegistered:
+          final craftId = event.payload['craftId'];
+          if (craftId is String && event.payload['kind'] == 'vehicle') {
+            vehicleCraftIds.add(craftId);
+          }
+        case RideEventType.deviceAttachedToCraft:
+          final deviceId = event.payload['deviceId'];
+          final craftId = event.payload['craftId'];
+          if (deviceId is String && craftId is String) {
+            craftByDevice[deviceId] = craftId;
           }
         case RideEventType.riderLeft:
         case RideEventType.statusMessage:
@@ -66,8 +95,6 @@ class RideLifecycleReducer {
         case RideEventType.iceInfoShared:
         case RideEventType.iceInfoViewed:
         case RideEventType.riderContactShared:
-        case RideEventType.craftRegistered:
-        case RideEventType.deviceAttachedToCraft:
         case RideEventType.craftPrimaryDeviceNominated:
         case RideEventType.craftChaseAssigned:
         case RideEventType.landingAreaNoted:
@@ -92,6 +119,15 @@ class RideLifecycleReducer {
     if (value is! String) return null;
     try {
       return RideRole.values.byName(value);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  static FlightRole? _flightRoleFromPayload(Object? value) {
+    if (value is! String) return null;
+    try {
+      return FlightRole.values.byName(value);
     } on ArgumentError {
       return null;
     }

--- a/apps/mobile/lib/services/ride_route_reducer.dart
+++ b/apps/mobile/lib/services/ride_route_reducer.dart
@@ -142,6 +142,7 @@ class RideRouteReducer {
           break;
         case RideEventType.riderLeft:
         case RideEventType.rideStarted:
+        case RideEventType.flightStartedByCrew:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/test/controllers/ride_controller_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_test.dart
@@ -366,6 +366,60 @@ void main() {
     );
   });
 
+  test('chase crew can start live tracking at balloon release', () async {
+    await controller.createRide('Oliver');
+    final chaseCrew = await joinedController(FlightRole.chaseCrew);
+
+    await chaseCrew.startRide();
+
+    expect(chaseCrew.errorMessage, isNull);
+    expect(chaseCrew.rideStarted, isTrue);
+    final start = chaseCrew.events.singleWhere(
+      (event) => event.type == RideEventType.flightStartedByCrew,
+    );
+    expect(start.payload, {
+      'crewRiderId': chaseCrew.session!.localRiderId,
+      'crewDisplayName': 'Alex',
+      'flightRole': 'chaseCrew',
+    });
+
+    for (final event in chaseCrew.events) {
+      controller.ingestStoredEvent(event);
+    }
+    expect(controller.rideStarted, isTrue);
+    expect(controller.rideStartedAt, start.createdAt);
+  });
+
+  test('balloon device cannot forge a chase role to start tracking', () async {
+    await controller.createRide('Oliver');
+    final balloonCrew = await joinedController(FlightRole.balloonCrew);
+    final session = balloonCrew.session!;
+    final forgedRole = _signedEvent(
+      session: session,
+      id: 'forged-chase-role',
+      type: RideEventType.roleChanged,
+      createdAt: DateTime.utc(2026, 7, 16, 12, 2),
+      payload: const {'role': 'rider', 'flightRole': 'chaseCrew'},
+    );
+    final forged = _signedEvent(
+      session: session,
+      id: 'forged-crew-start',
+      type: RideEventType.flightStartedByCrew,
+      createdAt: DateTime.utc(2026, 7, 16, 12, 3),
+      payload: {
+        'crewRiderId': session.localRiderId,
+        'crewDisplayName': session.displayName,
+        'flightRole': FlightRole.chaseCrew.name,
+      },
+    );
+
+    balloonCrew
+      ..ingestStoredEvent(forgedRole)
+      ..ingestStoredEvent(forged);
+
+    expect(balloonCrew.rideStarted, isFalse);
+  });
+
   test(
     'offline leader handover and duplicate starts converge deterministically',
     () async {

--- a/apps/mobile/test/internet/internet_relay_worker_test.dart
+++ b/apps/mobile/test/internet/internet_relay_worker_test.dart
@@ -247,6 +247,9 @@ void main() {
     await eventStore.append(
       _event(id: 'route', type: RideEventType.routeCleared),
     );
+    await eventStore.append(
+      _event(id: 'crew-start', type: RideEventType.flightStartedByCrew),
+    );
     final api = _CompatibilityApi(
       compatibility: _compatibility(
         RelayCompatibilityDisposition.legacyCompatible,
@@ -274,6 +277,12 @@ void main() {
         _session.rideId,
       )).map((event) => event.id),
       containsAll(['departure', 'route']),
+    );
+    expect(
+      (await eventStore.pendingEvents(
+        _session.rideId,
+      )).map((event) => event.id),
+      contains('crew-start'),
     );
     await worker.close();
   });

--- a/apps/mobile/test/services/carplay_bridge_test.dart
+++ b/apps/mobile/test/services/carplay_bridge_test.dart
@@ -191,10 +191,10 @@ void main() {
     });
   });
 
-  test('offers prepared-ride start only to an eligible leader', () {
+  test('offers prepared-flight start only to an eligible operational role', () {
     CarPlayRideStart? project({
       bool hasSession = true,
-      bool isLeader = true,
+      bool canStartFlight = true,
       bool rideStarted = false,
       bool rideEnded = false,
       bool busy = false,
@@ -202,7 +202,7 @@ void main() {
       bool isGroup = false,
     }) => CarPlayRideStart.project(
       hasSession: hasSession,
-      isLeader: isLeader,
+      canStartFlight: canStartFlight,
       rideStarted: rideStarted,
       rideEnded: rideEnded,
       busy: busy,
@@ -211,7 +211,7 @@ void main() {
     );
 
     expect(project(hasSession: false), isNull);
-    expect(project(isLeader: false), isNull);
+    expect(project(canStartFlight: false), isNull);
     expect(project(rideStarted: true), isNull);
     expect(project(rideEnded: true), isNull);
 
@@ -231,7 +231,7 @@ void main() {
 
     final forecast = CarPlayRideStart.project(
       hasSession: true,
-      isLeader: true,
+      canStartFlight: true,
       rideStarted: false,
       rideEnded: false,
       busy: false,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -632,8 +632,11 @@ void main() {
     await tester.pumpWidget(_app(controller));
     await tester.pumpAndSettle();
 
-    expect(find.text('Waiting for launch'), findsOneWidget);
-    expect(find.textContaining('Current positions only'), findsOneWidget);
+    expect(find.text('Crew room ready'), findsOneWidget);
+    expect(
+      find.textContaining('Live crew positions before release'),
+      findsOneWidget,
+    );
     expect(find.byKey(const Key('pre-start-roster')), findsOneWidget);
     expect(find.textContaining('Oliver (you)'), findsOneWidget);
     expect(
@@ -644,9 +647,9 @@ void main() {
 
     await tester.tap(find.byKey(const Key('start-ride-button')));
     await tester.pumpAndSettle();
-    expect(find.text('Start this flight?'), findsOneWidget);
+    expect(find.text('Balloon released?'), findsOneWidget);
     expect(
-      find.textContaining('No forecast plan or chase route is selected'),
+      find.textContaining('Start live recovery tracking now'),
       findsOneWidget,
     );
 
@@ -654,7 +657,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(controller.rideStarted, isTrue);
-    expect(find.text('Waiting for launch'), findsNothing);
+    expect(find.text('Crew room ready'), findsNothing);
     expect(find.text('Navigation map'), findsOneWidget);
   });
 

--- a/apps/server/src/balloon_crumbs_server/config.py
+++ b/apps/server/src/balloon_crumbs_server/config.py
@@ -102,6 +102,10 @@ class Settings(BaseSettings):
             # its leader back on the map while every other rider still sees a
             # finished ride.
             "ride-reopen-v1",
+            # A chase-role device may record balloon release and begin live
+            # recovery tracking. Additive so older relays reject rather than
+            # silently storing an event they did not negotiate.
+            "crew-flight-lifecycle-v1",
         ]
     )
     required_capabilities: list[str] = Field(default_factory=list)

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -88,6 +88,9 @@ EVENT_TYPES = {
     # after all. Deliberately not "rideResumed", which is the other half of
     # "ridePaused"; conflating them would make a pause look like a resurrection.
     "rideReopened",
+    # Field-operations lifecycle. Clients validate the signed author's explicit
+    # chase role; the relay remains payload-opaque and only bounds/carries it.
+    "flightStartedByCrew",
 }
 PRIORITIES = {"routine", "important", "critical"}
 EVENT_FIELDS = {
@@ -1043,6 +1046,7 @@ class RelayService:
             "deviceAttachedToCraft": timedelta(hours=72),
             "craftPrimaryDeviceNominated": timedelta(hours=72),
             "craftChaseAssigned": timedelta(hours=72),
+            "flightStartedByCrew": timedelta(hours=72),
             "landingAreaNoted": timedelta(hours=72),
             "windContextNoted": timedelta(hours=72),
             "operationalBoundaryUpserted": timedelta(hours=72),

--- a/apps/server/tests/test_additive_event_types.py
+++ b/apps/server/tests/test_additive_event_types.py
@@ -49,6 +49,35 @@ def test_retention_table_matches_the_documented_bands() -> None:
     # gets, and is capped independently of whatever expiry a client asks for.
     assert retention("riderContactShared") == timedelta(hours=2)
     assert retention("riderContactShared") == retention("iceInfoShared")
+    assert retention("flightStartedByCrew") == timedelta(hours=72)
+
+
+def test_ground_crew_start_is_accepted_and_relayed(client, synchronize, make_event) -> None:
+    ride_id = "ride-ground-crew-start"
+    start = make_event(
+        ride_id,
+        "event-ground-start",
+        event_type="flightStartedByCrew",
+        payload={
+            "crewRiderId": "device-a",
+            "crewDisplayName": "Alex",
+            "flightRole": "chaseCrew",
+        },
+    )
+
+    uploaded = synchronize(client, ride_id=ride_id, secret=SECRET, events=[start])
+    assert uploaded.status_code == 200
+    assert uploaded.json()["acceptedEventIds"] == ["event-ground-start"]
+
+    downloaded = synchronize(
+        client,
+        ride_id=ride_id,
+        secret=SECRET,
+        device_id="device-b",
+        cursor=None,
+    )
+    assert downloaded.status_code == 200
+    assert [event["type"] for event in downloaded.json()["events"]] == ["flightStartedByCrew"]
 
 
 def test_a_shared_phone_number_is_accepted_and_capped(client, synchronize, make_event) -> None:

--- a/apps/server/tests/test_compatibility.py
+++ b/apps/server/tests/test_compatibility.py
@@ -6,6 +6,7 @@ from balloon_crumbs_server.app import create_app
 
 SECRET = "0123456789abcdef0123456789abcdef"
 CURRENT_CAPABILITIES = [
+    "crew-flight-lifecycle-v1",
     "ride-start-v1",
     "live-presence-v2",
     "membership-v1",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,10 @@
 # Initial Backlog
 
+Field evidence from 23 August 2026 is planned in
+[field operations and recovery coordination](field-operations-recovery-plan.md).
+Its recovery-first P0 order supersedes the earlier pilot/planner ordering below;
+the existing work packages remain useful implementation dependencies.
+
 The next coordinated implementation is specified in
 [role-specific live flight experience](role-specific-live-flight-experience.md).
 Its slices supersede implementing WP3/WP5/WP6/WP7/WP10b/WP11 independently:

--- a/docs/field-operations-recovery-plan.md
+++ b/docs/field-operations-recovery-plan.md
@@ -1,0 +1,262 @@
+# Field operations and recovery coordination
+
+Status: **Accepted — field evidence supersedes earlier product prioritisation**
+
+Date: 23 August 2026
+
+Evidence: one complete UK balloon setup, launch, chase, landing and recovery
+observed with the current tester build.
+
+## Problem statement
+
+The useful job for Balloon Crumbs is not predicting where a pilot intends to
+fly. In a real launch the destination is unknown, the pilot is occupied, and the
+phone is primarily a shared moving picture for the recovery team. The product
+must therefore optimise the pre-launch crew room, live balloon/vehicle
+coordination, in-car guidance, landing confirmation and final land access.
+
+The planner remains useful for learning and forecast exploration, but a flight
+must work completely without a plan. Aviation chart context must not displace
+the road and field detail the recovery crew needs.
+
+## Goals
+
+1. A regular crew can reopen its familiar private crew room and have every
+   device ready before balloon setup begins.
+2. A chase participant, not the busy pilot, can mark the release and begin the
+   shared live phase.
+3. CarPlay provides a glanceable two-dimensional team map and continuously
+   recalculated lawful road guidance towards either the balloon or its current
+   landing intent.
+4. Every device sees the balloon's measured direction, speed, track, freshness
+   and a clearly labelled forecast landing envelope, plus all shared vehicle
+   positions and tracks.
+5. The team can publish a distinct **LANDED** state and an honest best-known
+   recovery location without prematurely ending tracking.
+6. Crews can retain useful private land-access knowledge without creating an
+   ungoverned public directory of landowners' personal information.
+
+## Non-goals
+
+- The live app is not a certified aviation chart, briefing or flight-control
+  tool. Airspace may remain as optional planner context, not a default live
+  layer.
+- A forecast landing envelope is not a promise of where the balloon will land
+  or that access is safe or permitted.
+- A reusable human code is not itself a permanent bearer secret. Knowing a
+  guessable word such as `TUCKER` must not silently grant access to future
+  flights.
+- The first land-access release will not publish landowner contacts to all app
+  users, rank individuals, or claim that a polygon proves ownership.
+- A ground declaration of landing will not invent an exact balloon coordinate
+  when the declaring device has only a stale or relayed position.
+
+## Primary user stories
+
+- As a regular crew member, I can reopen `TUCKER` and see who is ready without
+  exposing a new flight to somebody who merely guesses that word.
+- As chase crew, I can mark balloon release once the basket is airborne so the
+  pilot is not responsible for starting the recovery system.
+- As a chase driver, I can use CarPlay to see the whole team and receive lawful
+  live road guidance without handling the phone.
+- As balloon or ground crew, I can declare and, if necessary, retract LANDED
+  while all devices continue sharing through recovery.
+- As recovery crew, I can record a field access note for my private crew and
+  distinguish a remembered contact from authoritative ownership data.
+- As a person named in an access note, I can have my contact details corrected
+  or removed without needing a Balloon Crumbs account.
+
+## Product decisions
+
+### 1. Coordination is core; planning is optional
+
+- The home hierarchy leads with **Open crew room**, **Join crew**, and the last
+  active recovery. **Planner** remains available under planning/tools.
+- Creating or joining a live flight never requires a forecast route, intended
+  landing area, altitude plan, wind model or airspace layer.
+- Planner imports remain preserved as optional context and must never overwrite
+  a vehicle's local road route.
+
+### 2. Reusable crew rooms, fresh flight operations
+
+The user-facing reusable value is a **crew code**, not a never-ending flight.
+
+- A coordinator chooses a normalised 5–12 character alias such as `TUCKER`.
+- The alias identifies a persistent crew room and can be reused across days.
+- Each launch creates a fresh operation ID, event journal, retention window and
+  invite capability beneath that crew room. Old tracks never appear in a new
+  launch by code reuse alone.
+- Returning devices keep a private crew-room credential locally and can rejoin
+  quickly. A first-time device needs a QR/private link or an explicit approval
+  from a present trusted device; the memorable alias alone is insufficient.
+- Alias lookup is rate-limited, does not reveal crew membership, and supports
+  revocation, transfer and deletion without accounts.
+- If the relay is unavailable, a QR/private link can still bootstrap nearby
+  membership using the existing offline invitation path.
+
+### 3. The crew assembles before setup
+
+The pre-launch surface is a persistent lobby, not a temporary modal.
+
+- It groups people by Balloon and each chase vehicle, with role, device
+  freshness and readiness.
+- It stays useful for tens of minutes while the balloon is prepared.
+- Late joining is allowed, but the start confirmation names missing/stale
+  expected devices rather than silently pretending the crew is complete.
+- A person can correct their craft or role before release without recreating the
+  room.
+
+### 4. Ground crew controls release; landing is a separate phase
+
+Lifecycle:
+
+```text
+crew room -> setting up -> released/live -> landed/recovery -> complete
+```
+
+- Chase driver and chase crew devices may publish **Balloon released / Start
+  tracking**. The pilot retains a secondary recovery action but is never the
+  person the primary flow waits for.
+- The event records who acted, their flight role and the confirmation time.
+- Pilot, balloon crew, chase driver and chase crew may declare **LANDED**.
+- A declaration states its evidence: device in balloon, witnessed, radio
+  confirmation, or manually marked location.
+- A fresh balloon-device fix can become the confirmed landing point. A ground
+  declaration using a relayed fix keeps its age/source and is labelled
+  best-known until confirmed or manually corrected.
+- LANDED stops route prediction growth, alerts the team and retargets recovery
+  guidance, but location sharing continues until **Recovery complete**.
+- A mistaken landing declaration can be retracted with an attributable event.
+
+### 5. Live recovery map
+
+Default live layers:
+
+- road basemap;
+- balloon marker with ground-track arrow, speed, altitude and fix age;
+- altitude-coloured measured balloon track;
+- each vehicle's position, direction, freshness and complete shared track;
+- intended landing point when one has been published;
+- forecast possible-landing envelope computed from the latest usable balloon
+  fix, altitude and timestamped Open-Meteo wind inputs;
+- each chaser's own lawful road route and selected target.
+
+The user can lock the camera **North up** or **Direction up**. That preference
+persists independently on phone and CarPlay. Aeronautical tiles are removed from
+the default live hierarchy. A detailed Ordnance Survey layer is an optional
+final-approach basemap after its API key, attribution, offline behaviour and
+licence are implemented behind the existing map-provider boundary.
+
+### 6. CarPlay is a P0 chase surface
+
+- CarPlay shows one 2D recovery map containing the local vehicle, balloon,
+  recent balloon/vehicle traces, other chase vehicles, landing intent/envelope
+  and the current road route.
+- Guidance continuously recalculates to the selected safe road rendezvous near
+  the balloon or to the currently published landing area.
+- North-up and direction-up are available as one-tap map buttons.
+- Touch interactions while moving remain bounded by CarPlay templates;
+  retargeting is voice-first or performed by chase crew on a phone.
+- The existing native CarPlay implementation must be stripped of inherited
+  ride/rider/speed-camera hierarchy that is not part of recovery.
+- Shipping requires Apple's `com.apple.developer.carplay-maps` entitlement, a
+  matching provisioning profile, App Store review compliance and validation in
+  a physical vehicle. Simulator evidence alone is insufficient.
+
+### 7. Privacy-first land access knowledge
+
+The minimum useful record is a crew-private **access note**:
+
+- user-drawn polygon or point;
+- first name or role, optional phone number;
+- access/gate notes;
+- neutral outcome such as `permission granted`, `ask again`, `declined`, or
+  `unknown` rather than a public reputation score;
+- date confirmed, who recorded it, provenance and expiry/review date;
+- explicit owner/contact consent status when personal details were provided.
+
+V1 is device-local with encrypted export/import for a deliberate crew. Relay
+sync or club sharing is blocked until the controller, lawful basis, privacy
+notice, access controls, audit trail, retention, correction, erasure and abuse
+reporting are designed and tested. The subject must have a practical removal
+route even if they do not use the app.
+
+HM Land Registry INSPIRE Index Polygons may provide an optional boundary
+reference in England and Wales. They show the indicative extent of a subset of
+registered freehold titles and an ID; they do not provide the owner's name or
+contact details and must not be presented as proof of ownership. User-supplied
+contacts remain a separate private overlay.
+
+## Priority and phases
+
+### P0 — next field-test loop
+
+1. Crew-led start, shared LANDED/retract state and recovery-complete lifecycle.
+2. Reusable crew-room alias and returning-device credentials.
+3. Road-first live map with shared full tracks, balloon direction/speed,
+   forecast landing envelope and North-up/Direction-up camera modes.
+4. Recovery-specific CarPlay map, dynamic target selection and physical-car
+   evidence.
+5. Simulator and relay fixtures for long pre-launch waits, release, stale fixes,
+   radio-confirmed landing and reconnect.
+
+### P1 — field approach and access
+
+1. Optional OS OpenData/Premium basemap behind a bounded relay proxy.
+2. Device-local land-access notes, encrypted backup and deletion tools.
+3. Optional INSPIRE polygon reference with source, update date and limitations.
+4. Planner moved out of the primary live-flight hierarchy while remaining
+   maintained and linkable.
+
+### P2 — only after privacy evidence
+
+- opt-in crew/club land-access sharing;
+- contact-subject correction and removal portal;
+- moderated provenance/conflict handling;
+- Android Auto recovery surface after the CarPlay field loop is proven.
+
+## Acceptance metrics
+
+- All expected devices can remain visible in a pre-launch room for 45 minutes
+  and reconnect without creating duplicate craft or people.
+- A returning crew opens its room in under 30 seconds; a new member joins by QR
+  in under 60 seconds.
+- A chase device can start the live phase within 15 seconds of balloon release,
+  and all connected devices converge on the start within 10 seconds.
+- A LANDED declaration reaches connected chasers within 10 seconds and never
+  ends sharing automatically.
+- During a 60-minute replay, every shared track retains its full bounded history
+  and no stale fix is labelled live.
+- Phone and CarPlay camera mode survives reconnect and relaunch.
+- CarPlay completes a physical launch-to-recovery field test without requiring
+  unsafe phone interaction from the driver.
+- No land-contact record can be relayed or exported without an explicit action;
+  all exported records retain provenance, confirmation date and deletion data.
+
+## Provider and governance evidence
+
+- [Apple CarPlay entitlement documentation](https://developer.apple.com/documentation/carplay/requesting-carplay-entitlements)
+  requires category approval, the navigation entitlement and matching signing
+  configuration.
+- [OS Maps API](https://docs.os.uk/os-apis/accessing-os-apis/os-maps-api) provides
+  road/outdoor/light/leisure raster styles. [OS Data Hub plans](https://osdatahub.os.uk/plans/)
+  distinguish unlimited OpenData from premium data and its current credit and
+  usage terms.
+- [HM Land Registry INSPIRE guidance](https://www.gov.uk/guidance/inspire-index-polygons-spatial-data)
+  describes indicative registered-property polygons, not owner contacts.
+- [ICO lawful-basis guidance](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/)
+  and [right-to-erasure guidance](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/individual-rights/individual-rights/right-to-erasure/)
+  define the governance gate before shared personal land-contact data.
+
+## Ticket map
+
+- [#70 — field-feedback recovery-coordination epic](https://github.com/osholt/balloon-crumbs/issues/70)
+- [#71 — reusable named crew rooms](https://github.com/osholt/balloon-crumbs/issues/71)
+- [#72 — chase-led start and shared LANDED state](https://github.com/osholt/balloon-crumbs/issues/72)
+- [#73 — road-first shared recovery map](https://github.com/osholt/balloon-crumbs/issues/73)
+- [#15 — recovery-specific CarPlay chase map](https://github.com/osholt/balloon-crumbs/issues/15)
+- [#74 — long pre-launch and recovery acceptance matrix](https://github.com/osholt/balloon-crumbs/issues/74)
+- [#75 — optional OS final-approach basemap](https://github.com/osholt/balloon-crumbs/issues/75)
+- [#76 — device-local privacy-governed land access notes](https://github.com/osholt/balloon-crumbs/issues/76)
+- [#77 — HMLR INSPIRE boundary reference](https://github.com/osholt/balloon-crumbs/issues/77)
+- [#17 — optional planner-only aeronautical context](https://github.com/osholt/balloon-crumbs/issues/17)

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -1,11 +1,18 @@
 # Role-specific live flight experience
 
-Status: **Accepted — implementation in progress**
+Status: **Implemented technical foundation — product priority superseded**
 
 Date: 23 August 2026
 
 Scope: iOS and Android live-flight experience, its shared domain state, and the
 contract used to bring web-planner forecasts into a running flight.
+
+The launch-to-recovery field observation documented in
+[field operations and recovery coordination](field-operations-recovery-plan.md)
+supersedes this document where priorities conflict. Roles, crafts, shared tracks
+and route-state separation remain required architecture. Planning and pilot
+interaction are no longer the core workflow; crew assembly, recovery mapping,
+CarPlay, crew-led release and landing confirmation are.
 
 ## Executive summary
 


### PR DESCRIPTION
## Summary

- capture the 23 August launch-to-recovery field evidence as the active product plan and link the new #70–#77 delivery ticket set
- make planning optional in the release flow and expose **Balloon released** as the primary phone and CarPlay action
- allow validated chase-driver/chase-crew devices to start live tracking through an additive signed event and negotiated relay capability
- retain the legacy pilot start event for compatibility and reject crew starts without both a chase role and vehicle attachment
- reprioritise CarPlay, road maps, optional OS detail, aeronautical context, and privacy-governed land access work

## Verification

- `flutter analyze`
- `flutter test` — 1,781 passed, 24 intentional skips
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` — 138 passed

## Follow-up

This begins #72 with chase-led start. Shared LANDED/retract/recovery-complete state remains in that ticket. Reusable crew rooms, the road-first map, physical CarPlay validation, OS detail and land-access governance remain separate reviewable slices under #70.

Refs #70
Refs #72