### PR TITLE
feat: add shared LANDED recovery lifecycle

### DIFF
--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -12,6 +12,7 @@ import '../services/craft_roster.dart';
 import '../services/chase_guidance_target.dart';
 import '../domain/event_store.dart';
 import '../domain/flight_replay.dart';
+import '../domain/flight_landing.dart';
 import '../domain/flight_role.dart';
 import '../domain/geo_point.dart' as awareness_geo;
 import '../domain/ice_share.dart';
@@ -27,6 +28,7 @@ import '../domain/ride_role.dart';
 import '../domain/ride_join_payload.dart';
 import '../domain/ride_session.dart';
 import '../domain/rider_color.dart';
+import '../domain/rider_location.dart';
 import '../domain/session_store.dart';
 import '../features/map/craft_icon.dart';
 import '../relay/live_presence.dart';
@@ -122,6 +124,8 @@ class RideController extends ChangeNotifier {
   int _membershipProjectionCount = 0;
   LandingZoneTarget? _landingZoneCache;
   bool _landingZoneDirty = true;
+  FlightLandingState _flightLandingCache = const FlightLandingState();
+  bool _flightLandingDirty = true;
   List<OperationalBoundary> _operationalBoundaryCache = const [];
   bool _operationalBoundaryDirty = true;
 
@@ -240,6 +244,21 @@ class RideController extends ChangeNotifier {
       _landingZoneDirty = false;
     }
     return _landingZoneCache;
+  }
+
+  /// The latest valid shared LANDED/retraction state.
+  FlightLandingState get flightLanding {
+    final activeSession = _session;
+    if (activeSession == null) return const FlightLandingState();
+    if (_flightLandingDirty) {
+      _flightLandingCache = const FlightLandingReducer().fromEvents(
+        rideId: activeSession.rideId,
+        inviteSecret: activeSession.inviteSecret,
+        events: _events,
+      );
+      _flightLandingDirty = false;
+    }
+    return _flightLandingCache;
   }
 
   /// Pilot-authored advisory lines, areas and altitude bands for this flight.
@@ -690,6 +709,10 @@ class RideController extends ChangeNotifier {
     if (_affectsFlightSetup(event.type)) {
       _landingZoneDirty = true;
       _operationalBoundaryDirty = true;
+    }
+    if (event.type == RideEventType.flightLanded ||
+        event.type == RideEventType.flightLandingRetracted) {
+      _flightLandingDirty = true;
     }
     if (_affectsLifecycleOrRoute(event.type)) {
       _rebuildLifecycle();
@@ -1248,6 +1271,13 @@ class RideController extends ChangeNotifier {
         session.flightRole.mayStartFlight;
   }
 
+  bool get canManageRecovery {
+    final session = _session;
+    return session != null &&
+        !session.requiresFlightAssignment &&
+        session.flightRole.mayManageRecovery;
+  }
+
   /// Registers a balloon or vehicle in this ride.
   ///
   /// Idempotent by craft id: re-registering updates the label rather than
@@ -1699,6 +1729,77 @@ class RideController extends ChangeNotifier {
     });
   }
 
+  /// Publishes a shared LANDED declaration without ending location sharing.
+  ///
+  /// [balloonFix] may be stale or relayed: it is preserved exactly and the
+  /// reducer labels it best-known unless this is a fresh fix from a device in
+  /// the balloon. A manually selected point remains explicitly crew-marked.
+  Future<void> declareFlightLanded({
+    required FlightLandingEvidence evidence,
+    LocationSample? balloonFix,
+  }) async {
+    if (flightLanding.isLanded || rideEnded) return;
+    await _run(() async {
+      final session = _requireSession();
+      if (!rideStarted) {
+        throw const FormatException(
+          'Start live tracking before marking the balloon landed.',
+        );
+      }
+      if (!canManageRecovery) {
+        throw const FormatException(
+          'Observers cannot change the shared recovery state.',
+        );
+      }
+      if (evidence == FlightLandingEvidence.manuallyMarked &&
+          balloonFix == null) {
+        throw const FormatException('Choose the landing point on the map.');
+      }
+      await _record(
+        type: RideEventType.flightLanded,
+        priority: EventPriority.important,
+        payload: {
+          'declaredByDeviceId': session.localRiderId,
+          'declaredByDisplayName': session.displayName,
+          'declaredByRole': session.flightRole.name,
+          'evidence': evidence.name,
+          if (balloonFix != null) 'location': balloonFix.toJson(),
+        },
+      );
+    });
+  }
+
+  Future<void> retractFlightLanding({String? reason}) async {
+    final landing = flightLanding.landing;
+    if (landing == null || rideEnded) return;
+    await _run(() async {
+      final session = _requireSession();
+      if (!canManageRecovery) {
+        throw const FormatException(
+          'Observers cannot change the shared recovery state.',
+        );
+      }
+      final cleanReason = reason?.trim();
+      if (cleanReason != null && cleanReason.length > 160) {
+        throw const FormatException(
+          'Keep the retraction note under 160 characters.',
+        );
+      }
+      await _record(
+        type: RideEventType.flightLandingRetracted,
+        priority: EventPriority.important,
+        payload: {
+          'landingEventId': landing.eventId,
+          'retractedByDeviceId': session.localRiderId,
+          'retractedByDisplayName': session.displayName,
+          'retractedByRole': session.flightRole.name,
+          if (cleanReason != null && cleanReason.isNotEmpty)
+            'reason': cleanReason,
+        },
+      );
+    });
+  }
+
   Future<void> noteWindContext(FlightReplayWindContext context) async {
     await _run(() async {
       _requireSession();
@@ -1826,6 +1927,39 @@ class RideController extends ChangeNotifier {
         type: RideEventType.rideEnded,
         priority: EventPriority.important,
         payload: const {},
+      );
+      await _archiveCurrentRideIfComplete();
+      await _purgeUnusedIceSharesIfEnded();
+      await _expireEndedRideIfDue();
+    });
+  }
+
+  /// Ends sharing only after LANDED has been declared and recovery is complete.
+  Future<void> completeRecovery() async {
+    if (rideEnded) return;
+    await _run(() async {
+      final session = _requireSession();
+      final landing = flightLanding.landing;
+      if (landing == null) {
+        throw const FormatException(
+          'Mark the balloon LANDED before completing recovery.',
+        );
+      }
+      if (!canManageRecovery) {
+        throw const FormatException(
+          'Observers cannot complete the shared recovery.',
+        );
+      }
+      await _record(
+        type: RideEventType.rideEnded,
+        priority: EventPriority.important,
+        payload: {
+          'reason': 'recoveryComplete',
+          'landingEventId': landing.eventId,
+          'completedByDeviceId': session.localRiderId,
+          'completedByDisplayName': session.displayName,
+          'completedByRole': session.flightRole.name,
+        },
       );
       await _archiveCurrentRideIfComplete();
       await _purgeUnusedIceSharesIfEnded();
@@ -2315,6 +2449,7 @@ class RideController extends ChangeNotifier {
       ..addAll(_events.map((event) => event.id));
     _invalidateMembershipProjection();
     _landingZoneDirty = true;
+    _flightLandingDirty = true;
     _operationalBoundaryDirty = true;
     _applyLocalPilotAuthorityFromEvents();
   }

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -404,6 +404,8 @@ class SituationalAwarenessController extends ChangeNotifier {
       case RideEventType.roleChanged:
       case RideEventType.rideStarted:
       case RideEventType.flightStartedByCrew:
+      case RideEventType.flightLanded:
+      case RideEventType.flightLandingRetracted:
       case RideEventType.statusMessage:
       case RideEventType.ridePaused:
       case RideEventType.rideResumed:

--- a/apps/mobile/lib/domain/flight_landing.dart
+++ b/apps/mobile/lib/domain/flight_landing.dart
@@ -1,0 +1,200 @@
+import 'flight_role.dart';
+import 'ride_event.dart';
+import 'rider_location.dart';
+import '../services/ride_event_authenticator.dart';
+import '../services/ride_lifecycle.dart';
+
+enum FlightLandingEvidence { aboard, witnessed, radioConfirmed, manuallyMarked }
+
+extension FlightLandingEvidenceLabel on FlightLandingEvidence {
+  String get label => switch (this) {
+    FlightLandingEvidence.aboard => 'Device in balloon',
+    FlightLandingEvidence.witnessed => 'Witnessed by ground crew',
+    FlightLandingEvidence.radioConfirmed => 'Confirmed over radio',
+    FlightLandingEvidence.manuallyMarked => 'Manually marked location',
+  };
+}
+
+FlightLandingEvidence? flightLandingEvidenceFromName(Object? value) =>
+    value is String
+    ? FlightLandingEvidence.values
+          .where((evidence) => evidence.name == value)
+          .firstOrNull
+    : null;
+
+enum FlightLandingLocationConfidence { confirmed, manuallyMarked, bestKnown }
+
+extension FlightLandingLocationConfidenceLabel
+    on FlightLandingLocationConfidence {
+  String get label => switch (this) {
+    FlightLandingLocationConfidence.confirmed => 'Confirmed balloon fix',
+    FlightLandingLocationConfidence.manuallyMarked =>
+      'Crew-marked landing point',
+    FlightLandingLocationConfidence.bestKnown => 'Best-known balloon position',
+  };
+}
+
+class FlightLanding {
+  const FlightLanding({
+    required this.eventId,
+    required this.declaredAt,
+    required this.declaredByDeviceId,
+    required this.declaredByDisplayName,
+    required this.declaredByRole,
+    required this.evidence,
+    this.location,
+    this.locationConfidence,
+  });
+
+  final String eventId;
+  final DateTime declaredAt;
+  final String declaredByDeviceId;
+  final String declaredByDisplayName;
+  final FlightRole declaredByRole;
+  final FlightLandingEvidence evidence;
+  final LocationSample? location;
+  final FlightLandingLocationConfidence? locationConfidence;
+
+  bool get hasConfirmedLocation =>
+      locationConfidence == FlightLandingLocationConfidence.confirmed ||
+      locationConfidence == FlightLandingLocationConfidence.manuallyMarked;
+}
+
+class FlightLandingState {
+  const FlightLandingState({this.landing, this.retractedAt});
+
+  final FlightLanding? landing;
+  final DateTime? retractedAt;
+
+  bool get isLanded => landing != null;
+}
+
+/// Reconstructs the latest valid landing declaration from the signed journal.
+///
+/// Only an operational role may declare or retract landing. Retractions name
+/// the exact declaration they undo, so delayed/offline delivery cannot erase a
+/// newer declaration merely because its clock sorts later.
+class FlightLandingReducer {
+  const FlightLandingReducer({
+    this.maximumConfirmedFixAge = const Duration(seconds: 45),
+    this.maximumConfirmedAccuracyMeters = 100,
+  });
+
+  final Duration maximumConfirmedFixAge;
+  final double maximumConfirmedAccuracyMeters;
+
+  FlightLandingState fromEvents({
+    required String rideId,
+    required String inviteSecret,
+    required Iterable<RideEvent> events,
+  }) {
+    final ordered =
+        events
+            .where(
+              (event) =>
+                  event.rideId == rideId &&
+                  RideEventAuthenticator.verify(event, inviteSecret),
+            )
+            .toList(growable: false)
+          ..sort(RideLifecycleReducer.compareEvents);
+    final roles = <String, FlightRole>{};
+    FlightLanding? landing;
+    DateTime? retractedAt;
+
+    for (final event in ordered) {
+      switch (event.type) {
+        case RideEventType.rideCreated:
+        case RideEventType.riderJoined:
+        case RideEventType.roleChanged:
+          final role = _role(event.payload['flightRole']);
+          if (role != null) roles[event.deviceId] = role;
+        case RideEventType.flightLanded:
+          final role = roles[event.deviceId];
+          final parsed = role == null || role == FlightRole.observer
+              ? null
+              : _landing(event, role);
+          if (parsed != null) {
+            landing = parsed;
+            retractedAt = null;
+          }
+        case RideEventType.flightLandingRetracted:
+          final role = roles[event.deviceId];
+          if (role == null ||
+              role == FlightRole.observer ||
+              event.payload['landingEventId'] != landing?.eventId) {
+            break;
+          }
+          landing = null;
+          retractedAt = event.createdAt;
+        default:
+          break;
+      }
+    }
+    return FlightLandingState(landing: landing, retractedAt: retractedAt);
+  }
+
+  FlightLanding? _landing(RideEvent event, FlightRole role) {
+    final evidence = flightLandingEvidenceFromName(event.payload['evidence']);
+    if (evidence == null ||
+        event.payload['declaredByDeviceId'] != event.deviceId) {
+      return null;
+    }
+    final rawLocation = event.payload['location'];
+    LocationSample? location;
+    if (rawLocation is Map<Object?, Object?>) {
+      try {
+        location = LocationSample.fromJson(
+          Map<String, Object?>.from(rawLocation),
+        );
+      } on Object {
+        return null;
+      }
+    } else if (rawLocation != null) {
+      return null;
+    }
+
+    final confidence = _confidence(
+      evidence: evidence,
+      role: role,
+      event: event,
+      location: location,
+    );
+    final displayName = event.payload['declaredByDisplayName'];
+    return FlightLanding(
+      eventId: event.id,
+      declaredAt: event.createdAt,
+      declaredByDeviceId: event.deviceId,
+      declaredByDisplayName: displayName is String && displayName.isNotEmpty
+          ? displayName
+          : 'Crew member',
+      declaredByRole: role,
+      evidence: evidence,
+      location: location,
+      locationConfidence: location == null ? null : confidence,
+    );
+  }
+
+  FlightLandingLocationConfidence _confidence({
+    required FlightLandingEvidence evidence,
+    required FlightRole role,
+    required RideEvent event,
+    required LocationSample? location,
+  }) {
+    if (evidence == FlightLandingEvidence.manuallyMarked) {
+      return FlightLandingLocationConfidence.manuallyMarked;
+    }
+    if (location != null &&
+        evidence == FlightLandingEvidence.aboard &&
+        role.isAboardBalloon &&
+        location.ageAt(event.createdAt) <= maximumConfirmedFixAge &&
+        location.accuracyMeters <= maximumConfirmedAccuracyMeters) {
+      return FlightLandingLocationConfidence.confirmed;
+    }
+    return FlightLandingLocationConfidence.bestKnown;
+  }
+
+  static FlightRole? _role(Object? value) {
+    if (value is! String) return null;
+    return FlightRole.values.where((role) => role.name == value).firstOrNull;
+  }
+}

--- a/apps/mobile/lib/domain/flight_role.dart
+++ b/apps/mobile/lib/domain/flight_role.dart
@@ -65,6 +65,12 @@ extension FlightRoleLabel on FlightRole {
   /// out of this path for the same workload reason as the pilot, and observers
   /// are always read-only.
   bool get mayStartFlight => hasFlightAuthority || isChasing;
+
+  /// Whether this role may publish shared landing/recovery state.
+  ///
+  /// Field evidence can come from the basket, a witness or radio traffic, so
+  /// every operational role is allowed while observers remain read-only.
+  bool get mayManageRecovery => this != FlightRole.observer;
 }
 
 /// Reads a role name that another build may have written.

--- a/apps/mobile/lib/domain/landing_zone.dart
+++ b/apps/mobile/lib/domain/landing_zone.dart
@@ -122,6 +122,8 @@ class LandingZoneReducer {
         case RideEventType.riderLeft:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/domain/operational_boundary.dart
+++ b/apps/mobile/lib/domain/operational_boundary.dart
@@ -171,6 +171,8 @@ class OperationalBoundaryReducer {
         case RideEventType.riderLeft:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/domain/ride_event.dart
+++ b/apps/mobile/lib/domain/ride_event.dart
@@ -108,6 +108,19 @@ enum RideEventType {
   /// the legacy event for mixed-build flights, while a relay can negotiate this
   /// new ground-crew authority explicitly.
   flightStartedByCrew,
+
+  /// An operational crew member declares that the balloon has landed.
+  ///
+  /// The payload preserves how the declaration was obtained and any location
+  /// evidence without upgrading a stale/relayed fix into a confirmed point.
+  /// Location sharing continues until the separate [rideEnded] recovery-
+  /// complete action.
+  flightLanded,
+
+  /// Retracts one specific [flightLanded] event after a mistaken declaration.
+  /// Naming the event prevents a late offline retraction from undoing a newer
+  /// landing declaration.
+  flightLandingRetracted,
 }
 
 enum EventPriority { routine, important, critical }

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -31,6 +31,7 @@ import '../../data/secure_observer_grant_store.dart';
 import '../../domain/event_store.dart';
 import '../../domain/completed_ride_store.dart';
 import '../../domain/flight_replay.dart';
+import '../../domain/flight_landing.dart';
 import '../../domain/flight_role.dart';
 import '../../domain/geo_point.dart' as awareness_geo;
 import '../../domain/hazard.dart';
@@ -480,6 +481,11 @@ class _RideActionsPanel extends StatelessWidget {
     required this.canChangeRoute,
     required this.onAlertsAndReports,
     required this.onShareSummary,
+    required this.landing,
+    required this.canManageRecovery,
+    required this.onMarkLanded,
+    required this.onRetractLanding,
+    required this.onCompleteRecovery,
     required this.canOfferPilotHandover,
     required this.onOfferPilotHandover,
     required this.pendingPilotHandoverFrom,
@@ -522,6 +528,11 @@ class _RideActionsPanel extends StatelessWidget {
   final bool canChangeRoute;
   final VoidCallback onAlertsAndReports;
   final VoidCallback onShareSummary;
+  final FlightLanding? landing;
+  final bool canManageRecovery;
+  final VoidCallback onMarkLanded;
+  final VoidCallback onRetractLanding;
+  final VoidCallback onCompleteRecovery;
   final bool canOfferPilotHandover;
   final VoidCallback onOfferPilotHandover;
   final String? pendingPilotHandoverFrom;
@@ -597,6 +608,79 @@ class _RideActionsPanel extends StatelessWidget {
           Text(title, style: Theme.of(context).textTheme.headlineSmall),
           const SizedBox(height: 4),
           Text(detail, style: const TextStyle(color: Color(0xFF98A3B1))),
+          const SizedBox(height: 14),
+          if (landing == null && canManageRecovery)
+            FilledButton.icon(
+              key: const Key('mark-flight-landed'),
+              onPressed: onMarkLanded,
+              icon: const Icon(Icons.flag_outlined),
+              label: const Text('MARK BALLOON LANDED'),
+            )
+          else if (landing case final landing?)
+            Card(
+              key: const Key('flight-landed-status'),
+              color: const Color(0xFF17382F),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 14, 12, 10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Row(
+                      children: [
+                        Icon(Icons.flag_circle, color: Color(0xFF72D5A4)),
+                        SizedBox(width: 10),
+                        Text(
+                          'BALLOON LANDED',
+                          style: TextStyle(
+                            color: Color(0xFFBFF5D9),
+                            fontWeight: FontWeight.w800,
+                            letterSpacing: 0.8,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${landing.evidence.label} · ${landing.declaredByDisplayName} (${landing.declaredByRole.label})',
+                    ),
+                    if (landing.locationConfidence case final confidence?)
+                      Text(
+                        confidence.label,
+                        style: const TextStyle(color: Color(0xFFB9C8C2)),
+                      )
+                    else
+                      const Text(
+                        'No landing coordinate supplied',
+                        style: TextStyle(color: Color(0xFFFFC857)),
+                      ),
+                    const SizedBox(height: 4),
+                    const Text(
+                      'Live locations remain shared until Recovery complete.',
+                      style: TextStyle(color: Color(0xFFB9C8C2)),
+                    ),
+                    if (canManageRecovery) ...[
+                      const SizedBox(height: 8),
+                      Wrap(
+                        alignment: WrapAlignment.end,
+                        spacing: 8,
+                        children: [
+                          TextButton(
+                            key: const Key('retract-flight-landed'),
+                            onPressed: onRetractLanding,
+                            child: const Text('Retract'),
+                          ),
+                          FilledButton(
+                            key: const Key('complete-recovery'),
+                            onPressed: onCompleteRecovery,
+                            child: const Text('Recovery complete'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
           const SizedBox(height: 8),
           if (flightRole.isChasing)
             ListTile(
@@ -1312,10 +1396,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   );
   final ValueNotifier<MapLandingZone?> _sharedLandingZone = ValueNotifier(null);
   bool _selectingLandingZone = false;
+  bool _selectingConfirmedLandingPoint = false;
   _OperationalBoundaryDraft? _operationalBoundaryDraft;
   double _landingRadiusMeters = 500;
   ChaseGuidanceTarget? _chaseGuidanceTarget;
   String? _observedLandingGuidanceRevision;
+  String? _observedFlightLandingEventId;
   bool _chaseGuidanceRouting = false;
   DateTime? _lastChaseGuidanceRouteAt;
   awareness_geo.GeoPoint? _lastChaseGuidanceTarget;
@@ -1909,9 +1995,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   Future<void> _initializeChaseGuidanceTarget() async {
     if (!_isChaserPerspective) return;
+    final flightLanding = widget.rideController.flightLanding.landing;
+    _observedFlightLandingEventId = flightLanding?.eventId;
     final shared = widget.rideController.localChaseGuidanceSelection;
     final initial =
-        shared?.target ??
+        (flightLanding == null
+            ? shared?.target
+            : ChaseGuidanceTarget.balloon) ??
         (widget.rideController.landingZone == null
             ? ChaseGuidanceTarget.balloon
             : ChaseGuidanceTarget.landingArea);
@@ -2701,6 +2791,21 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final overlays = <MapOverlayMarker>[
       for (final judgement in hazardJudgements)
         if (judgement.isVisible) _hazardOverlayMarker(judgement.report, now),
+      if (widget.rideController.flightLanding.landing case final landing?)
+        if (landing.location case final location?)
+          MapOverlayMarker(
+            id: 'confirmed-flight-landing-${landing.eventId}',
+            point: route_domain.GeoPoint(
+              latitude: location.position.latitude,
+              longitude: location.position.longitude,
+              recordedAt: landing.declaredAt,
+            ),
+            label:
+                'LANDED · ${landing.locationConfidence?.label ?? 'location supplied'} · ${landing.declaredByDisplayName}',
+            motorcycleStyle: CraftIconStyle.balloon,
+            riderDisplayName: 'LANDED',
+            color: const Color(0xFF72D5A4),
+          ),
       ...(simulatedRiders == null
               ? _productionCraftMapLocations(
                   craftRoster!,
@@ -3020,7 +3125,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (_autoEndingRide ||
         !widget.rideController.rideStarted ||
         widget.rideController.rideEnded ||
-        widget.rideController.ridePaused) {
+        widget.rideController.ridePaused ||
+        !widget.rideController.flightLanding.isLanded) {
       return;
     }
     final session = widget.rideController.session;
@@ -3088,7 +3194,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       );
       if (decision == RideCompletionDecision.endForEveryone) {
         _rideCompletionSuggestion.value = null;
-        await widget.rideController.endRide();
+        await widget.rideController.completeRecovery();
       }
     } catch (error, stackTrace) {
       if (kDebugMode) {
@@ -3546,12 +3652,24 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final landingTargetChanged =
         landingRevision != _observedLandingGuidanceRevision;
     _observedLandingGuidanceRevision = landingRevision;
+    final flightLanding = widget.rideController.flightLanding.landing;
+    final flightLandingChanged =
+        flightLanding?.eventId != _observedFlightLandingEventId;
+    _observedFlightLandingEventId = flightLanding?.eventId;
     _syncSharedLandingZone();
     _syncOperationalBoundaries();
     if (_isChaserPerspective && _chaseGuidanceTarget == null) {
       _chaseGuidanceTarget = widget.rideController.landingZone == null
           ? ChaseGuidanceTarget.balloon
           : ChaseGuidanceTarget.landingArea;
+    }
+    if (_isChaserPerspective && flightLandingChanged && flightLanding != null) {
+      _chaseGuidanceTarget = ChaseGuidanceTarget.balloon;
+      unawaited(
+        widget.rideController.setLocalChaseGuidanceTarget(
+          ChaseGuidanceTarget.balloon,
+        ),
+      );
     }
     final session = widget.rideController.session;
     final rideStarted =
@@ -3581,6 +3699,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         _refreshChaseGuidanceIfNeeded(
           force:
               chaseTargetChanged ||
+              (flightLandingChanged && flightLanding != null) ||
               (landingTargetChanged &&
                   _chaseGuidanceTarget == ChaseGuidanceTarget.landingArea),
         ),
@@ -4191,7 +4310,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       riderTrails: _riderTrails,
       landingZone: landingZoneUpdates.value,
       landingZoneUpdates: landingZoneUpdates,
-      onMapTap: _selectingLandingZone || boundaryDraft != null
+      onMapTap:
+          _selectingLandingZone ||
+              _selectingConfirmedLandingPoint ||
+              boundaryDraft != null
           ? _handleFlightSetupMapTap
           : null,
       windForecastController: isDriverView ? null : _windForecastController,
@@ -4290,7 +4412,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           flightRole == FlightRole.balloonCrew ||
           flightRole == FlightRole.chaseCrew,
     );
-    if (!_selectingLandingZone && boundaryDraft == null) return map;
+    if (!_selectingLandingZone &&
+        !_selectingConfirmedLandingPoint &&
+        boundaryDraft == null) {
+      return map;
+    }
     return Stack(
       children: [
         Positioned.fill(child: map),
@@ -4307,7 +4433,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               child: Row(
                 children: [
                   Icon(
-                    boundaryDraft == null
+                    _selectingConfirmedLandingPoint
+                        ? Icons.flag_circle_outlined
+                        : boundaryDraft == null
                         ? Icons.touch_app
                         : Icons.polyline_outlined,
                     color: const Color(0xFFFFC857),
@@ -4315,7 +4443,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                   const SizedBox(width: 10),
                   Expanded(
                     child: Text(
-                      boundaryDraft == null
+                      _selectingConfirmedLandingPoint
+                          ? 'Tap the map at the balloon’s confirmed landing point'
+                          : boundaryDraft == null
                           ? 'Tap the map to update the intended landing area · ${_landingRadiusMeters < 1000 ? '${_landingRadiusMeters.toInt()} m' : '${(_landingRadiusMeters / 1000).toStringAsFixed(1)} km'} radius'
                           : boundaryDraft.kind == OperationalBoundaryKind.line
                           ? 'Tap two points for ${boundaryDraft.label} · ${boundaryDraft.points.length}/2'
@@ -4345,6 +4475,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   Future<void> _handleFlightSetupMapTap(route_domain.GeoPoint point) async {
+    if (_selectingConfirmedLandingPoint) {
+      await _declareManuallyMarkedLanding(point);
+      return;
+    }
     if (_selectingLandingZone) {
       await _updateLandingZoneFromMap(point);
       return;
@@ -4363,6 +4497,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   void _cancelMapSelection() {
     setState(() {
       _selectingLandingZone = false;
+      _selectingConfirmedLandingPoint = false;
       _operationalBoundaryDraft = null;
     });
     _syncOperationalBoundaries();
@@ -4424,6 +4559,180 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return;
     }
     setState(() => _selectingLandingZone = false);
+  }
+
+  Future<void> _markFlightLanded() async {
+    final controller = widget.rideController;
+    if (!controller.canManageRecovery ||
+        !controller.rideStarted ||
+        controller.rideEnded ||
+        controller.flightLanding.isLanded) {
+      return;
+    }
+    if (!_relayCanCarryCrewFlightLifecycle) {
+      _showRideSnackBar(
+        'This flight service cannot yet share LANDED state. Update the service before declaring landing.',
+      );
+      return;
+    }
+    final evidence = await showModalBottomSheet<FlightLandingEvidence>(
+      context: context,
+      useSafeArea: true,
+      showDragHandle: true,
+      builder: (context) => ListView(
+        shrinkWrap: true,
+        padding: const EdgeInsets.only(bottom: 16),
+        children: [
+          const ListTile(
+            title: Text('How was landing confirmed?'),
+            subtitle: Text(
+              'This is shared with the whole recovery crew. Tracking continues until Recovery complete.',
+            ),
+          ),
+          for (final value in FlightLandingEvidence.values)
+            ListTile(
+              key: Key('landing-evidence-${value.name}'),
+              leading: Icon(switch (value) {
+                FlightLandingEvidence.aboard => Icons.airplanemode_inactive,
+                FlightLandingEvidence.witnessed => Icons.visibility_outlined,
+                FlightLandingEvidence.radioConfirmed => Icons.radio_outlined,
+                FlightLandingEvidence.manuallyMarked =>
+                  Icons.add_location_alt_outlined,
+              }),
+              title: Text(value.label),
+              subtitle: Text(switch (value) {
+                FlightLandingEvidence.aboard =>
+                  'Use the latest fix from this device in the balloon.',
+                FlightLandingEvidence.witnessed =>
+                  'Keep the latest balloon fix labelled best-known.',
+                FlightLandingEvidence.radioConfirmed =>
+                  'Keep the latest balloon fix labelled best-known.',
+                FlightLandingEvidence.manuallyMarked =>
+                  'Tap the confirmed landing point on the map.',
+              }),
+              onTap: () => Navigator.pop(context, value),
+            ),
+        ],
+      ),
+    );
+    if (evidence == null || !mounted) return;
+    if (evidence == FlightLandingEvidence.manuallyMarked) {
+      setState(() {
+        _selectedIndex = 0;
+        _selectingConfirmedLandingPoint = true;
+        _selectingLandingZone = false;
+        _operationalBoundaryDraft = null;
+      });
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Mark balloon LANDED?'),
+        content: Text(
+          '${evidence.label} will be recorded for the whole crew. Location sharing and chase guidance continue during recovery.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton.icon(
+            key: const Key('confirm-flight-landed'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            icon: const Icon(Icons.flag),
+            label: const Text('Mark LANDED'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    await controller.declareFlightLanded(
+      evidence: evidence,
+      balloonFix: _latestBalloonFix(),
+    );
+    if (!mounted) return;
+    _showRideSnackBar(
+      controller.errorMessage ??
+          'LANDED shared. Location sharing continues during recovery.',
+    );
+  }
+
+  Future<void> _declareManuallyMarkedLanding(
+    route_domain.GeoPoint point,
+  ) async {
+    await widget.rideController.declareFlightLanded(
+      evidence: FlightLandingEvidence.manuallyMarked,
+      balloonFix: LocationSample(
+        position: awareness_geo.GeoPoint(
+          latitude: point.latitude,
+          longitude: point.longitude,
+        ),
+        recordedAt: DateTime.now(),
+        accuracyMeters: 0,
+      ),
+    );
+    if (!mounted) return;
+    setState(() => _selectingConfirmedLandingPoint = false);
+    _showRideSnackBar(
+      widget.rideController.errorMessage ??
+          'Crew-marked landing point shared. Tracking continues.',
+    );
+  }
+
+  Future<void> _retractFlightLanding() async {
+    final landing = widget.rideController.flightLanding.landing;
+    if (landing == null || !_relayCanCarryCrewFlightLifecycle) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Retract LANDED?'),
+        content: const Text(
+          'Use this only when the landing report was mistaken. The crew will return to live-flight guidance.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Keep LANDED'),
+          ),
+          FilledButton(
+            key: const Key('confirm-retract-landing'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Retract'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await widget.rideController.retractFlightLanding(
+      reason: 'Landing report corrected by crew',
+    );
+  }
+
+  Future<void> _completeRecovery() async {
+    if (!widget.rideController.flightLanding.isLanded) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Recovery complete?'),
+        content: const Text(
+          'The balloon and crew have been recovered. This ends the shared flight and stops live location publication for everyone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Keep tracking'),
+          ),
+          FilledButton(
+            key: const Key('confirm-recovery-complete'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Recovery complete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await widget.rideController.completeRecovery();
   }
 
   LocationSample? _latestBalloonFix() {
@@ -4492,6 +4801,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       fix?.altitudeMeters?.toStringAsFixed(1) ?? 'none',
       field?.fetchedAt.toUtc().toIso8601String() ?? 'none',
       field?.validAt.toUtc().toIso8601String() ?? 'none',
+      widget.rideController.flightLanding.landing?.eventId ?? 'flying',
       now.millisecondsSinceEpoch ~/ const Duration(seconds: 15).inMilliseconds,
     ].join(':');
     if (fingerprint == _liveFlightProjectionFingerprint) return;
@@ -4502,6 +4812,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       wind: field,
       now: now,
       allowReferenceWind: _isSimulation,
+      flightLanded: widget.rideController.flightLanding.isLanded,
     );
     _pushRiderTrails();
     if (mounted) setState(() {});
@@ -4517,6 +4828,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       now: DateTime.now(),
       landingZone: widget.rideController.landingZone,
       balloonFix: _latestBalloonFix(),
+      landing: widget.rideController.flightLanding.landing,
     );
   }
 
@@ -4970,6 +5282,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   String get _projectedRideState {
     if (widget.rideController.rideEnded) return 'Flight ended';
+    if (widget.rideController.flightLanding.isLanded) {
+      return 'Balloon landed · recovery in progress';
+    }
     if (widget.rideController.ridePaused) return 'Flight paused';
     if (widget.rideController.rideStarted) return 'Flight in progress';
     return 'Waiting for the pilot or coordinator to start';
@@ -5623,6 +5938,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     canChangeRoute: _isSimulation || widget.rideController.hasFlightAuthority,
     onAlertsAndReports: _openAlertsAndReports,
     onShareSummary: _shareCurrentRideSummary,
+    landing: widget.rideController.flightLanding.landing,
+    canManageRecovery:
+        !_isSimulation &&
+        widget.rideController.rideStarted &&
+        !widget.rideController.rideEnded &&
+        widget.rideController.canManageRecovery,
+    onMarkLanded: () => unawaited(_markFlightLanded()),
+    onRetractLanding: () => unawaited(_retractFlightLanding()),
+    onCompleteRecovery: () => unawaited(_completeRecovery()),
     canOfferPilotHandover:
         widget.rideController.hasFlightAuthority &&
         _pilotHandoverTargets.isNotEmpty,
@@ -6343,6 +6667,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final generatedAt = controller.nextSnapshotGeneratedAt();
     final rideStatus = widget.rideController.rideEnded
         ? 'ended'
+        : widget.rideController.flightLanding.isLanded
+        ? 'landed'
         : widget.rideController.ridePaused
         ? 'paused'
         : widget.rideController.rideStarted
@@ -6384,6 +6710,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       if (event.type == RideEventType.rideStarted ||
           event.type == RideEventType.ridePaused ||
           event.type == RideEventType.rideResumed ||
+          event.type == RideEventType.flightLanded ||
+          event.type == RideEventType.flightLandingRetracted ||
           event.type == RideEventType.rideEnded) {
         return event.createdAt;
       }

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -1231,6 +1231,8 @@ class _EventRow extends StatelessWidget {
       RideEventType.roleChanged => 'Role changed',
       RideEventType.rideStarted => 'Flight started',
       RideEventType.flightStartedByCrew => 'Tracking started by chase crew',
+      RideEventType.flightLanded => 'Balloon marked LANDED',
+      RideEventType.flightLandingRetracted => 'Landing declaration retracted',
       // Also the acknowledgement of another rider's message, which is a
       // `statusMessage` carrying `acknowledgesQuickMessageEventId` and the label
       // "Seen: <what they raised>" (#151). One row either way: the log records

--- a/apps/mobile/lib/internet/internet_relay_worker.dart
+++ b/apps/mobile/lib/internet/internet_relay_worker.dart
@@ -452,7 +452,9 @@ class InternetRelayWorker {
       RideEventType.pilotHandoverAccepted =>
         RelayProtocolCapabilities.pilotHandover,
       RideEventType.rideReopened => RelayProtocolCapabilities.rideReopen,
-      RideEventType.flightStartedByCrew =>
+      RideEventType.flightStartedByCrew ||
+      RideEventType.flightLanded ||
+      RideEventType.flightLandingRetracted =>
         RelayProtocolCapabilities.crewFlightLifecycle,
       _ => null,
     };

--- a/apps/mobile/lib/services/chase_guidance_target.dart
+++ b/apps/mobile/lib/services/chase_guidance_target.dart
@@ -1,4 +1,5 @@
 import '../domain/craft.dart';
+import '../domain/flight_landing.dart';
 import '../domain/geo_point.dart';
 import '../domain/landing_zone.dart';
 import '../domain/ride_event.dart';
@@ -86,6 +87,8 @@ class ChaseGuidanceSelectionReducer {
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:
@@ -157,9 +160,10 @@ class ChaseGuidanceTargetResolver {
     required DateTime now,
     LandingZoneTarget? landingZone,
     LocationSample? balloonFix,
+    FlightLanding? landing,
   }) => switch (target) {
     ChaseGuidanceTarget.landingArea => _landingArea(landingZone),
-    ChaseGuidanceTarget.balloon => _balloon(balloonFix, now),
+    ChaseGuidanceTarget.balloon => _balloon(balloonFix, now, landing),
   };
 
   ChaseGuidanceDestination? _landingArea(LandingZoneTarget? target) {
@@ -174,7 +178,23 @@ class ChaseGuidanceTargetResolver {
     );
   }
 
-  ChaseGuidanceDestination? _balloon(LocationSample? fix, DateTime now) {
+  ChaseGuidanceDestination? _balloon(
+    LocationSample? fix,
+    DateTime now,
+    FlightLanding? landing,
+  ) {
+    if (landing?.location case final landedFix?) {
+      return ChaseGuidanceDestination(
+        kind: ChaseGuidanceTarget.balloon,
+        point: landedFix.position,
+        label:
+            '${landing!.locationConfidence?.label ?? 'Best-known landing'} · LANDED',
+        maximumRoadSeparationMeters: landing.hasConfirmedLocation
+            ? 800
+            : maximumBalloonRoadSeparationMeters,
+        observedAt: landing.declaredAt,
+      );
+    }
     if (fix == null || fix.ageAt(now) > maximumBalloonFixAge) return null;
     return ChaseGuidanceDestination(
       kind: ChaseGuidanceTarget.balloon,

--- a/apps/mobile/lib/services/craft_roster.dart
+++ b/apps/mobile/lib/services/craft_roster.dart
@@ -153,6 +153,8 @@ class CraftRosterReducer {
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -78,6 +78,8 @@ class CraftTrackReducer {
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/flight_replay_archiver.dart
+++ b/apps/mobile/lib/services/flight_replay_archiver.dart
@@ -113,6 +113,8 @@ class FlightReplayArchiver {
         case RideEventType.roleChanged:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/live_flight_projection.dart
+++ b/apps/mobile/lib/services/live_flight_projection.dart
@@ -16,6 +16,7 @@ enum LiveFlightProjectionStatus {
   staleWind,
   outsideWindValidity,
   noUsableWindVector,
+  landed,
 }
 
 class LiveFlightProjection {
@@ -64,6 +65,8 @@ class LiveFlightProjectionAssessment {
       'The forecast is not valid near the current flight time.',
     LiveFlightProjectionStatus.noUsableWindVector =>
       'The forecast contains no usable wind at the balloon position.',
+    LiveFlightProjectionStatus.landed =>
+      'The balloon is marked LANDED; the forecast envelope is no longer extended.',
   };
 }
 
@@ -94,7 +97,13 @@ class LiveFlightProjectionEngine {
     required WindForecastField? wind,
     required DateTime now,
     bool allowReferenceWind = false,
+    bool flightLanded = false,
   }) {
+    if (flightLanded) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.landed,
+      );
+    }
     if (plan == null) {
       return const LiveFlightProjectionAssessment(
         LiveFlightProjectionStatus.noStructuredPlan,

--- a/apps/mobile/lib/services/ride_lifecycle.dart
+++ b/apps/mobile/lib/services/ride_lifecycle.dart
@@ -69,6 +69,9 @@ class RideLifecycleReducer {
               event.payload['flightRole'] == recordedRole.name) {
             return RideLifecycle(startEvent: event);
           }
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
+          break;
         case RideEventType.craftRegistered:
           final craftId = event.payload['craftId'];
           if (craftId is String && event.payload['kind'] == 'vehicle') {

--- a/apps/mobile/lib/services/ride_route_reducer.dart
+++ b/apps/mobile/lib/services/ride_route_reducer.dart
@@ -143,6 +143,8 @@ class RideRouteReducer {
         case RideEventType.riderLeft:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:
+        case RideEventType.flightLanded:
+        case RideEventType.flightLandingRetracted:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/test/controllers/ride_controller_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/quick_message.dart';
 import 'package:balloon_crumbs/domain/completed_ride_store.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/flight_landing.dart';
 import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart' as route_domain;
 import 'package:balloon_crumbs/domain/ride_event.dart';
@@ -388,6 +389,85 @@ void main() {
     }
     expect(controller.rideStarted, isTrue);
     expect(controller.rideStartedAt, start.createdAt);
+  });
+
+  test('an aboard declaration keeps a fresh balloon fix confirmed', () async {
+    await controller.createRide('Oliver');
+    await controller.startRide();
+    final now = DateTime.utc(2026, 7, 16, 12);
+
+    await controller.declareFlightLanded(
+      evidence: FlightLandingEvidence.aboard,
+      balloonFix: LocationSample(
+        position: const GeoPoint(latitude: 51.45, longitude: -2.61),
+        recordedAt: now.subtract(const Duration(seconds: 4)),
+        accuracyMeters: 6,
+        altitudeMeters: 92,
+        altitudeSource: AltitudeSource.gnss,
+        altitudeDatum: AltitudeDatum.wgs84Geoid,
+      ),
+    );
+
+    final landing = controller.flightLanding.landing;
+    expect(landing, isNotNull);
+    expect(landing!.evidence, FlightLandingEvidence.aboard);
+    expect(
+      landing.locationConfidence,
+      FlightLandingLocationConfidence.confirmed,
+    );
+    expect(controller.rideEnded, isFalse);
+  });
+
+  test('ground crew can declare, retract and complete recovery', () async {
+    await controller.createRide('Oliver');
+    final chaseCrew = await joinedController(FlightRole.chaseCrew);
+    await chaseCrew.startRide();
+    final staleFix = LocationSample(
+      position: const GeoPoint(latitude: 51.46, longitude: -2.62),
+      recordedAt: DateTime.utc(2026, 7, 16, 11, 56),
+      accuracyMeters: 18,
+    );
+
+    await chaseCrew.declareFlightLanded(
+      evidence: FlightLandingEvidence.radioConfirmed,
+      balloonFix: staleFix,
+    );
+
+    expect(chaseCrew.rideEnded, isFalse);
+    expect(
+      chaseCrew.flightLanding.landing?.locationConfidence,
+      FlightLandingLocationConfidence.bestKnown,
+    );
+    final firstLandingId = chaseCrew.flightLanding.landing!.eventId;
+
+    await chaseCrew.retractFlightLanding(reason: 'Radio correction');
+    expect(chaseCrew.flightLanding.isLanded, isFalse);
+    expect(chaseCrew.events.last.payload['landingEventId'], firstLandingId);
+
+    await chaseCrew.declareFlightLanded(
+      evidence: FlightLandingEvidence.manuallyMarked,
+      balloonFix: LocationSample(
+        position: const GeoPoint(latitude: 51.461, longitude: -2.621),
+        recordedAt: DateTime.utc(2026, 7, 16, 12, 1),
+        accuracyMeters: 0,
+      ),
+    );
+    await chaseCrew.completeRecovery();
+
+    expect(chaseCrew.rideEnded, isTrue);
+    expect(chaseCrew.events.last.type, RideEventType.rideEnded);
+    expect(chaseCrew.events.last.payload['reason'], 'recoveryComplete');
+  });
+
+  test('recovery cannot complete before a landing declaration', () async {
+    await controller.createRide('Oliver');
+    final chaseCrew = await joinedController(FlightRole.chaseDriver);
+    await chaseCrew.startRide();
+
+    await chaseCrew.completeRecovery();
+
+    expect(chaseCrew.rideEnded, isFalse);
+    expect(chaseCrew.errorMessage, contains('Mark the balloon LANDED'));
   });
 
   test('balloon device cannot forge a chase role to start tracking', () async {

--- a/apps/mobile/test/domain/flight_landing_test.dart
+++ b/apps/mobile/test/domain/flight_landing_test.dart
@@ -1,0 +1,144 @@
+import 'package:balloon_crumbs/domain/flight_landing.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
+import 'package:balloon_crumbs/services/ride_event_authenticator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const secret = '0123456789abcdef0123456789abcdef';
+  final start = DateTime.utc(2026, 8, 23, 9);
+
+  test('a late retraction cannot erase a newer landing declaration', () {
+    final events = [
+      _signed(
+        id: 'join',
+        type: RideEventType.riderJoined,
+        at: start,
+        secret: secret,
+        payload: const {
+          'displayName': 'Alex',
+          'role': 'rider',
+          'flightRole': 'chaseCrew',
+        },
+      ),
+      _signed(
+        id: 'landing-old',
+        type: RideEventType.flightLanded,
+        at: start.add(const Duration(minutes: 1)),
+        secret: secret,
+        payload: const {
+          'declaredByDeviceId': 'crew',
+          'declaredByDisplayName': 'Alex',
+          'declaredByRole': 'chaseCrew',
+          'evidence': 'radioConfirmed',
+        },
+      ),
+      _signed(
+        id: 'landing-new',
+        type: RideEventType.flightLanded,
+        at: start.add(const Duration(minutes: 2)),
+        secret: secret,
+        payload: const {
+          'declaredByDeviceId': 'crew',
+          'declaredByDisplayName': 'Alex',
+          'declaredByRole': 'chaseCrew',
+          'evidence': 'witnessed',
+        },
+      ),
+      _signed(
+        id: 'late-retraction',
+        type: RideEventType.flightLandingRetracted,
+        at: start.add(const Duration(minutes: 3)),
+        secret: secret,
+        payload: const {
+          'landingEventId': 'landing-old',
+          'retractedByDeviceId': 'crew',
+        },
+      ),
+    ];
+
+    final state = const FlightLandingReducer().fromEvents(
+      rideId: 'flight',
+      inviteSecret: secret,
+      events: events.reversed,
+    );
+
+    expect(state.landing?.eventId, 'landing-new');
+    expect(state.landing?.evidence, FlightLandingEvidence.witnessed);
+  });
+
+  test('observer declarations and invalid signatures are ignored', () {
+    final observer = _signed(
+      id: 'observer-join',
+      deviceId: 'watcher',
+      type: RideEventType.riderJoined,
+      at: start,
+      secret: secret,
+      payload: const {
+        'displayName': 'Watcher',
+        'role': 'rider',
+        'flightRole': 'observer',
+      },
+    );
+    final declaration = _signed(
+      id: 'observer-landing',
+      deviceId: 'watcher',
+      type: RideEventType.flightLanded,
+      at: start.add(const Duration(minutes: 1)),
+      secret: secret,
+      payload: const {
+        'declaredByDeviceId': 'watcher',
+        'declaredByDisplayName': 'Watcher',
+        'declaredByRole': 'observer',
+        'evidence': 'witnessed',
+      },
+    );
+    final forged = RideEvent(
+      id: 'forged',
+      rideId: 'flight',
+      deviceId: 'crew',
+      type: RideEventType.flightLanded,
+      priority: EventPriority.important,
+      createdAt: start.add(const Duration(minutes: 2)),
+      payload: const {'declaredByDeviceId': 'crew', 'evidence': 'witnessed'},
+      signature: '0' * 64,
+    );
+
+    final state = const FlightLandingReducer().fromEvents(
+      rideId: 'flight',
+      inviteSecret: secret,
+      events: [observer, declaration, forged],
+    );
+
+    expect(state.isLanded, isFalse);
+  });
+}
+
+RideEvent _signed({
+  required String id,
+  required RideEventType type,
+  required DateTime at,
+  required String secret,
+  required Map<String, Object?> payload,
+  String deviceId = 'crew',
+}) {
+  final unsigned = RideEvent(
+    id: id,
+    rideId: 'flight',
+    deviceId: deviceId,
+    type: type,
+    priority: EventPriority.important,
+    createdAt: at,
+    payload: payload,
+    signature: '',
+  );
+  return RideEvent(
+    id: unsigned.id,
+    rideId: unsigned.rideId,
+    deviceId: unsigned.deviceId,
+    type: unsigned.type,
+    priority: unsigned.priority,
+    createdAt: unsigned.createdAt,
+    payload: unsigned.payload,
+    signature: RideEventAuthenticator.sign(unsigned, secret),
+  );
+}

--- a/apps/mobile/test/internet/internet_relay_worker_test.dart
+++ b/apps/mobile/test/internet/internet_relay_worker_test.dart
@@ -250,6 +250,15 @@ void main() {
     await eventStore.append(
       _event(id: 'crew-start', type: RideEventType.flightStartedByCrew),
     );
+    await eventStore.append(
+      _event(id: 'landed', type: RideEventType.flightLanded),
+    );
+    await eventStore.append(
+      _event(
+        id: 'landing-retracted',
+        type: RideEventType.flightLandingRetracted,
+      ),
+    );
     final api = _CompatibilityApi(
       compatibility: _compatibility(
         RelayCompatibilityDisposition.legacyCompatible,
@@ -283,6 +292,12 @@ void main() {
         _session.rideId,
       )).map((event) => event.id),
       contains('crew-start'),
+    );
+    expect(
+      (await eventStore.pendingEvents(
+        _session.rideId,
+      )).map((event) => event.id),
+      containsAll(['landed', 'landing-retracted']),
     );
     await worker.close();
   });

--- a/apps/mobile/test/services/chase_guidance_target_test.dart
+++ b/apps/mobile/test/services/chase_guidance_target_test.dart
@@ -1,4 +1,6 @@
 import 'package:balloon_crumbs/domain/craft.dart';
+import 'package:balloon_crumbs/domain/flight_landing.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart';
 import 'package:balloon_crumbs/domain/landing_zone.dart';
 import 'package:balloon_crumbs/domain/ride_event.dart';
@@ -56,6 +58,30 @@ void main() {
       ),
       isFalse,
     );
+  });
+
+  test('LANDED retargets guidance to the preserved landing evidence', () {
+    final landingFix = _fix(now.subtract(const Duration(minutes: 5)));
+    final target = resolver.resolve(
+      target: ChaseGuidanceTarget.balloon,
+      now: now,
+      balloonFix: null,
+      landing: FlightLanding(
+        eventId: 'landed',
+        declaredAt: now,
+        declaredByDeviceId: 'crew',
+        declaredByDisplayName: 'Alex',
+        declaredByRole: FlightRole.chaseCrew,
+        evidence: FlightLandingEvidence.radioConfirmed,
+        location: landingFix,
+        locationConfidence: FlightLandingLocationConfidence.bestKnown,
+      ),
+    );
+
+    expect(target, isNotNull);
+    expect(target!.point, landingFix.position);
+    expect(target.label, contains('LANDED'));
+    expect(target.label, contains('Best-known'));
   });
 
   test('moving-target reroutes are time and movement bounded', () {

--- a/apps/mobile/test/services/live_flight_projection_test.dart
+++ b/apps/mobile/test/services/live_flight_projection_test.dart
@@ -139,4 +139,18 @@ void main() {
       LiveFlightProjectionStatus.staleWind,
     );
   });
+
+  test('stops extending the forecast envelope after LANDED', () {
+    final result = const LiveFlightProjectionEngine().evaluate(
+      plan: null,
+      balloonFix: null,
+      wind: null,
+      now: DateTime.utc(2026, 8, 23, 8),
+      flightLanded: true,
+    );
+
+    expect(result.status, LiveFlightProjectionStatus.landed);
+    expect(result.projection, isNull);
+    expect(result.message, contains('no longer extended'));
+  });
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -661,6 +661,55 @@ void main() {
     expect(find.text('Navigation map'), findsOneWidget);
   });
 
+  testWidgets(
+    'LANDED remains a shared recovery phase until explicitly complete',
+    (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final controller = await _controller();
+      await controller.createRide('Oliver');
+      await controller.startRide();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(_app(controller));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Flight').last);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('mark-flight-landed')), findsOneWidget);
+      await tester.ensureVisible(find.byKey(const Key('mark-flight-landed')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('mark-flight-landed')));
+      await tester.pumpAndSettle();
+      final radioEvidence = find.byKey(
+        const Key('landing-evidence-radioConfirmed'),
+      );
+      await tester.ensureVisible(radioEvidence);
+      await tester.pumpAndSettle();
+      await tester.tap(radioEvidence);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('confirm-flight-landed')));
+      await tester.pumpAndSettle();
+
+      expect(controller.flightLanding.isLanded, isTrue);
+      expect(controller.rideEnded, isFalse);
+      expect(find.byKey(const Key('flight-landed-status')), findsOneWidget);
+      expect(
+        find.text('Live locations remain shared until Recovery complete.'),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const Key('retract-flight-landed')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('confirm-retract-landing')));
+      await tester.pumpAndSettle();
+      expect(controller.flightLanding.isLanded, isFalse);
+      expect(find.byKey(const Key('mark-flight-landed')), findsOneWidget);
+    },
+  );
+
   testWidgets('simulated bikes wait for the leader to start the ride', (
     tester,
   ) async {

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -91,6 +91,8 @@ EVENT_TYPES = {
     # Field-operations lifecycle. Clients validate the signed author's explicit
     # chase role; the relay remains payload-opaque and only bounds/carries it.
     "flightStartedByCrew",
+    "flightLanded",
+    "flightLandingRetracted",
 }
 PRIORITIES = {"routine", "important", "critical"}
 EVENT_FIELDS = {
@@ -1047,6 +1049,8 @@ class RelayService:
             "craftPrimaryDeviceNominated": timedelta(hours=72),
             "craftChaseAssigned": timedelta(hours=72),
             "flightStartedByCrew": timedelta(hours=72),
+            "flightLanded": timedelta(hours=72),
+            "flightLandingRetracted": timedelta(hours=72),
             "landingAreaNoted": timedelta(hours=72),
             "windContextNoted": timedelta(hours=72),
             "operationalBoundaryUpserted": timedelta(hours=72),

--- a/apps/server/tests/test_additive_event_types.py
+++ b/apps/server/tests/test_additive_event_types.py
@@ -50,6 +50,8 @@ def test_retention_table_matches_the_documented_bands() -> None:
     assert retention("riderContactShared") == timedelta(hours=2)
     assert retention("riderContactShared") == retention("iceInfoShared")
     assert retention("flightStartedByCrew") == timedelta(hours=72)
+    assert retention("flightLanded") == timedelta(hours=72)
+    assert retention("flightLandingRetracted") == timedelta(hours=72)
 
 
 def test_ground_crew_start_is_accepted_and_relayed(client, synchronize, make_event) -> None:
@@ -78,6 +80,51 @@ def test_ground_crew_start_is_accepted_and_relayed(client, synchronize, make_eve
     )
     assert downloaded.status_code == 200
     assert [event["type"] for event in downloaded.json()["events"]] == ["flightStartedByCrew"]
+
+
+def test_landing_and_retraction_are_accepted_and_relayed(client, synchronize, make_event) -> None:
+    ride_id = "flight-landing-lifecycle"
+    shared = [
+        make_event(
+            ride_id,
+            "event-landed",
+            event_type="flightLanded",
+            payload={
+                "declaredByDeviceId": "device-a",
+                "declaredByDisplayName": "Alex",
+                "declaredByRole": "chaseCrew",
+                "evidence": "radioConfirmed",
+            },
+        ),
+        make_event(
+            ride_id,
+            "event-retracted",
+            event_type="flightLandingRetracted",
+            payload={
+                "landingEventId": "event-landed",
+                "retractedByDeviceId": "device-a",
+                "retractedByDisplayName": "Alex",
+                "retractedByRole": "chaseCrew",
+            },
+        ),
+    ]
+
+    uploaded = synchronize(client, ride_id=ride_id, secret=SECRET, events=shared)
+    assert uploaded.status_code == 200
+    assert uploaded.json()["acceptedEventIds"] == ["event-landed", "event-retracted"]
+
+    downloaded = synchronize(
+        client,
+        ride_id=ride_id,
+        secret=SECRET,
+        device_id="device-b",
+        cursor=None,
+    )
+    assert downloaded.status_code == 200
+    assert [item["type"] for item in downloaded.json()["events"]] == [
+        "flightLanded",
+        "flightLandingRetracted",
+    ]
 
 
 def test_a_shared_phone_number_is_accepted_and_capped(client, synchronize, make_event) -> None:

--- a/docs/field-operations-recovery-plan.md
+++ b/docs/field-operations-recovery-plan.md
@@ -258,5 +258,10 @@ contacts remain a separate private overlay.
 - [#74 — long pre-launch and recovery acceptance matrix](https://github.com/osholt/balloon-crumbs/issues/74)
 - [#75 — optional OS final-approach basemap](https://github.com/osholt/balloon-crumbs/issues/75)
 - [#76 — device-local privacy-governed land access notes](https://github.com/osholt/balloon-crumbs/issues/76)
+
+## Delivery evidence
+
+- Shared release, LANDED, retraction and recovery-complete semantics are
+  documented in [recovery lifecycle](recovery-lifecycle.md).
 - [#77 — HMLR INSPIRE boundary reference](https://github.com/osholt/balloon-crumbs/issues/77)
 - [#17 — optional planner-only aeronautical context](https://github.com/osholt/balloon-crumbs/issues/17)

--- a/docs/recovery-lifecycle.md
+++ b/docs/recovery-lifecycle.md
@@ -1,0 +1,71 @@
+# Shared landing and recovery lifecycle
+
+Status: implemented for the private tester relay and mobile clients.
+
+The live operation is an append-only sequence:
+
+```text
+crew room -> setting up -> released/live -> LANDED/recovery -> complete
+```
+
+`flightStartedByCrew` begins live tracking. `flightLanded` records a landing
+declaration, and `flightLandingRetracted` retracts one named declaration. The
+existing `rideEnded` event is the final recovery-complete transition. A LANDED
+event does **not** stop location capture, relay publication or shared tracks.
+
+## Landing evidence
+
+Every declaration records the author device, display name, flight role, event
+time and one of:
+
+- `aboard` — reported by a device in the balloon;
+- `witnessed` — seen by ground crew;
+- `radioConfirmed` — confirmed over radio or another channel;
+- `manuallyMarked` — a crew member selected the confirmed point on the map.
+
+A fresh, accurate fix from an aboard role is labelled **Confirmed balloon
+fix**. A manually selected coordinate is labelled **Crew-marked landing
+point**. A location attached by ground crew is always **Best-known balloon
+position**, even if the shared fix looked fresh locally. Missing, stale or
+relayed evidence is never promoted to an exact balloon position.
+
+Retraction names the exact `flightLanded` event it reverses. If an old offline
+retraction arrives after a newer declaration, it cannot erase the newer state.
+Observers cannot declare, retract or complete recovery.
+
+## Live behaviour
+
+- The Flight screen exposes one prominent `MARK BALLOON LANDED` action.
+- The author chooses how landing was confirmed and confirms the shared action.
+- Manual confirmation moves to the map for one explicit point selection.
+- All clients show the LANDED evidence and location-confidence label.
+- The landing evidence is shown on phone and projected maps.
+- Forecast-envelope growth stops once LANDED is current.
+- A chaser's balloon target resolves to the preserved landing evidence and a
+  fresh lawful road route is requested; a missing landing coordinate leaves the
+  previous route in place rather than inventing a destination.
+- `Retract` returns clients to the live-flight state.
+- `Recovery complete` is separately confirmed and is the only new recovery
+  action that ends the operation and stops location publication.
+
+## Compatibility and retention
+
+The additive landing event types use the existing
+`crew-flight-lifecycle-v1` relay capability. A client that has negotiated an
+older relay refuses to publish the shared action instead of recording a
+local-only success. Current relays cap both event types at 72 hours, matching
+the rest of the flight-scoped journal. Older clients skip unknown event names
+and continue processing the remaining batch.
+
+## Automated evidence
+
+- `test/domain/flight_landing_test.dart` — signed role validation, deterministic
+  ordering, targeted offline retraction and observer/forgery rejection.
+- `test/controllers/ride_controller_test.dart` — aboard confirmation,
+  best-known radio evidence, retraction, continued sharing phase and explicit
+  recovery completion.
+- `test/services/chase_guidance_target_test.dart` — post-landing retargeting.
+- `test/services/live_flight_projection_test.dart` — forecast envelope stops.
+- `test/internet/internet_relay_worker_test.dart` and server additive-event
+  tests — capability gating, relay carriage and bounded retention.
+- `test/widget_test.dart` — the end-to-end LANDED/retract recovery flow.


### PR DESCRIPTION
## Summary
- add signed, role-aware LANDED and targeted retraction events with explicit evidence and location-confidence labels
- keep location sharing active through recovery, stop forecast-envelope growth, and retarget chasers to preserved landing evidence
- expose recovery controls on mobile and shared/projected maps, with capability-gated older-relay handling
- separate Recovery complete from LANDED and retain/replay additive events on the relay

## Verification
- `flutter analyze`
- `flutter test --reporter compact` (1,789 passed; 24 intentionally skipped)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -q` (139 passed)
- `git diff --check`

Closes #72