### PR TITLE
feat: add secure reusable crew rooms

### DIFF
--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -7,6 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:crypto/crypto.dart';
 import 'package:uuid/uuid.dart';
 
+import '../data/in_memory_crew_room_store.dart';
+import '../domain/crew_room.dart';
+import '../domain/crew_room_store.dart';
 import '../domain/craft.dart';
 import '../services/craft_roster.dart';
 import '../services/chase_guidance_target.dart';
@@ -43,6 +46,7 @@ import '../services/received_quick_message.dart';
 import '../services/ride_route_reducer.dart';
 import '../services/rider_contact_share.dart';
 import '../internet/internet_relay_client.dart';
+import '../internet/crew_room_directory.dart';
 
 typedef Clock = DateTime Function();
 typedef IdFactory = String Function();
@@ -80,13 +84,18 @@ class RideController extends ChangeNotifier {
     IdFactory? idFactory,
     Random? random,
     RideCodeDirectory? rideCodeDirectory,
+    CrewRoomDirectory? crewRoomDirectory,
+    CrewRoomStore? crewRoomStore,
     this._completedRideStore,
     this._installationId,
   }) : _clock = clock ?? DateTime.now,
        _idFactory = idFactory ?? const Uuid().v7,
        _random = random ?? Random.secure(),
        _rideCodeDirectory =
-           rideCodeDirectory ?? HttpRideCodeDirectory.fromEnvironment();
+           rideCodeDirectory ?? HttpRideCodeDirectory.fromEnvironment(),
+       _crewRoomDirectory =
+           crewRoomDirectory ?? HttpCrewRoomDirectory.fromEnvironment(),
+       _crewRoomStore = crewRoomStore ?? InMemoryCrewRoomStore();
 
   static const endedRideRecoveryWindow = Duration(hours: 24);
 
@@ -99,6 +108,9 @@ class RideController extends ChangeNotifier {
   final CompletedRideStore? _completedRideStore;
   final String? _installationId;
   final RideCodeDirectory _rideCodeDirectory;
+  final CrewRoomDirectory _crewRoomDirectory;
+  final CrewRoomStore _crewRoomStore;
+  List<CrewRoomMembership> _crewRooms = const [];
 
   RideSession? _session;
   List<RideEvent> _events = <RideEvent>[];
@@ -143,6 +155,13 @@ class RideController extends ChangeNotifier {
   final Set<String> _usedIceShareEventIds = {};
 
   RideSession? get session => _session;
+  List<CrewRoomMembership> get crewRooms => List.unmodifiable(_crewRooms);
+  CrewRoomMembership? get currentCrewRoom {
+    final roomId = _session?.crewRoomId;
+    if (roomId == null) return null;
+    return _crewRooms.where((room) => room.roomId == roomId).firstOrNull;
+  }
+
   EventStore get eventStore => _eventStore;
   List<RideEvent> get events => UnmodifiableListView(_events);
   int get eventCount => _events.length;
@@ -637,6 +656,7 @@ class RideController extends ChangeNotifier {
 
   Future<void> initialize() async {
     _nearbyCapabilities = await _nearbyBridge.capabilities();
+    _crewRooms = await _crewRoomStore.loadAll();
     _session = await _sessionStore.load();
     final activeSession = _session;
     if (activeSession != null) {
@@ -755,8 +775,12 @@ class RideController extends ChangeNotifier {
     RiderColor riderColor = riderColorDefault,
     RideCoordinationMode coordinationMode = RideCoordinationMode.keepTogether,
     String? rideName,
+    String? crewRoomAlias,
   }) async {
     await _run(() async {
+      final roomAlias = crewRoomAlias == null || crewRoomAlias.trim().isEmpty
+          ? null
+          : normaliseCrewRoomAlias(crewRoomAlias);
       await _createRide(
         displayName: displayName,
         motorcycleStyle: motorcycleStyle,
@@ -765,7 +789,251 @@ class RideController extends ChangeNotifier {
         coordinationMode: coordinationMode,
         rideName: rideName,
       );
+      if (roomAlias != null) {
+        final operation = _requireSession();
+        final deviceId = _newCrewRoomDeviceId();
+        try {
+          final access = await _crewRoomDirectory.create(
+            alias: roomAlias,
+            deviceId: deviceId,
+            displayName: operation.displayName,
+            operation: operation,
+          );
+          final membership = CrewRoomMembership(
+            roomId: access.roomId,
+            alias: access.alias,
+            deviceId: deviceId,
+            deviceCredential: access.deviceCredential,
+            displayName: operation.displayName,
+            flightRole: FlightRole.pilot,
+            owner: access.owner,
+            operationGeneration: access.operationGeneration,
+            operationExpiresAt: access.operationExpiresAt,
+            inviteToken: access.inviteToken,
+          );
+          await _saveCrewRoomMembership(membership);
+          final updated = operation.copyWith(crewRoomId: access.roomId);
+          _session = updated;
+          await _sessionStore.save(updated);
+        } on Object {
+          await _removeRideData();
+          rethrow;
+        }
+      }
     });
+  }
+
+  Future<void> startNewCrewRoomOperation(
+    CrewRoomMembership membership, {
+    required String displayName,
+    CraftIconStyle motorcycleStyle = craftIconStyleDefault,
+    RiderSymbol riderSymbol = riderSymbolDefault,
+    RiderColor riderColor = riderColorDefault,
+  }) async {
+    await _run(() async {
+      if (!membership.owner) {
+        throw const FormatException(
+          'Only the crew room owner can start a fresh flight.',
+        );
+      }
+      await _createRide(
+        displayName: displayName,
+        motorcycleStyle: motorcycleStyle,
+        riderSymbol: riderSymbol,
+        riderColor: riderColor,
+        coordinationMode: RideCoordinationMode.keepTogether,
+        crewRoomId: membership.roomId,
+      );
+      final operation = _requireSession();
+      try {
+        final access = await _crewRoomDirectory.startOperation(
+          membership: membership,
+          operation: operation,
+        );
+        await _saveCrewRoomMembership(
+          membership.copyWith(
+            operationGeneration: access.operationGeneration,
+            operationExpiresAt: access.operationExpiresAt,
+            inviteToken: access.inviteToken,
+          ),
+        );
+      } on Object {
+        await _removeRideData();
+        rethrow;
+      }
+    });
+  }
+
+  Future<void> openCrewRoom(CrewRoomMembership membership) async {
+    await _run(() async {
+      final access = await _crewRoomDirectory.open(membership);
+      final operation = access.operation;
+      if (operation == null) {
+        throw const FormatException(
+          'This crew room has no active flight. Ask its owner to start one.',
+        );
+      }
+      await _joinWithCredentials(
+        rideId: operation.rideId,
+        rideCode: operation.rideCode,
+        inviteSecret: operation.inviteSecret,
+        joinToken: operation.joinToken,
+        displayName: membership.displayName,
+        flightRole: membership.flightRole,
+        vehicleLabel: membership.vehicleLabel,
+        motorcycleStyle: craftIconStyleDefault,
+        riderSymbol: riderSymbolDefault,
+        riderColor: riderColorDefault,
+        crewRoomId: access.roomId,
+        allowPilotRole: access.owner,
+      );
+      await _saveCrewRoomMembership(
+        CrewRoomMembership(
+          roomId: access.roomId,
+          alias: access.alias,
+          deviceId: membership.deviceId,
+          deviceCredential: access.deviceCredential,
+          displayName: membership.displayName,
+          flightRole: membership.flightRole,
+          vehicleLabel: membership.vehicleLabel,
+          owner: access.owner,
+          operationGeneration: access.operationGeneration,
+          operationExpiresAt: access.operationExpiresAt,
+          inviteToken:
+              access.owner &&
+                  access.operationGeneration == membership.operationGeneration
+              ? membership.inviteToken
+              : null,
+        ),
+      );
+    });
+  }
+
+  Future<void> joinCrewRoom({
+    required String alias,
+    required String inviteToken,
+    required String displayName,
+    required FlightRole flightRole,
+    String vehicleLabel = 'Land Rover',
+    CraftIconStyle motorcycleStyle = craftIconStyleDefault,
+    RiderSymbol riderSymbol = riderSymbolDefault,
+    RiderColor riderColor = riderColorDefault,
+  }) async {
+    await _run(() async {
+      final deviceId = _newCrewRoomDeviceId();
+      final access = await _crewRoomDirectory.join(
+        alias: alias,
+        inviteToken: inviteToken,
+        deviceId: deviceId,
+        displayName: _normaliseName(displayName),
+      );
+      final operation = access.operation;
+      if (operation == null) {
+        throw const FormatException(
+          'That crew room invitation has no active flight.',
+        );
+      }
+      await _joinWithCredentials(
+        rideId: operation.rideId,
+        rideCode: operation.rideCode,
+        inviteSecret: operation.inviteSecret,
+        joinToken: operation.joinToken,
+        displayName: displayName,
+        flightRole: flightRole,
+        vehicleLabel: vehicleLabel,
+        motorcycleStyle: motorcycleStyle,
+        riderSymbol: riderSymbol,
+        riderColor: riderColor,
+        crewRoomId: access.roomId,
+      );
+      await _saveCrewRoomMembership(
+        CrewRoomMembership(
+          roomId: access.roomId,
+          alias: access.alias,
+          deviceId: deviceId,
+          deviceCredential: access.deviceCredential,
+          displayName: _normaliseName(displayName),
+          flightRole: flightRole,
+          vehicleLabel: vehicleLabel,
+          owner: access.owner,
+          operationGeneration: access.operationGeneration,
+          operationExpiresAt: access.operationExpiresAt,
+        ),
+      );
+    });
+  }
+
+  Future<List<CrewRoomDevice>> crewRoomDevices(CrewRoomMembership membership) =>
+      _crewRoomDirectory.devices(membership);
+
+  Future<void> renameCrewRoom(
+    CrewRoomMembership membership,
+    String newAlias,
+  ) async {
+    await _run(() async {
+      final alias = await _crewRoomDirectory.rename(membership, newAlias);
+      await _saveCrewRoomMembership(membership.copyWith(alias: alias));
+    });
+  }
+
+  Future<void> transferCrewRoom(
+    CrewRoomMembership membership,
+    String targetDeviceId,
+  ) async {
+    await _run(() async {
+      await _crewRoomDirectory.transfer(membership, targetDeviceId);
+      await _saveCrewRoomMembership(
+        CrewRoomMembership(
+          roomId: membership.roomId,
+          alias: membership.alias,
+          deviceId: membership.deviceId,
+          deviceCredential: membership.deviceCredential,
+          displayName: membership.displayName,
+          flightRole: membership.flightRole,
+          vehicleLabel: membership.vehicleLabel,
+          owner: false,
+          operationGeneration: membership.operationGeneration,
+          operationExpiresAt: membership.operationExpiresAt,
+        ),
+      );
+    });
+  }
+
+  Future<void> revokeCrewRoomDevice(
+    CrewRoomMembership membership,
+    String targetDeviceId,
+  ) => _run(() => _crewRoomDirectory.revoke(membership, targetDeviceId));
+
+  Future<void> deleteCrewRoom(CrewRoomMembership membership) async {
+    await _run(() async {
+      await _crewRoomDirectory.delete(membership);
+      await _crewRoomStore.delete(membership.roomId);
+      _crewRooms = _crewRooms
+          .where((room) => room.roomId != membership.roomId)
+          .toList(growable: false);
+    });
+  }
+
+  Future<void> forgetCrewRoom(CrewRoomMembership membership) async {
+    await _crewRoomStore.delete(membership.roomId);
+    _crewRooms = _crewRooms
+        .where((room) => room.roomId != membership.roomId)
+        .toList(growable: false);
+    notifyListeners();
+  }
+
+  String _newCrewRoomDeviceId() {
+    final seed = _installationId ?? _idFactory();
+    final digest = sha256.convert(utf8.encode('crew-room-device-v1\n$seed'));
+    return 'room-device-${digest.toString().substring(0, 32)}';
+  }
+
+  Future<void> _saveCrewRoomMembership(CrewRoomMembership membership) async {
+    await _crewRoomStore.upsert(membership);
+    _crewRooms = [
+      ..._crewRooms.where((room) => room.roomId != membership.roomId),
+      membership,
+    ]..sort((a, b) => a.alias.compareTo(b.alias));
   }
 
   Future<void> createSimulationRide({
@@ -858,8 +1126,11 @@ class RideController extends ChangeNotifier {
     RiderSymbol riderSymbol = riderSymbolDefault,
     RiderColor riderColor = riderColorDefault,
   }) async {
-    await _run(
-      () => _joinWithCredentials(
+    await _run(() async {
+      final roomDeviceId = invitation.crewRoomId == null
+          ? null
+          : _newCrewRoomDeviceId();
+      await _joinWithCredentials(
         rideId: invitation.rideId,
         rideCode: invitation.rideCode,
         inviteSecret: invitation.inviteSecret,
@@ -870,8 +1141,47 @@ class RideController extends ChangeNotifier {
         motorcycleStyle: motorcycleStyle,
         riderSymbol: riderSymbol,
         riderColor: riderColor,
-      ),
-    );
+        crewRoomId: invitation.crewRoomId,
+      );
+      final roomId = invitation.crewRoomId;
+      final alias = invitation.crewRoomAlias;
+      final roomInvite = invitation.crewRoomInviteToken;
+      if (roomId == null ||
+          alias == null ||
+          roomInvite == null ||
+          roomDeviceId == null) {
+        return;
+      }
+      try {
+        final access = await _crewRoomDirectory.join(
+          alias: alias,
+          inviteToken: roomInvite,
+          deviceId: roomDeviceId,
+          displayName: _normaliseName(displayName),
+        );
+        if (access.roomId != roomId) return;
+        await _saveCrewRoomMembership(
+          CrewRoomMembership(
+            roomId: roomId,
+            alias: access.alias,
+            deviceId: roomDeviceId,
+            deviceCredential: access.deviceCredential,
+            displayName: _normaliseName(displayName),
+            flightRole: flightRole,
+            vehicleLabel: vehicleLabel,
+            owner: access.owner,
+            operationGeneration: access.operationGeneration,
+            operationExpiresAt: access.operationExpiresAt,
+          ),
+        );
+      } on CrewRoomDirectoryException catch (error) {
+        if (kDebugMode) {
+          debugPrint(
+            'Joined flight offline; returning room access was deferred: $error',
+          );
+        }
+      }
+    });
   }
 
   Future<void> joinRide(
@@ -920,6 +1230,8 @@ class RideController extends ChangeNotifier {
     required CraftIconStyle motorcycleStyle,
     required RiderSymbol riderSymbol,
     required RiderColor riderColor,
+    String? crewRoomId,
+    bool allowPilotRole = false,
   }) async {
     {
       // Deep links can arrive while any screen is open. Never let a join path
@@ -942,7 +1254,8 @@ class RideController extends ChangeNotifier {
         joinToken: joinToken,
       );
       final now = _clock();
-      if (flightRole == FlightRole.pilot || flightRole == FlightRole.observer) {
+      if ((flightRole == FlightRole.pilot && !allowPilotRole) ||
+          flightRole == FlightRole.observer) {
         throw const FormatException(
           'Join as balloon crew, a chase driver, or chase crew.',
         );
@@ -965,13 +1278,14 @@ class RideController extends ChangeNotifier {
         joinToken: credentials.joinToken,
         localRiderId: _localRiderIdForRide(credentials.rideId),
         displayName: _normaliseName(displayName),
-        role: RideRole.rider,
+        role: flightRole == FlightRole.pilot ? RideRole.lead : RideRole.rider,
         flightRole: flightRole,
         localCraftId: craftId,
         joinedAt: now,
         motorcycleStyle: motorcycleStyle,
         riderSymbol: riderSymbol,
         riderColor: riderColor,
+        crewRoomId: crewRoomId,
       );
       _session = session;
       await _sessionStore.save(session);
@@ -2097,6 +2411,7 @@ class RideController extends ChangeNotifier {
     RiderColor riderColor = riderColorDefault,
     RideCoordinationMode coordinationMode = RideCoordinationMode.keepTogether,
     String? rideName,
+    String? crewRoomId,
   }) async {
     // The home screen deliberately remains available while an ended ride is
     // set aside (#207). Creating its replacement must file that completed ride
@@ -2144,6 +2459,7 @@ class RideController extends ChangeNotifier {
       rideName: normalisedRideName == null || normalisedRideName.isEmpty
           ? null
           : normalisedRideName,
+      crewRoomId: crewRoomId,
     );
     _session = session;
     await _sessionStore.save(session);
@@ -2216,6 +2532,9 @@ class RideController extends ChangeNotifier {
       // The rider's own input. Retrying it unchanged would fail identically.
       _errorMessage = error.message;
     } on RideCodeDirectoryException catch (error) {
+      _errorMessage = error.message;
+      _errorIsRetryable = error.retryable;
+    } on CrewRoomDirectoryException catch (error) {
       _errorMessage = error.message;
       _errorIsRetryable = error.retryable;
     } on Object catch (error, stackTrace) {
@@ -2505,6 +2824,7 @@ class RideController extends ChangeNotifier {
   void dispose() {
     _endedRideCleanupTimer?.cancel();
     _rideCodeDirectory.close();
+    _crewRoomDirectory.close();
     _eventStore.close();
     super.dispose();
   }

--- a/apps/mobile/lib/data/in_memory_crew_room_store.dart
+++ b/apps/mobile/lib/data/in_memory_crew_room_store.dart
@@ -1,0 +1,21 @@
+import '../domain/crew_room.dart';
+import '../domain/crew_room_store.dart';
+
+class InMemoryCrewRoomStore implements CrewRoomStore {
+  final Map<String, CrewRoomMembership> _rooms = {};
+
+  @override
+  Future<List<CrewRoomMembership>> loadAll() async => List.unmodifiable(
+    _rooms.values.toList()..sort((a, b) => a.alias.compareTo(b.alias)),
+  );
+
+  @override
+  Future<void> upsert(CrewRoomMembership membership) async {
+    _rooms[membership.roomId] = membership;
+  }
+
+  @override
+  Future<void> delete(String roomId) async {
+    _rooms.remove(roomId);
+  }
+}

--- a/apps/mobile/lib/data/secure_crew_room_store.dart
+++ b/apps/mobile/lib/data/secure_crew_room_store.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../domain/crew_room.dart';
+import '../domain/crew_room_store.dart';
+
+class SecureCrewRoomStore implements CrewRoomStore {
+  const SecureCrewRoomStore({FlutterSecureStorage? storage})
+    : _storage = storage ?? const FlutterSecureStorage();
+
+  static const _key = 'balloon_crumbs_crew_rooms_v1';
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<List<CrewRoomMembership>> loadAll() async {
+    final encoded = await _storage.read(key: _key);
+    if (encoded == null) return const [];
+    try {
+      final value = Map<String, Object?>.from(jsonDecode(encoded) as Map);
+      if (value['schemaVersion'] != 1 || value['rooms'] is! List) {
+        throw const FormatException('Crew room store is invalid.');
+      }
+      final memberships = (value['rooms']! as List)
+          .map(
+            (item) => CrewRoomMembership.fromJson(
+              Map<String, Object?>.from(item as Map),
+            ),
+          )
+          .toList(growable: false);
+      if (memberships.length > 50 ||
+          memberships.map((room) => room.roomId).toSet().length !=
+              memberships.length) {
+        throw const FormatException('Crew room store is invalid.');
+      }
+      return List.unmodifiable(memberships);
+    } on Object {
+      await _storage.delete(key: _key);
+      return const [];
+    }
+  }
+
+  @override
+  Future<void> upsert(CrewRoomMembership membership) async {
+    final rooms = [...await loadAll()];
+    rooms.removeWhere((room) => room.roomId == membership.roomId);
+    rooms.add(membership);
+    rooms.sort((a, b) => a.alias.compareTo(b.alias));
+    await _storage.write(
+      key: _key,
+      value: jsonEncode({
+        'schemaVersion': 1,
+        'rooms': rooms.map((room) => room.toJson()).toList(growable: false),
+      }),
+    );
+  }
+
+  @override
+  Future<void> delete(String roomId) async {
+    final rooms = [...await loadAll()]
+      ..removeWhere((room) => room.roomId == roomId);
+    if (rooms.isEmpty) {
+      await _storage.delete(key: _key);
+      return;
+    }
+    await _storage.write(
+      key: _key,
+      value: jsonEncode({
+        'schemaVersion': 1,
+        'rooms': rooms.map((room) => room.toJson()).toList(growable: false),
+      }),
+    );
+  }
+}

--- a/apps/mobile/lib/domain/crew_room.dart
+++ b/apps/mobile/lib/domain/crew_room.dart
@@ -1,0 +1,193 @@
+import 'flight_role.dart';
+
+class CrewRoomOperation {
+  const CrewRoomOperation({
+    required this.rideId,
+    required this.rideCode,
+    required this.inviteSecret,
+    required this.joinToken,
+  });
+
+  final String rideId;
+  final String rideCode;
+  final String inviteSecret;
+  final String joinToken;
+
+  Map<String, Object?> toJson() => {
+    'rideId': rideId,
+    'rideCode': rideCode,
+    'inviteSecret': inviteSecret,
+    'resolveToken': joinToken,
+  };
+
+  factory CrewRoomOperation.fromJson(Map<String, Object?> json) {
+    final rideId = json['rideId'];
+    final rideCode = json['rideCode'];
+    final inviteSecret = json['inviteSecret'];
+    final joinToken = json['resolveToken'];
+    if (rideId is! String ||
+        rideId.isEmpty ||
+        rideCode is! String ||
+        !RegExp(r'^\d{6}$').hasMatch(rideCode) ||
+        inviteSecret is! String ||
+        inviteSecret.length < 16 ||
+        joinToken is! String ||
+        joinToken.length < 16) {
+      throw const FormatException('Crew room operation is invalid.');
+    }
+    return CrewRoomOperation(
+      rideId: rideId,
+      rideCode: rideCode,
+      inviteSecret: inviteSecret,
+      joinToken: joinToken,
+    );
+  }
+}
+
+class CrewRoomMembership {
+  const CrewRoomMembership({
+    required this.roomId,
+    required this.alias,
+    required this.deviceId,
+    required this.deviceCredential,
+    required this.displayName,
+    required this.flightRole,
+    required this.owner,
+    required this.operationGeneration,
+    required this.operationExpiresAt,
+    this.vehicleLabel = 'Land Rover',
+    this.inviteToken,
+  });
+
+  final String roomId;
+  final String alias;
+  final String deviceId;
+  final String deviceCredential;
+  final String displayName;
+  final FlightRole flightRole;
+  final String vehicleLabel;
+  final bool owner;
+  final int operationGeneration;
+  final DateTime operationExpiresAt;
+  final String? inviteToken;
+
+  CrewRoomMembership copyWith({
+    String? alias,
+    bool? owner,
+    int? operationGeneration,
+    DateTime? operationExpiresAt,
+    String? inviteToken,
+  }) => CrewRoomMembership(
+    roomId: roomId,
+    alias: alias ?? this.alias,
+    deviceId: deviceId,
+    deviceCredential: deviceCredential,
+    displayName: displayName,
+    flightRole: flightRole,
+    vehicleLabel: vehicleLabel,
+    owner: owner ?? this.owner,
+    operationGeneration: operationGeneration ?? this.operationGeneration,
+    operationExpiresAt: operationExpiresAt ?? this.operationExpiresAt,
+    inviteToken: inviteToken ?? this.inviteToken,
+  );
+
+  Map<String, Object?> toJson() => {
+    'roomId': roomId,
+    'alias': alias,
+    'deviceId': deviceId,
+    'deviceCredential': deviceCredential,
+    'displayName': displayName,
+    'flightRole': flightRole.name,
+    'vehicleLabel': vehicleLabel,
+    'owner': owner,
+    'operationGeneration': operationGeneration,
+    'operationExpiresAt': operationExpiresAt.toUtc().toIso8601String(),
+    if (inviteToken != null) 'inviteToken': inviteToken,
+  };
+
+  factory CrewRoomMembership.fromJson(Map<String, Object?> json) {
+    final alias = normaliseCrewRoomAlias(json['alias']);
+    final roleName = json['flightRole'];
+    final role = roleName is String
+        ? FlightRole.values.where((item) => item.name == roleName).firstOrNull
+        : null;
+    final roomId = json['roomId'];
+    final deviceId = json['deviceId'];
+    final credential = json['deviceCredential'];
+    final displayName = json['displayName'];
+    final owner = json['owner'];
+    final generation = json['operationGeneration'];
+    final expires = json['operationExpiresAt'];
+    final inviteToken = json['inviteToken'];
+    if (roomId is! String ||
+        roomId.isEmpty ||
+        deviceId is! String ||
+        deviceId.isEmpty ||
+        credential is! String ||
+        !RegExp(r'^crd1_[A-Za-z0-9_-]{43}$').hasMatch(credential) ||
+        displayName is! String ||
+        displayName.isEmpty ||
+        role == null ||
+        owner is! bool ||
+        generation is! int ||
+        generation < 1 ||
+        expires is! String ||
+        (inviteToken != null &&
+            (inviteToken is! String ||
+                !RegExp(r'^cri1_[A-Za-z0-9_-]{43}$').hasMatch(inviteToken)))) {
+      throw const FormatException('Crew room membership is invalid.');
+    }
+    return CrewRoomMembership(
+      roomId: roomId,
+      alias: alias,
+      deviceId: deviceId,
+      deviceCredential: credential,
+      displayName: displayName,
+      flightRole: role,
+      vehicleLabel: json['vehicleLabel'] is String
+          ? json['vehicleLabel']! as String
+          : 'Land Rover',
+      owner: owner,
+      operationGeneration: generation,
+      operationExpiresAt: DateTime.parse(expires).toLocal(),
+      inviteToken: inviteToken as String?,
+    );
+  }
+}
+
+class CrewRoomDevice {
+  const CrewRoomDevice({
+    required this.deviceId,
+    required this.displayName,
+    required this.owner,
+    required this.revoked,
+    required this.lastSeenAt,
+  });
+
+  final String deviceId;
+  final String displayName;
+  final bool owner;
+  final bool revoked;
+  final DateTime lastSeenAt;
+
+  factory CrewRoomDevice.fromJson(Map<String, Object?> json) => CrewRoomDevice(
+    deviceId: json['deviceId']! as String,
+    displayName: json['displayName']! as String,
+    owner: json['owner']! as bool,
+    revoked: json['revoked']! as bool,
+    lastSeenAt: DateTime.parse(json['lastSeenAt']! as String).toLocal(),
+  );
+}
+
+String normaliseCrewRoomAlias(Object? value) {
+  if (value is! String) {
+    throw const FormatException('Enter a crew room alias.');
+  }
+  final normalised = value.trim().toUpperCase();
+  if (!RegExp(r'^[A-Z0-9]{5,12}$').hasMatch(normalised)) {
+    throw const FormatException(
+      'Use 5–12 letters or numbers for the crew room alias.',
+    );
+  }
+  return normalised;
+}

--- a/apps/mobile/lib/domain/crew_room_store.dart
+++ b/apps/mobile/lib/domain/crew_room_store.dart
@@ -1,0 +1,9 @@
+import 'crew_room.dart';
+
+abstract interface class CrewRoomStore {
+  Future<List<CrewRoomMembership>> loadAll();
+
+  Future<void> upsert(CrewRoomMembership membership);
+
+  Future<void> delete(String roomId);
+}

--- a/apps/mobile/lib/domain/ride_join_payload.dart
+++ b/apps/mobile/lib/domain/ride_join_payload.dart
@@ -29,6 +29,9 @@ class RideJoinPayload {
     required this.rideCode,
     required this.inviteSecret,
     required this.joinToken,
+    this.crewRoomId,
+    this.crewRoomAlias,
+    this.crewRoomInviteToken,
   });
 
   /// Version prefix, so a payload from a future format is **rejected** rather
@@ -58,9 +61,24 @@ class RideJoinPayload {
   final String rideCode;
   final String inviteSecret;
   final String joinToken;
+  final String? crewRoomId;
+  final String? crewRoomAlias;
+  final String? crewRoomInviteToken;
 
-  String encode() =>
-      [scheme, rideCode, rideId, inviteSecret, joinToken].join(_separator);
+  String encode() {
+    final base = [scheme, rideCode, rideId, inviteSecret, joinToken];
+    if (crewRoomId == null ||
+        crewRoomAlias == null ||
+        crewRoomInviteToken == null) {
+      return base.join(_separator);
+    }
+    return [
+      ...base,
+      crewRoomId!,
+      crewRoomAlias!,
+      crewRoomInviteToken!,
+    ].join(_separator);
+  }
 
   /// Parses [raw], or throws [FormatException] with a reason a person can act on.
   ///
@@ -70,13 +88,16 @@ class RideJoinPayload {
   /// from a camera - anyone can print one.
   static RideJoinPayload decode(String raw) {
     final parts = raw.trim().split(_separator);
-    if (parts.length != 5 ||
+    if ((parts.length != 5 && parts.length != 8) ||
         (parts.first != scheme && parts.first != legacyScheme)) {
       throw const FormatException(
         'That code is not a Balloon Crumbs flight invitation.',
       );
     }
-    final [_, rideCode, rideId, inviteSecret, joinToken] = parts;
+    final rideCode = parts[1];
+    final rideId = parts[2];
+    final inviteSecret = parts[3];
+    final joinToken = parts[4];
 
     if (!RegExp(r'^\d{6}$').hasMatch(rideCode)) {
       throw const FormatException('That invitation has no valid flight code.');
@@ -98,11 +119,35 @@ class RideJoinPayload {
         'That invitation is incomplete and cannot join securely.',
       );
     }
+    String? crewRoomId;
+    String? crewRoomAlias;
+    String? crewRoomInviteToken;
+    if (parts.length == 8) {
+      crewRoomId = parts[5];
+      crewRoomAlias = parts[6];
+      crewRoomInviteToken = parts[7];
+      if (crewRoomId.isEmpty || crewRoomId.length > 128) {
+        throw const FormatException('That invitation has no valid crew room.');
+      }
+      if (!RegExp(r'^[A-Z0-9]{5,12}$').hasMatch(crewRoomAlias)) {
+        throw const FormatException(
+          'That invitation has no valid crew room alias.',
+        );
+      }
+      if (!RegExp(r'^cri1_[A-Za-z0-9_-]{43}$').hasMatch(crewRoomInviteToken)) {
+        throw const FormatException(
+          'That invitation cannot grant returning crew access.',
+        );
+      }
+    }
     return RideJoinPayload(
       rideId: rideId,
       rideCode: rideCode,
       inviteSecret: inviteSecret,
       joinToken: joinToken,
+      crewRoomId: crewRoomId,
+      crewRoomAlias: crewRoomAlias,
+      crewRoomInviteToken: crewRoomInviteToken,
     );
   }
 

--- a/apps/mobile/lib/domain/ride_session.dart
+++ b/apps/mobile/lib/domain/ride_session.dart
@@ -31,6 +31,7 @@ class RideSession {
     this.riderColor = riderColorDefault,
     this.coordinationMode = RideCoordinationMode.keepTogether,
     this.rideName,
+    this.crewRoomId,
   }) : flightRole =
            flightRole ??
            (role == RideRole.lead ? FlightRole.pilot : FlightRole.chaseCrew),
@@ -79,6 +80,9 @@ class RideSession {
   /// identifiable by their six-digit code even with no name set.
   final String? rideName;
 
+  /// Opaque persistent room identity, never an access credential.
+  final String? crewRoomId;
+
   RideSession copyWith({
     RideRole? role,
     FlightRole? flightRole,
@@ -87,6 +91,7 @@ class RideSession {
     String? rideCode,
     int? simulationRiderCount,
     RideCoordinationMode? coordinationMode,
+    String? crewRoomId,
   }) => RideSession(
     rideId: rideId,
     rideCode: rideCode ?? this.rideCode,
@@ -107,6 +112,7 @@ class RideSession {
     riderColor: riderColor,
     coordinationMode: coordinationMode ?? this.coordinationMode,
     rideName: rideName,
+    crewRoomId: crewRoomId ?? this.crewRoomId,
   );
 
   Map<String, Object?> toJson() => {
@@ -128,6 +134,7 @@ class RideSession {
     'riderColor': riderColor.name,
     'coordinationMode': coordinationMode.name,
     if (rideName != null) 'rideName': rideName,
+    if (crewRoomId != null) 'crewRoomId': crewRoomId,
   };
 
   factory RideSession.fromJson(Map<String, Object?> json) {
@@ -161,6 +168,7 @@ class RideSession {
         json['coordinationMode'] as String?,
       ),
       rideName: json['rideName'] as String?,
+      crewRoomId: json['crewRoomId'] as String?,
     );
   }
 

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -23,6 +23,7 @@ import '../../domain/geo_point.dart' as awareness_geo;
 import '../../domain/landing_zone.dart';
 import '../../domain/map_style_mode.dart';
 import '../../domain/flight_role.dart';
+import '../../domain/crew_room.dart';
 import '../../services/road_routing.dart';
 import 'home_destination_search.dart';
 import 'home_map_backdrop.dart';
@@ -598,6 +599,32 @@ class _HomeScreenState extends State<HomeScreen> {
         child: ListView(
           shrinkWrap: true,
           children: [
+            if (widget.controller.crewRooms.isNotEmpty) ...[
+              const ListTile(
+                leading: Icon(Icons.groups_3_outlined),
+                title: Text('Your crew rooms'),
+                subtitle: Text(
+                  'A room name returns to a fresh private flight; it is not a password.',
+                ),
+              ),
+              for (final room in widget.controller.crewRooms)
+                ListTile(
+                  key: Key('crew-room-${room.alias}'),
+                  leading: const Icon(Icons.tag),
+                  title: Text(room.alias),
+                  subtitle: Text(
+                    room.owner
+                        ? 'You manage this room · flight ${room.operationGeneration}'
+                        : 'Returning crew access · flight ${room.operationGeneration}',
+                  ),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () {
+                    Navigator.of(sheetContext).pop();
+                    unawaited(_openCrewRoomActions(room));
+                  },
+                ),
+              const Divider(height: 8),
+            ],
             ListTile(
               key: const Key('open-flight-planner'),
               leading: const Icon(Icons.air_outlined),
@@ -669,6 +696,323 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       ),
     );
+  }
+
+  Future<void> _openCrewRoomActions(CrewRoomMembership room) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      backgroundColor: const Color(0xFF171D25),
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.groups_3_outlined),
+              title: Text(room.alias),
+              subtitle: const Text(
+                'The alias identifies the crew. Access stays on this device.',
+              ),
+            ),
+            ListTile(
+              key: const Key('open-crew-room-operation'),
+              leading: const Icon(Icons.login),
+              title: const Text('Open current flight'),
+              onTap: () {
+                Navigator.of(sheetContext).pop();
+                unawaited(_openCurrentCrewRoomFlight(room));
+              },
+            ),
+            if (room.owner)
+              ListTile(
+                key: const Key('start-new-crew-room-operation'),
+                leading: const Icon(Icons.add_circle_outline),
+                title: const Text('Start a fresh flight'),
+                subtitle: const Text(
+                  'Keeps the room name but creates a new private journal and invite.',
+                ),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  unawaited(_startFreshCrewRoomFlight(room));
+                },
+              ),
+            if (room.owner)
+              ListTile(
+                key: const Key('manage-crew-room'),
+                leading: const Icon(Icons.manage_accounts_outlined),
+                title: const Text('Manage room access'),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  unawaited(_manageCrewRoom(room));
+                },
+              ),
+            ListTile(
+              key: const Key('forget-crew-room'),
+              leading: const Icon(Icons.delete_outline),
+              title: Text(
+                room.owner ? 'Delete or forget room' : 'Forget this room',
+              ),
+              onTap: () {
+                Navigator.of(sheetContext).pop();
+                unawaited(
+                  room.owner
+                      ? _confirmDeleteCrewRoom(room)
+                      : widget.controller.forgetCrewRoom(room),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openCurrentCrewRoomFlight(CrewRoomMembership room) async {
+    await widget.controller.openCrewRoom(room);
+    _showCrewRoomErrorIfAny();
+  }
+
+  Future<void> _startFreshCrewRoomFlight(CrewRoomMembership room) async {
+    final profile = widget.riderProfile;
+    await widget.controller.startNewCrewRoomOperation(
+      room,
+      displayName: profile.displayName,
+      motorcycleStyle: profile.motorcycleStyle,
+      riderSymbol: profile.riderSymbol,
+      riderColor: profile.riderColor,
+    );
+    _showCrewRoomErrorIfAny();
+  }
+
+  void _showCrewRoomErrorIfAny() {
+    if (!mounted) return;
+    final message = widget.controller.errorMessage;
+    if (message != null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(message)));
+    }
+  }
+
+  Future<void> _manageCrewRoom(CrewRoomMembership room) async {
+    List<CrewRoomDevice> devices;
+    try {
+      devices = await widget.controller.crewRoomDevices(room);
+    } on Object {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not load crew room access.')),
+        );
+      }
+      return;
+    }
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      isScrollControlled: true,
+      backgroundColor: const Color(0xFF171D25),
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          padding: const EdgeInsets.only(bottom: 20),
+          children: [
+            ListTile(
+              title: Text('Manage ${room.alias}'),
+              subtitle: const Text(
+                'A revoked device cannot open later flights. Current flight data follows its own retention window.',
+              ),
+              trailing: IconButton(
+                key: const Key('rename-crew-room'),
+                tooltip: 'Rename room',
+                onPressed: () {
+                  Navigator.of(sheetContext).pop();
+                  unawaited(_renameCrewRoom(room));
+                },
+                icon: const Icon(Icons.edit_outlined),
+              ),
+            ),
+            for (final device in devices)
+              ListTile(
+                leading: Icon(
+                  device.owner
+                      ? Icons.admin_panel_settings
+                      : Icons.phone_android,
+                ),
+                title: Text(device.displayName),
+                subtitle: Text(
+                  device.revoked
+                      ? 'Revoked'
+                      : device.owner
+                      ? 'Room owner'
+                      : 'Returning device · last seen ${device.lastSeenAt}',
+                ),
+                trailing: device.deviceId == room.deviceId || device.revoked
+                    ? null
+                    : PopupMenuButton<String>(
+                        onSelected: (action) {
+                          Navigator.of(sheetContext).pop();
+                          if (action == 'transfer') {
+                            unawaited(_confirmTransferCrewRoom(room, device));
+                          } else {
+                            unawaited(
+                              _confirmRevokeCrewRoomDevice(room, device),
+                            );
+                          }
+                        },
+                        itemBuilder: (_) => const [
+                          PopupMenuItem(
+                            value: 'transfer',
+                            child: Text('Transfer ownership'),
+                          ),
+                          PopupMenuItem(
+                            value: 'revoke',
+                            child: Text('Revoke device'),
+                          ),
+                        ],
+                      ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _renameCrewRoom(CrewRoomMembership room) async {
+    final text = TextEditingController(text: room.alias);
+    final alias = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Rename crew room'),
+        content: TextField(
+          key: const Key('rename-crew-room-field'),
+          controller: text,
+          textCapitalization: TextCapitalization.characters,
+          maxLength: 12,
+          inputFormatters: [
+            FilteringTextInputFormatter.allow(RegExp('[A-Za-z0-9]')),
+            LengthLimitingTextInputFormatter(12),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, text.text),
+            child: const Text('Rename'),
+          ),
+        ],
+      ),
+    );
+    text.dispose();
+    if (alias == null) return;
+    await widget.controller.renameCrewRoom(room, alias);
+    _showCrewRoomErrorIfAny();
+  }
+
+  Future<void> _confirmTransferCrewRoom(
+    CrewRoomMembership room,
+    CrewRoomDevice device,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text('Make ${device.displayName} the owner?'),
+        content: Text(
+          '${device.displayName} will be able to rename or delete ${room.alias}, '
+          'start fresh flights and manage returning devices. You will keep crew '
+          'access but will no longer manage the room.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Transfer ownership'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await widget.controller.transferCrewRoom(room, device.deviceId);
+    if (!mounted) return;
+    if (widget.controller.errorMessage != null) {
+      _showCrewRoomErrorIfAny();
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${device.displayName} now manages ${room.alias}.'),
+      ),
+    );
+  }
+
+  Future<void> _confirmRevokeCrewRoomDevice(
+    CrewRoomMembership room,
+    CrewRoomDevice device,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text('Revoke ${device.displayName}?'),
+        content: Text(
+          '${device.displayName} will not be able to open later ${room.alias} '
+          'flights. This does not erase a still-retained current flight from '
+          'their device.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Revoke device'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await widget.controller.revokeCrewRoomDevice(room, device.deviceId);
+    if (!mounted) return;
+    if (widget.controller.errorMessage != null) {
+      _showCrewRoomErrorIfAny();
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${device.displayName} cannot open later flights.'),
+      ),
+    );
+  }
+
+  Future<void> _confirmDeleteCrewRoom(CrewRoomMembership room) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text('Delete ${room.alias}?'),
+        content: const Text(
+          'This revokes returning access for every device. It does not erase a still-retained current flight from those devices.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Delete room'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await widget.controller.deleteCrewRoom(room);
+    _showCrewRoomErrorIfAny();
   }
 
   Future<void> _openFlightPlanner() async {
@@ -1071,6 +1415,7 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
     text: widget.creating ? null : widget.rideCodePreference.savedCode,
   );
   final _rideNameController = TextEditingController();
+  final _crewRoomAliasController = TextEditingController();
   final _planCodeController = TextEditingController();
   final _vehicleLabelController = TextEditingController(text: 'Land Rover');
   final _codeFocusNode = FocusNode();
@@ -1107,6 +1452,7 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
     _nameController.dispose();
     _codeController.dispose();
     _rideNameController.dispose();
+    _crewRoomAliasController.dispose();
     _planCodeController.dispose();
     _vehicleLabelController.dispose();
     super.dispose();
@@ -1198,6 +1544,27 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
                   ),
                 ),
                 const SizedBox(height: 12),
+                if (_selectedCoordinationMode.isGroup) ...[
+                  TextField(
+                    key: const Key('crew-room-alias-field'),
+                    controller: _crewRoomAliasController,
+                    maxLength: 12,
+                    textCapitalization: TextCapitalization.characters,
+                    autocorrect: false,
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp('[A-Za-z0-9]')),
+                      LengthLimitingTextInputFormatter(12),
+                    ],
+                    decoration: const InputDecoration(
+                      labelText: 'Reusable crew room (optional)',
+                      hintText: 'e.g. TUCKER',
+                      helperText:
+                          '5–12 letters or numbers. The name can be reused; private device access cannot be guessed from it.',
+                      counterText: '',
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                ],
                 TextField(
                   key: const Key('planned-route-code-field'),
                   controller: _planCodeController,
@@ -1487,6 +1854,9 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
         riderColor: widget.riderProfile.riderColor,
         coordinationMode: _selectedCoordinationMode,
         rideName: _rideNameController.text,
+        crewRoomAlias: _selectedCoordinationMode.isGroup
+            ? _crewRoomAliasController.text
+            : null,
       );
       if (widget.controller.hasActiveRide) {
         final target = widget.initialLandingZone;

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -1142,8 +1142,11 @@ class _RideCodeCard extends StatelessWidget {
                       // with no bars they do nothing at all (#279).
                       TextButton.icon(
                         key: const Key('show-invitation-qr'),
-                        onPressed: () =>
-                            RideInvitationQrSheet.show(context, session),
+                        onPressed: () => RideInvitationQrSheet.show(
+                          context,
+                          session,
+                          crewRoom: controller.currentCrewRoom,
+                        ),
                         icon: const Icon(Icons.qr_code_2),
                         label: const Text('Show QR'),
                       ),

--- a/apps/mobile/lib/features/ride/ride_invitation_qr_sheet.dart
+++ b/apps/mobile/lib/features/ride/ride_invitation_qr_sheet.dart
@@ -3,6 +3,7 @@ import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../domain/ride_join_payload.dart';
 import '../../domain/ride_session.dart';
+import '../../domain/crew_room.dart';
 
 /// Shows the ride's invitation as a QR code, generated on this phone.
 ///
@@ -20,18 +21,26 @@ import '../../domain/ride_session.dart';
 /// away - not left open on a phone on a café table. A dismissible sheet expresses
 /// that; a tab would not.
 class RideInvitationQrSheet extends StatelessWidget {
-  const RideInvitationQrSheet({super.key, required this.session});
+  const RideInvitationQrSheet({
+    super.key,
+    required this.session,
+    this.crewRoom,
+  });
 
   final RideSession session;
+  final CrewRoomMembership? crewRoom;
 
-  static Future<void> show(BuildContext context, RideSession session) =>
-      showModalBottomSheet<void>(
-        context: context,
-        showDragHandle: true,
-        useSafeArea: true,
-        isScrollControlled: true,
-        builder: (_) => RideInvitationQrSheet(session: session),
-      );
+  static Future<void> show(
+    BuildContext context,
+    RideSession session, {
+    CrewRoomMembership? crewRoom,
+  }) => showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    useSafeArea: true,
+    isScrollControlled: true,
+    builder: (_) => RideInvitationQrSheet(session: session, crewRoom: crewRoom),
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +49,9 @@ class RideInvitationQrSheet extends StatelessWidget {
       rideCode: session.rideCode,
       inviteSecret: session.inviteSecret,
       joinToken: session.joinToken,
+      crewRoomId: crewRoom?.inviteToken == null ? null : crewRoom!.roomId,
+      crewRoomAlias: crewRoom?.inviteToken == null ? null : crewRoom!.alias,
+      crewRoomInviteToken: crewRoom?.inviteToken,
     );
 
     return SingleChildScrollView(
@@ -52,9 +64,10 @@ class RideInvitationQrSheet extends StatelessWidget {
             style: Theme.of(context).textTheme.headlineSmall,
           ),
           const SizedBox(height: 8),
-          const Text(
-            'This works with no signal. Everything needed to join is in the '
-            'code itself, so nobody has to be online to scan it.',
+          Text(
+            crewRoom?.inviteToken == null
+                ? 'This works with no signal. Everything needed to join is in the code itself, so nobody has to be online to scan it.'
+                : 'This works with no signal for this flight. When connected, it also saves returning access to crew room ${crewRoom!.alias}.',
             style: TextStyle(color: Color(0xFFABB5C1), height: 1.45),
           ),
           const SizedBox(height: 20),
@@ -81,7 +94,9 @@ class RideInvitationQrSheet extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           Text(
-            'Flight ${session.rideCode}',
+            crewRoom == null
+                ? 'Flight ${session.rideCode}'
+                : '${crewRoom!.alias} · flight ${session.rideCode}',
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.titleMedium,
           ),

--- a/apps/mobile/lib/internet/crew_room_directory.dart
+++ b/apps/mobile/lib/internet/crew_room_directory.dart
@@ -1,0 +1,341 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+
+import '../domain/crew_room.dart';
+import '../domain/ride_session.dart';
+import 'internet_relay_client.dart';
+
+class CrewRoomAccess {
+  const CrewRoomAccess({
+    required this.roomId,
+    required this.alias,
+    required this.deviceCredential,
+    required this.operationGeneration,
+    required this.operationExpiresAt,
+    required this.owner,
+    this.inviteToken,
+    this.operation,
+  });
+
+  final String roomId;
+  final String alias;
+  final String deviceCredential;
+  final String? inviteToken;
+  final int operationGeneration;
+  final CrewRoomOperation? operation;
+  final DateTime operationExpiresAt;
+  final bool owner;
+
+  factory CrewRoomAccess.fromJson(Map<String, Object?> json) {
+    final operation = json['operation'];
+    final roomId = json['roomId'];
+    final credential = json['deviceCredential'];
+    final generation = json['operationGeneration'];
+    final expires = json['operationExpiresAt'];
+    final owner = json['owner'];
+    final inviteToken = json['inviteToken'];
+    if (roomId is! String ||
+        roomId.isEmpty ||
+        credential is! String ||
+        !RegExp(r'^crd1_[A-Za-z0-9_-]{43}$').hasMatch(credential) ||
+        generation is! int ||
+        generation < 1 ||
+        expires is! String ||
+        owner is! bool ||
+        (inviteToken != null && inviteToken is! String)) {
+      throw const FormatException('Crew room response is invalid.');
+    }
+    return CrewRoomAccess(
+      roomId: roomId,
+      alias: normaliseCrewRoomAlias(json['alias']),
+      deviceCredential: credential,
+      inviteToken: inviteToken as String?,
+      operationGeneration: generation,
+      operation: operation == null
+          ? null
+          : CrewRoomOperation.fromJson(
+              Map<String, Object?>.from(operation as Map),
+            ),
+      operationExpiresAt: DateTime.parse(expires).toLocal(),
+      owner: owner,
+    );
+  }
+}
+
+abstract interface class CrewRoomDirectory {
+  Future<CrewRoomAccess> create({
+    required String alias,
+    required String deviceId,
+    required String displayName,
+    required RideSession operation,
+  });
+
+  Future<CrewRoomAccess> open(CrewRoomMembership membership);
+
+  Future<CrewRoomAccess> join({
+    required String alias,
+    required String inviteToken,
+    required String deviceId,
+    required String displayName,
+  });
+
+  Future<CrewRoomAccess> startOperation({
+    required CrewRoomMembership membership,
+    required RideSession operation,
+  });
+
+  Future<List<CrewRoomDevice>> devices(CrewRoomMembership membership);
+
+  Future<String> rename(CrewRoomMembership membership, String newAlias);
+
+  Future<void> transfer(CrewRoomMembership membership, String targetDeviceId);
+
+  Future<void> revoke(CrewRoomMembership membership, String targetDeviceId);
+
+  Future<void> delete(CrewRoomMembership membership);
+
+  void close();
+}
+
+class CrewRoomDirectoryException implements Exception {
+  const CrewRoomDirectoryException(this.message, {this.retryable = false});
+
+  final String message;
+  final bool retryable;
+
+  @override
+  String toString() => 'CrewRoomDirectoryException: $message';
+}
+
+class HttpCrewRoomDirectory implements CrewRoomDirectory {
+  factory HttpCrewRoomDirectory.fromEnvironment() => HttpCrewRoomDirectory(
+    configuration: InternetRelayConfiguration.fromEnvironment(),
+    client: http.Client(),
+  );
+
+  HttpCrewRoomDirectory({
+    required this.configuration,
+    required this.client,
+    RelayClientDescriptor? descriptor,
+  }) : _descriptor = descriptor ?? RelayClientDescriptor.current();
+
+  final InternetRelayConfiguration configuration;
+  final http.Client client;
+  final RelayClientDescriptor _descriptor;
+
+  @override
+  Future<CrewRoomAccess> create({
+    required String alias,
+    required String deviceId,
+    required String displayName,
+    required RideSession operation,
+  }) async => CrewRoomAccess.fromJson(
+    await _request(
+      'create',
+      {
+        'alias': normaliseCrewRoomAlias(alias),
+        'deviceId': deviceId,
+        'displayName': displayName,
+        'operation': _operation(operation),
+      },
+      ride: operation,
+      expectedStatus: 201,
+    ),
+  );
+
+  @override
+  Future<CrewRoomAccess> open(CrewRoomMembership membership) async =>
+      CrewRoomAccess.fromJson(await _request('open', _auth(membership)));
+
+  @override
+  Future<CrewRoomAccess> join({
+    required String alias,
+    required String inviteToken,
+    required String deviceId,
+    required String displayName,
+  }) async => CrewRoomAccess.fromJson(
+    await _request('join', {
+      'alias': normaliseCrewRoomAlias(alias),
+      'inviteToken': inviteToken,
+      'deviceId': deviceId,
+      'displayName': displayName,
+    }),
+  );
+
+  @override
+  Future<CrewRoomAccess> startOperation({
+    required CrewRoomMembership membership,
+    required RideSession operation,
+  }) async => CrewRoomAccess.fromJson(
+    await _request('start-operation', {
+      ..._auth(membership),
+      'operation': _operation(operation),
+    }, ride: operation),
+  );
+
+  @override
+  Future<List<CrewRoomDevice>> devices(CrewRoomMembership membership) async {
+    final json = await _request('devices', _auth(membership));
+    final values = json['devices'];
+    if (values is! List) {
+      throw const CrewRoomDirectoryException(
+        'Crew room service returned an invalid response.',
+      );
+    }
+    return List.unmodifiable(
+      values.map(
+        (item) =>
+            CrewRoomDevice.fromJson(Map<String, Object?>.from(item as Map)),
+      ),
+    );
+  }
+
+  @override
+  Future<String> rename(CrewRoomMembership membership, String newAlias) async {
+    final json = await _request('rename', {
+      ..._auth(membership),
+      'newAlias': normaliseCrewRoomAlias(newAlias),
+    });
+    return normaliseCrewRoomAlias(json['alias']);
+  }
+
+  @override
+  Future<void> transfer(CrewRoomMembership membership, String targetDeviceId) =>
+      _emptyRequest('transfer', {
+        ..._auth(membership),
+        'targetDeviceId': targetDeviceId,
+      });
+
+  @override
+  Future<void> revoke(CrewRoomMembership membership, String targetDeviceId) =>
+      _emptyRequest('revoke-device', {
+        ..._auth(membership),
+        'targetDeviceId': targetDeviceId,
+      });
+
+  @override
+  Future<void> delete(CrewRoomMembership membership) =>
+      _emptyRequest('delete', _auth(membership));
+
+  Map<String, Object?> _auth(CrewRoomMembership membership) => {
+    'alias': membership.alias,
+    'deviceId': membership.deviceId,
+    'deviceCredential': membership.deviceCredential,
+  };
+
+  Map<String, Object?> _operation(RideSession session) => {
+    'rideId': session.rideId,
+    'rideCode': session.rideCode,
+    'inviteSecret': session.inviteSecret,
+    'resolveToken': session.joinToken,
+  };
+
+  Future<Map<String, Object?>> _request(
+    String action,
+    Map<String, Object?> body, {
+    RideSession? ride,
+    int expectedStatus = 200,
+  }) async {
+    final response = await _send(action, body, ride: ride);
+    if (response.statusCode != expectedStatus) {
+      throw _failure(response.statusCode);
+    }
+    final contentType = response.headers['content-type']?.toLowerCase();
+    if (response.bodyBytes.length > 64 * 1024 ||
+        contentType == null ||
+        !contentType.contains('application/json')) {
+      throw const CrewRoomDirectoryException(
+        'Crew room service returned an invalid response.',
+      );
+    }
+    try {
+      return Map<String, Object?>.from(
+        jsonDecode(utf8.decode(response.bodyBytes)) as Map,
+      );
+    } on Object {
+      throw const CrewRoomDirectoryException(
+        'Crew room service returned an invalid response.',
+      );
+    }
+  }
+
+  Future<void> _emptyRequest(String action, Map<String, Object?> body) async {
+    final response = await _send(action, body);
+    if (response.statusCode != 204) throw _failure(response.statusCode);
+  }
+
+  Future<http.Response> _send(
+    String action,
+    Map<String, Object?> body, {
+    RideSession? ride,
+  }) async {
+    final error = configuration.configurationError;
+    if (error != null) {
+      throw const CrewRoomDirectoryException(
+        'Crew rooms need the Balloon Crumbs service to be connected.',
+      );
+    }
+    final headers = {
+      'accept': 'application/json',
+      'content-type': 'application/json',
+      ..._descriptor.headers,
+      if (ride != null) 'authorization': 'Bearer ${_rideBearer(ride)}',
+    };
+    try {
+      return await client
+          .post(_uri(action), headers: headers, body: jsonEncode(body))
+          .timeout(configuration.bodyTimeout);
+    } on TimeoutException {
+      throw const CrewRoomDirectoryException(
+        'Crew room service timed out. Try again.',
+        retryable: true,
+      );
+    } on http.ClientException {
+      throw const CrewRoomDirectoryException(
+        'Crew room service is temporarily unavailable. Try again.',
+        retryable: true,
+      );
+    }
+  }
+
+  Uri _uri(String action) {
+    final base = configuration.baseUri!.toString().replaceFirst(
+      RegExp(r'/$'),
+      '',
+    );
+    return Uri.parse('$base/v1/crew-rooms/$action');
+  }
+
+  CrewRoomDirectoryException _failure(int status) => switch (status) {
+    400 => const CrewRoomDirectoryException(
+      'Check the crew room alias and try again.',
+    ),
+    404 => const CrewRoomDirectoryException(
+      'This device no longer has access to that crew room.',
+    ),
+    409 => const CrewRoomDirectoryException(
+      'That crew room alias is already in use.',
+    ),
+    429 => const CrewRoomDirectoryException(
+      'Too many crew room attempts. Wait a moment and try again.',
+      retryable: true,
+    ),
+    _ => CrewRoomDirectoryException(
+      'Crew room service returned HTTP $status.',
+      retryable: status >= 500,
+    ),
+  };
+
+  String _rideBearer(RideSession session) {
+    final digest = Hmac(sha256, utf8.encode(session.inviteSecret)).convert(
+      utf8.encode('balloon-crumbs-internet-token-v1\n${session.rideId}'),
+    );
+    return 'rr1_${base64Url.encode(digest.bytes).replaceAll('=', '')}';
+  }
+
+  @override
+  void close() => client.close();
+}

--- a/apps/mobile/lib/internet/internet_relay_client.dart
+++ b/apps/mobile/lib/internet/internet_relay_client.dart
@@ -94,6 +94,7 @@ abstract final class RelayProtocolCapabilities {
   /// A chase-role device starting live tracking at balloon release. Kept
   /// additive because older clients understand only pilot-authored rideStarted.
   static const crewFlightLifecycle = 'crew-flight-lifecycle-v1';
+  static const crewRooms = 'crew-rooms-v1';
 
   static const current = {
     rideStart,
@@ -109,6 +110,7 @@ abstract final class RelayProtocolCapabilities {
     pilotHandover,
     rideReopen,
     crewFlightLifecycle,
+    crewRooms,
   };
 }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -21,6 +21,7 @@ import 'controllers/test_control_controller.dart';
 import 'data/json_file_recorded_route_store.dart';
 import 'data/json_file_completed_ride_store.dart';
 import 'data/shared_preferences_session_store.dart';
+import 'data/secure_crew_room_store.dart';
 import 'data/sqlite_event_store.dart';
 import 'services/nearby_bridge.dart';
 import 'services/test_control_registry.dart';
@@ -99,6 +100,7 @@ Future<void> main() async {
     const NearbyBridge(),
     installationId: riderProfile.installationId,
     completedRideStore: completedRides,
+    crewRoomStore: const SecureCrewRoomStore(),
   );
 
   // The registry is created unconditionally - it is one nullable field - but the

--- a/apps/mobile/test/controllers/crew_room_controller_test.dart
+++ b/apps/mobile/test/controllers/crew_room_controller_test.dart
@@ -1,0 +1,247 @@
+import 'package:balloon_crumbs/controllers/ride_controller.dart';
+import 'package:balloon_crumbs/data/in_memory_crew_room_store.dart';
+import 'package:balloon_crumbs/data/in_memory_event_store.dart';
+import 'package:balloon_crumbs/data/in_memory_session_store.dart';
+import 'package:balloon_crumbs/domain/crew_room.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/internet/crew_room_directory.dart';
+import 'package:balloon_crumbs/internet/internet_relay_client.dart';
+import 'package:balloon_crumbs/services/nearby_bridge.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late _FakeCrewRoomDirectory directory;
+  late InMemoryCrewRoomStore roomStore;
+  late RideController controller;
+  var id = 0;
+
+  RideController buildController({
+    InMemoryCrewRoomStore? store,
+    String installationId = 'stable-installation',
+  }) => RideController(
+    InMemoryEventStore(),
+    InMemorySessionStore(),
+    const _NoNearby(),
+    idFactory: () => 'event-${id++}',
+    installationId: installationId,
+    rideCodeDirectory: _NoRideCodes(),
+    crewRoomDirectory: directory,
+    crewRoomStore: store ?? roomStore,
+  );
+
+  setUp(() async {
+    directory = _FakeCrewRoomDirectory();
+    roomStore = InMemoryCrewRoomStore();
+    controller = buildController();
+    await controller.initialize();
+  });
+
+  tearDown(() => controller.dispose());
+
+  test(
+    'TUCKER creates fresh isolated operations under one durable room',
+    () async {
+      await controller.createRide('Oliver', crewRoomAlias: 'tucker');
+
+      expect(controller.errorMessage, isNull);
+      expect(controller.currentCrewRoom?.alias, 'TUCKER');
+      expect(controller.currentCrewRoom?.owner, isTrue);
+      expect(controller.currentCrewRoom?.inviteToken, startsWith('cri1_'));
+      final firstRideId = controller.session!.rideId;
+      final membership = controller.currentCrewRoom!;
+
+      await controller.startRide();
+      await controller.endRide();
+      await controller.startNewCrewRoomOperation(
+        membership,
+        displayName: 'Oliver',
+      );
+
+      expect(controller.errorMessage, isNull);
+      expect(controller.session!.rideId, isNot(firstRideId));
+      expect(controller.session!.crewRoomId, membership.roomId);
+      expect(controller.currentCrewRoom?.operationGeneration, 2);
+      expect(
+        controller.events.every((event) => event.rideId != firstRideId),
+        isTrue,
+      );
+      expect(directory.startedRideIds, [controller.session!.rideId]);
+    },
+  );
+
+  test(
+    'a returning device opens the current room without the human alias alone',
+    () async {
+      await controller.createRide('Oliver', crewRoomAlias: 'TUCKER');
+      final membership = controller.currentCrewRoom!;
+
+      final restored = buildController(store: roomStore);
+      addTearDown(restored.dispose);
+      await restored.initialize();
+      expect(restored.crewRooms.single.alias, 'TUCKER');
+
+      await restored.openCrewRoom(membership);
+
+      expect(restored.errorMessage, isNull);
+      expect(restored.session?.rideId, controller.session?.rideId);
+      expect(restored.session?.flightRole, FlightRole.pilot);
+      expect(restored.currentCrewRoom?.roomId, membership.roomId);
+    },
+  );
+
+  test('a private room invitation enrols a new independent device', () async {
+    await controller.createRide('Oliver', crewRoomAlias: 'TUCKER');
+    final owner = controller.currentCrewRoom!;
+    final joinedStore = InMemoryCrewRoomStore();
+    final joined = buildController(
+      store: joinedStore,
+      installationId: 'nigel-installation',
+    );
+    addTearDown(joined.dispose);
+    await joined.initialize();
+
+    await joined.joinCrewRoom(
+      alias: owner.alias,
+      inviteToken: owner.inviteToken!,
+      displayName: 'Nigel',
+      flightRole: FlightRole.chaseDriver,
+    );
+
+    expect(joined.errorMessage, isNull);
+    expect(joined.session?.rideId, controller.session?.rideId);
+    expect(joined.session?.flightRole, FlightRole.chaseDriver);
+    expect(joined.crewRooms.single.owner, isFalse);
+    expect(joined.crewRooms.single.deviceId, isNot(owner.deviceId));
+  });
+}
+
+class _FakeCrewRoomDirectory implements CrewRoomDirectory {
+  CrewRoomOperation? operation;
+  String? ownerDeviceId;
+  int generation = 1;
+  final List<String> startedRideIds = [];
+
+  static const roomId = 'room_test';
+  static const credential = 'crd1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  static const invite = 'cri1_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+  @override
+  Future<CrewRoomAccess> create({
+    required String alias,
+    required String deviceId,
+    required String displayName,
+    required RideSession operation,
+  }) async {
+    ownerDeviceId = deviceId;
+    this.operation = _operation(operation);
+    return _access(alias: 'TUCKER', owner: true, inviteToken: invite);
+  }
+
+  @override
+  Future<CrewRoomAccess> open(CrewRoomMembership membership) async {
+    if (membership.deviceCredential != credential) {
+      throw const CrewRoomDirectoryException('No access.');
+    }
+    return _access(
+      alias: membership.alias,
+      owner: membership.deviceId == ownerDeviceId,
+    );
+  }
+
+  @override
+  Future<CrewRoomAccess> join({
+    required String alias,
+    required String inviteToken,
+    required String deviceId,
+    required String displayName,
+  }) async {
+    if (inviteToken != invite) {
+      throw const CrewRoomDirectoryException('No access.');
+    }
+    return _access(alias: alias, owner: false);
+  }
+
+  @override
+  Future<CrewRoomAccess> startOperation({
+    required CrewRoomMembership membership,
+    required RideSession operation,
+  }) async {
+    generation += 1;
+    this.operation = _operation(operation);
+    startedRideIds.add(operation.rideId);
+    return _access(
+      alias: membership.alias,
+      owner: true,
+      inviteToken: 'cri1_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+    );
+  }
+
+  CrewRoomAccess _access({
+    required String alias,
+    required bool owner,
+    String? inviteToken,
+  }) => CrewRoomAccess(
+    roomId: roomId,
+    alias: alias,
+    deviceCredential: credential,
+    inviteToken: inviteToken,
+    operationGeneration: generation,
+    operation: operation,
+    operationExpiresAt: DateTime.utc(2026, 9, 1),
+    owner: owner,
+  );
+
+  CrewRoomOperation _operation(RideSession session) => CrewRoomOperation(
+    rideId: session.rideId,
+    rideCode: session.rideCode,
+    inviteSecret: session.inviteSecret,
+    joinToken: session.joinToken,
+  );
+
+  @override
+  Future<void> delete(CrewRoomMembership membership) async {}
+
+  @override
+  Future<List<CrewRoomDevice>> devices(CrewRoomMembership membership) async =>
+      const [];
+
+  @override
+  Future<String> rename(CrewRoomMembership membership, String newAlias) async =>
+      normaliseCrewRoomAlias(newAlias);
+
+  @override
+  Future<void> revoke(
+    CrewRoomMembership membership,
+    String targetDeviceId,
+  ) async {}
+
+  @override
+  Future<void> transfer(
+    CrewRoomMembership membership,
+    String targetDeviceId,
+  ) async {}
+
+  @override
+  void close() {}
+}
+
+class _NoRideCodes implements RideCodeDirectory {
+  @override
+  Future<void> register(RideSession session) async {}
+
+  @override
+  Future<RideCodeCredentials> resolve(String rideCode, {String? joinToken}) =>
+      throw UnimplementedError();
+
+  @override
+  void close() {}
+}
+
+class _NoNearby implements NearbyBridge {
+  const _NoNearby();
+
+  @override
+  Future<NearbyCapabilities> capabilities() async =>
+      const NearbyCapabilities.unavailable();
+}

--- a/apps/mobile/test/data/secure_crew_room_store_test.dart
+++ b/apps/mobile/test/data/secure_crew_room_store_test.dart
@@ -1,0 +1,43 @@
+import 'package:balloon_crumbs/data/secure_crew_room_store.dart';
+import 'package:balloon_crumbs/domain/crew_room.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() => FlutterSecureStorage.setMockInitialValues({}));
+
+  test('returning credential stays in secure storage across flights', () async {
+    const store = SecureCrewRoomStore();
+    final membership = CrewRoomMembership(
+      roomId: 'room-one',
+      alias: 'TUCKER',
+      deviceId: 'device-one',
+      deviceCredential: 'crd1_${'A' * 43}',
+      displayName: 'Oliver',
+      flightRole: FlightRole.pilot,
+      owner: true,
+      operationGeneration: 1,
+      operationExpiresAt: DateTime.utc(2026, 8, 26),
+      inviteToken: 'cri1_${'B' * 43}',
+    );
+
+    await store.upsert(membership);
+    final restored = (await store.loadAll()).single;
+
+    expect(restored.alias, 'TUCKER');
+    expect(restored.deviceCredential, membership.deviceCredential);
+    expect(restored.inviteToken, membership.inviteToken);
+    await store.delete(membership.roomId);
+    expect(await store.loadAll(), isEmpty);
+  });
+
+  test('corrupt room state is removed rather than partially trusted', () async {
+    await const FlutterSecureStorage().write(
+      key: 'balloon_crumbs_crew_rooms_v1',
+      value: '{"schemaVersion":1,"rooms":[{"alias":"TUCKER"}]}',
+    );
+
+    expect(await const SecureCrewRoomStore().loadAll(), isEmpty);
+  });
+}

--- a/apps/mobile/test/domain/crew_room_test.dart
+++ b/apps/mobile/test/domain/crew_room_test.dart
@@ -1,0 +1,52 @@
+import 'package:balloon_crumbs/domain/crew_room.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/ride_join_payload.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('normalises a memorable alias without making it a credential', () {
+    expect(normaliseCrewRoomAlias('  tucker '), 'TUCKER');
+    expect(() => normaliseCrewRoomAlias('four'), throwsFormatException);
+    expect(() => normaliseCrewRoomAlias('TUCKER GRAVE'), throwsFormatException);
+  });
+
+  test('room membership round-trips its revocable credential', () {
+    final membership = CrewRoomMembership(
+      roomId: 'room-one',
+      alias: 'TUCKER',
+      deviceId: 'device-one',
+      deviceCredential: 'crd1_${'A' * 43}',
+      displayName: 'Oliver',
+      flightRole: FlightRole.pilot,
+      owner: true,
+      operationGeneration: 2,
+      operationExpiresAt: DateTime.utc(2026, 8, 26),
+      inviteToken: 'cri1_${'B' * 43}',
+    );
+
+    expect(
+      CrewRoomMembership.fromJson(membership.toJson()).toJson(),
+      membership.toJson(),
+    );
+  });
+
+  test(
+    'QR carries offline flight bootstrap plus optional returning access',
+    () {
+      const payload = RideJoinPayload(
+        rideId: 'ride-one',
+        rideCode: '123456',
+        inviteSecret: '0123456789abcdef',
+        joinToken: 'join-token-0123456789',
+        crewRoomId: 'room-one',
+        crewRoomAlias: 'TUCKER',
+        crewRoomInviteToken: 'cri1_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      );
+
+      final decoded = RideJoinPayload.decode(payload.encode());
+      expect(decoded.rideId, payload.rideId);
+      expect(decoded.crewRoomAlias, 'TUCKER');
+      expect(decoded.crewRoomInviteToken, payload.crewRoomInviteToken);
+    },
+  );
+}

--- a/apps/mobile/test/features/home/home_reachability_test.dart
+++ b/apps/mobile/test/features/home/home_reachability_test.dart
@@ -170,6 +170,22 @@ void main() {
     expect(rideController.session?.riderColor, RiderColor.cyan);
   });
 
+  testWidgets('group setup explains the reusable crew room alias', (
+    tester,
+  ) async {
+    await pumpHome(tester);
+
+    await tester.tap(find.text('Create flight'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('crew-room-alias-field')), findsOneWidget);
+    expect(find.text('Reusable crew room (optional)'), findsOneWidget);
+    expect(
+      find.textContaining('private device access cannot be guessed'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('a past ride is reachable by words alone', (tester) async {
     // Moved one tap in by #426, which removed the full-screen start panel these
     // rows used to sit on. The #306 rule is what matters and it still holds: the

--- a/apps/mobile/test/internet/crew_room_directory_test.dart
+++ b/apps/mobile/test/internet/crew_room_directory_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+import 'package:balloon_crumbs/domain/crew_room.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/internet/crew_room_directory.dart';
+import 'package:balloon_crumbs/internet/internet_relay_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  test(
+    'creates a room through a generic path with a ride credential',
+    () async {
+      late http.Request captured;
+      final client = MockClient((request) async {
+        captured = request;
+        return http.Response(
+          jsonEncode(_response(inviteToken: 'cri1_${'B' * 43}')),
+          201,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final directory = HttpCrewRoomDirectory(
+        configuration: _configuration,
+        client: client,
+      );
+
+      final access = await directory.create(
+        alias: 'tucker',
+        deviceId: 'room-device-one',
+        displayName: 'Oliver',
+        operation: _session,
+      );
+
+      expect(captured.url.path, '/api/v1/crew-rooms/create');
+      expect(captured.url.toString(), isNot(contains('TUCKER')));
+      expect(captured.headers['authorization'], startsWith('Bearer rr1_'));
+      final body = jsonDecode(captured.body) as Map<String, Object?>;
+      expect(body['alias'], 'TUCKER');
+      expect(access.alias, 'TUCKER');
+      expect(access.operation?.rideId, _session.rideId);
+      expect(access.inviteToken, startsWith('cri1_'));
+    },
+  );
+
+  test(
+    'a missing or revoked returning credential has one bounded error',
+    () async {
+      final directory = HttpCrewRoomDirectory(
+        configuration: _configuration,
+        client: MockClient(
+          (_) async => http.Response(
+            '{"error":"Crew room is not available"}',
+            404,
+            headers: {'content-type': 'application/json'},
+          ),
+        ),
+      );
+
+      await expectLater(
+        directory.open(_membership),
+        throwsA(
+          isA<CrewRoomDirectoryException>().having(
+            (error) => error.message,
+            'message',
+            'This device no longer has access to that crew room.',
+          ),
+        ),
+      );
+    },
+  );
+}
+
+final _configuration = InternetRelayConfiguration(
+  baseUri: Uri.parse('https://relay.example/api'),
+);
+
+final _session = RideSession(
+  rideId: 'ride-one',
+  rideCode: '123456',
+  inviteSecret: '0123456789abcdef0123456789abcdef',
+  joinToken: 'resolve-token-0123456789',
+  localRiderId: 'rider-one',
+  displayName: 'Oliver',
+  role: RideRole.lead,
+  joinedAt: DateTime.utc(2026, 8, 23),
+);
+
+final _membership = CrewRoomMembership(
+  roomId: 'room-one',
+  alias: 'TUCKER',
+  deviceId: 'room-device-one',
+  deviceCredential: 'crd1_${'A' * 43}',
+  displayName: 'Oliver',
+  flightRole: _session.flightRole,
+  owner: true,
+  operationGeneration: 1,
+  operationExpiresAt: DateTime.utc(2026, 8, 26),
+);
+
+Map<String, Object?> _response({String? inviteToken}) => {
+  'roomId': 'room-one',
+  'alias': 'TUCKER',
+  'deviceCredential': 'crd1_${'A' * 43}',
+  'inviteToken': inviteToken,
+  'operationGeneration': 1,
+  'operation': {
+    'rideId': _session.rideId,
+    'rideCode': _session.rideCode,
+    'inviteSecret': _session.inviteSecret,
+    'resolveToken': _session.joinToken,
+  },
+  'operationExpiresAt': '2026-08-26T00:00:00Z',
+  'owner': true,
+};

--- a/apps/server/alembic/versions/0012_crew_rooms.py
+++ b/apps/server/alembic/versions/0012_crew_rooms.py
@@ -1,0 +1,66 @@
+"""Add persistent, privacy-bounded named crew rooms.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-08-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0012"
+down_revision: str | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "crew_rooms",
+        sa.Column("id", sa.String(length=128), nullable=False),
+        sa.Column("alias_digest", sa.LargeBinary(length=32), nullable=False),
+        sa.Column("alias_ciphertext", sa.LargeBinary(), nullable=False),
+        sa.Column("owner_device_digest", sa.LargeBinary(length=32), nullable=False),
+        sa.Column("invite_token_hash", sa.LargeBinary(length=32), nullable=False),
+        sa.Column("operation_ciphertext", sa.LargeBinary(), nullable=False),
+        sa.Column("operation_generation", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("operation_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("alias_digest", name="uq_crew_room_alias_digest"),
+    )
+    op.create_index(
+        "ix_crew_rooms_operation_expiry",
+        "crew_rooms",
+        ["operation_expires_at"],
+    )
+    op.create_table(
+        "crew_room_devices",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("room_id", sa.String(length=128), nullable=False),
+        sa.Column("device_digest", sa.LargeBinary(length=32), nullable=False),
+        sa.Column("credential_hash", sa.LargeBinary(length=32), nullable=False),
+        sa.Column("profile_ciphertext", sa.LargeBinary(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["room_id"], ["crew_rooms.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("room_id", "device_digest", name="uq_crew_room_device_identity"),
+    )
+    op.create_index(
+        "ix_crew_room_devices_active",
+        "crew_room_devices",
+        ["room_id", "revoked_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_crew_room_devices_active", table_name="crew_room_devices")
+    op.drop_table("crew_room_devices")
+    op.drop_index("ix_crew_rooms_operation_expiry", table_name="crew_rooms")
+    op.drop_table("crew_rooms")

--- a/apps/server/src/balloon_crumbs_server/app.py
+++ b/apps/server/src/balloon_crumbs_server/app.py
@@ -43,12 +43,18 @@ from .push import PushDispatcher, register_push, registration_json, revoke_push
 from .rate_limit import SlidingWindowRateLimiter
 from .schemas import (
     CompatibilityResponse,
+    CreateCrewRoomRequest,
     CreateObserverGrantRequest,
     CreateObserverGrantResponse,
     CreatePlanRequest,
     CreatePlanResponse,
+    CrewRoomAuthRequest,
+    CrewRoomDeviceListResponse,
+    CrewRoomResponse,
+    CrewRoomTargetDeviceRequest,
     GetPlanResponse,
     JoinCodeResponse,
+    JoinCrewRoomRequest,
     ObserverGrantResponse,
     ObserverSnapshotResponse,
     PresenceSyncRequest,
@@ -57,6 +63,8 @@ from .schemas import (
     PushRegistrationRequest,
     PushRegistrationResponse,
     RegisterJoinCodeRequest,
+    RenameCrewRoomRequest,
+    StartCrewRoomOperationRequest,
     SyncRequest,
     TrafficRerouteRequest,
 )
@@ -104,6 +112,10 @@ def create_app(
         maximum_requests=settings.join_code_global_rate_limit_requests,
         window_seconds=settings.join_code_lookup_rate_limit_window_seconds,
         maximum_keys=1,
+    )
+    crew_room_limiter = SlidingWindowRateLimiter(
+        maximum_requests=settings.crew_room_rate_limit_requests,
+        window_seconds=settings.crew_room_rate_limit_window_seconds,
     )
     plan_create_limiter = SlidingWindowRateLimiter(
         maximum_requests=settings.plan_create_rate_limit_requests,
@@ -478,6 +490,183 @@ def create_app(
         )
         join_code_requests.labels(outcome="resolved").inc()
         return JSONResponse(content=JoinCodeResponse.model_validate(result).model_dump())
+
+    def _crew_room_rate_limit(request: Request) -> Response | None:
+        client_ip = request.client.host if request.client is not None else "unknown"
+        retry_after = crew_room_limiter.check(f"crew-room-ip:{client_ip}")
+        if retry_after is None:
+            return None
+        return JSONResponse(
+            status_code=429,
+            headers={"retry-after": str(min(retry_after, 300))},
+            content={"error": "Crew room request rate limit exceeded"},
+        )
+
+    def _ride_bearer_for_room(request: Request) -> str:
+        authorization = request.headers.get("authorization", "")
+        if not authorization.startswith("Bearer "):
+            raise RelayServiceError(401, "Ride credential required")
+        token = authorization[7:]
+        if not RIDE_API_TOKEN.fullmatch(token):
+            raise RelayServiceError(401, "Ride credential rejected")
+        return token
+
+    @app.post("/api/v1/crew-rooms/create", include_in_schema=False)
+    def create_crew_room(
+        payload: CreateCrewRoomRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        result = service.create_crew_room(
+            session,
+            alias=payload.alias,
+            device_id=payload.deviceId,
+            display_name=payload.displayName,
+            operation=payload.operation.model_dump(),
+            bearer_token=_ride_bearer_for_room(request),
+        )
+        return JSONResponse(
+            status_code=201,
+            content=CrewRoomResponse.model_validate(result).model_dump(mode="json"),
+        )
+
+    @app.post("/api/v1/crew-rooms/open", include_in_schema=False)
+    def open_crew_room(
+        payload: CrewRoomAuthRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        result = service.open_crew_room(
+            session,
+            alias=payload.alias,
+            device_id=payload.deviceId,
+            device_credential=payload.deviceCredential,
+        )
+        return JSONResponse(content=CrewRoomResponse.model_validate(result).model_dump(mode="json"))
+
+    @app.post("/api/v1/crew-rooms/join", include_in_schema=False)
+    def join_crew_room(
+        payload: JoinCrewRoomRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        result = service.join_crew_room(
+            session,
+            alias=payload.alias,
+            invite_token=payload.inviteToken,
+            device_id=payload.deviceId,
+            display_name=payload.displayName,
+        )
+        return JSONResponse(content=CrewRoomResponse.model_validate(result).model_dump(mode="json"))
+
+    @app.post("/api/v1/crew-rooms/start-operation", include_in_schema=False)
+    def start_crew_room_operation(
+        payload: StartCrewRoomOperationRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        result = service.start_crew_room_operation(
+            session,
+            alias=payload.alias,
+            device_id=payload.deviceId,
+            device_credential=payload.deviceCredential,
+            operation=payload.operation.model_dump(),
+            bearer_token=_ride_bearer_for_room(request),
+        )
+        return JSONResponse(content=CrewRoomResponse.model_validate(result).model_dump(mode="json"))
+
+    @app.post("/api/v1/crew-rooms/devices", include_in_schema=False)
+    def list_crew_room_devices(
+        payload: CrewRoomAuthRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        result = service.list_crew_room_devices(
+            session,
+            alias=payload.alias,
+            device_id=payload.deviceId,
+            device_credential=payload.deviceCredential,
+        )
+        return JSONResponse(
+            content=CrewRoomDeviceListResponse.model_validate(result).model_dump(mode="json")
+        )
+
+    @app.post("/api/v1/crew-rooms/rename", include_in_schema=False)
+    def rename_crew_room(
+        payload: RenameCrewRoomRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        result = service.rename_crew_room(
+            session,
+            alias=payload.alias,
+            new_alias=payload.newAlias,
+            device_id=payload.deviceId,
+            device_credential=payload.deviceCredential,
+        )
+        return JSONResponse(content=result)
+
+    @app.post("/api/v1/crew-rooms/transfer", include_in_schema=False)
+    def transfer_crew_room(
+        payload: CrewRoomTargetDeviceRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        service.transfer_crew_room(
+            session,
+            alias=payload.alias,
+            device_id=payload.deviceId,
+            device_credential=payload.deviceCredential,
+            target_device_id=payload.targetDeviceId,
+        )
+        return Response(status_code=204)
+
+    @app.post("/api/v1/crew-rooms/revoke-device", include_in_schema=False)
+    def revoke_crew_room_device(
+        payload: CrewRoomTargetDeviceRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        service.revoke_crew_room_device(
+            session,
+            alias=payload.alias,
+            device_id=payload.deviceId,
+            device_credential=payload.deviceCredential,
+            target_device_id=payload.targetDeviceId,
+        )
+        return Response(status_code=204)
+
+    @app.post("/api/v1/crew-rooms/delete", include_in_schema=False)
+    def delete_crew_room(
+        payload: CrewRoomAuthRequest,
+        request: Request,
+        session: Session = Depends(database_session),
+    ) -> Response:
+        if limited := _crew_room_rate_limit(request):
+            return limited
+        service.delete_crew_room(
+            session,
+            alias=payload.alias,
+            device_id=payload.deviceId,
+            device_credential=payload.deviceCredential,
+        )
+        return Response(status_code=204)
 
     def _plan_rate_limit_response(retry_after: int) -> Response:
         return JSONResponse(

--- a/apps/server/src/balloon_crumbs_server/config.py
+++ b/apps/server/src/balloon_crumbs_server/config.py
@@ -30,6 +30,8 @@ class Settings(BaseSettings):
     join_code_lookup_rate_limit_requests: int = Field(default=30, ge=1, le=1000)
     join_code_lookup_rate_limit_window_seconds: int = Field(default=60, ge=1, le=3600)
     join_code_global_rate_limit_requests: int = Field(default=20, ge=1, le=1000)
+    crew_room_rate_limit_requests: int = Field(default=30, ge=1, le=1000)
+    crew_room_rate_limit_window_seconds: int = Field(default=60, ge=1, le=3600)
     # Browser origins allowed to call the relay. Named `discovery_*` while the
     # discovery web surface was the only cross-origin caller; the observer page is
     # served from the marketing site, so it outlived discovery and this is not a
@@ -106,6 +108,10 @@ class Settings(BaseSettings):
             # recovery tracking. Additive so older relays reject rather than
             # silently storing an event they did not negotiate.
             "crew-flight-lifecycle-v1",
+            # Persistent aliases point at fresh, encrypted operations. Alias
+            # knowledge alone grants no access; returning and invitation
+            # credentials are independently revocable.
+            "crew-rooms-v1",
         ]
     )
     required_capabilities: list[str] = Field(default_factory=list)

--- a/apps/server/src/balloon_crumbs_server/crypto.py
+++ b/apps/server/src/balloon_crumbs_server/crypto.py
@@ -24,7 +24,20 @@ def token_hash(token: str) -> bytes:
 
 class DataCipher:
     def __init__(self, key: bytes) -> None:
+        self._blind_index_key = hashlib.sha256(b"balloon-crumbs-blind-index-v1\x00" + key).digest()
         self._cipher = AESGCM(key)
+
+    def blind_index(self, value: str, *, namespace: str) -> bytes:
+        """Return a keyed lookup digest without storing guessable plaintext.
+
+        Crew-room aliases are intentionally memorable and therefore cannot be
+        protected by an ordinary SHA-256 digest.  A database-only disclosure
+        must not turn into an offline alias directory, so lookup uses a keyed,
+        namespace-separated HMAC derived from the data-encryption key.
+        """
+
+        message = f"{namespace}\n{value}".encode()
+        return hmac.new(self._blind_index_key, message, hashlib.sha256).digest()
 
     def encrypt_json(self, value: Any, *, associated_data: bytes) -> bytes:
         nonce = os.urandom(12)

--- a/apps/server/src/balloon_crumbs_server/models.py
+++ b/apps/server/src/balloon_crumbs_server/models.py
@@ -77,6 +77,57 @@ class RideJoinCode(Base):
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
+class CrewRoom(Base):
+    """Persistent named crew directory containing only encrypted room data."""
+
+    __tablename__ = "crew_rooms"
+    __table_args__ = (
+        UniqueConstraint("alias_digest", name="uq_crew_room_alias_digest"),
+        Index("ix_crew_rooms_operation_expiry", "operation_expires_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    alias_digest: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)
+    alias_ciphertext: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    owner_device_digest: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)
+    invite_token_hash: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)
+    operation_ciphertext: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    operation_generation: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    operation_expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    devices: Mapped[list[CrewRoomDevice]] = relationship(
+        back_populates="room",
+        cascade="all, delete-orphan",
+    )
+
+
+class CrewRoomDevice(Base):
+    """One independently revocable returning-device credential."""
+
+    __tablename__ = "crew_room_devices"
+    __table_args__ = (
+        UniqueConstraint("room_id", "device_digest", name="uq_crew_room_device_identity"),
+        Index("ix_crew_room_devices_active", "room_id", "revoked_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    room_id: Mapped[str] = mapped_column(
+        String(128),
+        ForeignKey("crew_rooms.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    device_digest: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)
+    credential_hash: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)
+    profile_ciphertext: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    room: Mapped[CrewRoom] = relationship(back_populates="devices")
+
+
 class RidePlan(Base):
     """An encrypted, pre-ride forecast plan behind a short lookup code.
 

--- a/apps/server/src/balloon_crumbs_server/schemas.py
+++ b/apps/server/src/balloon_crumbs_server/schemas.py
@@ -177,6 +177,83 @@ class JoinCodeResponse(BaseModel):
     resolveToken: str
 
 
+class CrewRoomOperation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rideId: str = Field(min_length=1, max_length=128)
+    rideCode: str = Field(pattern=r"^\d{6}$")
+    inviteSecret: str = Field(min_length=16, max_length=512)
+    resolveToken: str = Field(min_length=16, max_length=128)
+
+
+class CreateCrewRoomRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alias: str = Field(min_length=5, max_length=12)
+    deviceId: str = Field(min_length=1, max_length=128)
+    displayName: str = Field(min_length=1, max_length=80)
+    operation: CrewRoomOperation
+
+
+class CrewRoomAuthRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alias: str = Field(min_length=5, max_length=12)
+    deviceId: str = Field(min_length=1, max_length=128)
+    deviceCredential: str = Field(min_length=48, max_length=48)
+
+
+class JoinCrewRoomRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alias: str = Field(min_length=5, max_length=12)
+    inviteToken: str = Field(min_length=48, max_length=48)
+    deviceId: str = Field(min_length=1, max_length=128)
+    displayName: str = Field(min_length=1, max_length=80)
+
+
+class StartCrewRoomOperationRequest(CrewRoomAuthRequest):
+    operation: CrewRoomOperation
+
+
+class RenameCrewRoomRequest(CrewRoomAuthRequest):
+    newAlias: str = Field(min_length=5, max_length=12)
+
+
+class CrewRoomTargetDeviceRequest(CrewRoomAuthRequest):
+    targetDeviceId: str = Field(min_length=1, max_length=128)
+
+
+class CrewRoomDeviceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    deviceId: str
+    displayName: str
+    owner: bool
+    revoked: bool
+    lastSeenAt: datetime
+
+
+class CrewRoomDeviceListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alias: str
+    devices: list[CrewRoomDeviceResponse]
+
+
+class CrewRoomResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    roomId: str
+    alias: str
+    deviceCredential: str
+    inviteToken: str | None = None
+    operationGeneration: int = Field(ge=1)
+    operation: CrewRoomOperation | None
+    operationExpiresAt: datetime
+    owner: bool
+
+
 class CompatibilityResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -18,6 +18,8 @@ from .crypto import CursorCodec, DataCipher, base64url, sha256, token_hash
 from .gpx import GpxValidationError, validate_gpx
 from .membership import MembershipEvent, project_membership_events
 from .models import (
+    CrewRoom,
+    CrewRoomDevice,
     IdempotencyReplay,
     ObserverGrant,
     PreStartPosition,
@@ -36,6 +38,9 @@ SIGNATURE = re.compile(r"^[0-9a-f]{64}$")
 PLAN_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
 PLAN_CODE_LENGTH = 8
 PLAN_CODE = re.compile(f"^[{PLAN_CODE_ALPHABET}]{{{PLAN_CODE_LENGTH}}}$")
+CREW_ROOM_ALIAS = re.compile(r"^[A-Z0-9]{5,12}$")
+CREW_ROOM_DEVICE_CREDENTIAL = re.compile(r"^crd1_[A-Za-z0-9_-]{43}$")
+CREW_ROOM_INVITE_TOKEN = re.compile(r"^cri1_[A-Za-z0-9_-]{43}$")
 EVENT_TYPES = {
     "rideCreated",
     "riderJoined",
@@ -567,6 +572,363 @@ class RelayService:
                 "resolveToken": stored_resolve_token,
             }
 
+    def create_crew_room(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        display_name: str,
+        operation: dict[str, str],
+        bearer_token: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Create a named room without making its alias an access credential."""
+
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        profile = self._validate_crew_room_profile(device_id, display_name)
+        clean_operation = self._validate_crew_room_operation(operation, bearer_token)
+        room_id = "room_" + base64url(secrets.token_bytes(18))
+        alias_digest = self._crew_room_alias_digest(normalised_alias)
+        device_digest = self._crew_room_device_digest(room_id, profile["deviceId"])
+        device_credential = "crd1_" + base64url(secrets.token_bytes(32))
+        invite_token = "cri1_" + base64url(secrets.token_bytes(32))
+        with session.begin():
+            if (
+                session.scalar(select(CrewRoom.id).where(CrewRoom.alias_digest == alias_digest))
+                is not None
+            ):
+                raise RelayServiceError(409, "Crew room alias is already in use")
+            room = CrewRoom(
+                id=room_id,
+                alias_digest=alias_digest,
+                alias_ciphertext=self._cipher.encrypt_json(
+                    {"alias": normalised_alias},
+                    associated_data=self._crew_room_aad(room_id, "alias"),
+                ),
+                owner_device_digest=device_digest,
+                invite_token_hash=token_hash(invite_token),
+                operation_ciphertext=self._cipher.encrypt_json(
+                    clean_operation,
+                    associated_data=self._crew_room_aad(room_id, "operation"),
+                ),
+                operation_generation=1,
+                operation_expires_at=now + timedelta(hours=self._settings.ride_retention_hours),
+                created_at=now,
+                updated_at=now,
+            )
+            room.devices.append(
+                CrewRoomDevice(
+                    device_digest=device_digest,
+                    credential_hash=token_hash(device_credential),
+                    profile_ciphertext=self._cipher.encrypt_json(
+                        profile,
+                        associated_data=self._crew_room_device_aad(room_id, device_digest),
+                    ),
+                    created_at=now,
+                    last_seen_at=now,
+                )
+            )
+            session.add(room)
+        return {
+            "roomId": room_id,
+            "alias": normalised_alias,
+            "deviceCredential": device_credential,
+            "inviteToken": invite_token,
+            "operationGeneration": 1,
+            "operation": clean_operation,
+            "operationExpiresAt": room.operation_expires_at,
+            "owner": True,
+        }
+
+    def open_crew_room(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        device_credential: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        with session.begin():
+            room, device = self._authorise_crew_room_device(
+                session,
+                alias=normalised_alias,
+                device_id=device_id,
+                credential=device_credential,
+            )
+            device.last_seen_at = now
+            return self._crew_room_response(
+                room,
+                device_credential=device_credential,
+                invite_token=None,
+                device_digest=device.device_digest,
+                now=now,
+            )
+
+    def join_crew_room(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        invite_token: str,
+        device_id: str,
+        display_name: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        if not CREW_ROOM_INVITE_TOKEN.fullmatch(invite_token):
+            raise RelayServiceError(404, "Crew room invitation is not active")
+        profile = self._validate_crew_room_profile(device_id, display_name)
+        alias_digest = self._crew_room_alias_digest(normalised_alias)
+        device_credential = "crd1_" + base64url(secrets.token_bytes(32))
+        with session.begin():
+            room = session.scalar(select(CrewRoom).where(CrewRoom.alias_digest == alias_digest))
+            if room is None or not hmac.compare_digest(
+                room.invite_token_hash, token_hash(invite_token)
+            ):
+                raise RelayServiceError(404, "Crew room invitation is not active")
+            device_digest = self._crew_room_device_digest(room.id, profile["deviceId"])
+            device = session.scalar(
+                select(CrewRoomDevice).where(
+                    CrewRoomDevice.room_id == room.id,
+                    CrewRoomDevice.device_digest == device_digest,
+                )
+            )
+            encrypted_profile = self._cipher.encrypt_json(
+                profile,
+                associated_data=self._crew_room_device_aad(room.id, device_digest),
+            )
+            if device is None:
+                device = CrewRoomDevice(
+                    room_id=room.id,
+                    device_digest=device_digest,
+                    credential_hash=token_hash(device_credential),
+                    profile_ciphertext=encrypted_profile,
+                    created_at=now,
+                    last_seen_at=now,
+                )
+                session.add(device)
+            else:
+                device.credential_hash = token_hash(device_credential)
+                device.profile_ciphertext = encrypted_profile
+                device.last_seen_at = now
+                device.revoked_at = None
+            room.updated_at = now
+            return self._crew_room_response(
+                room,
+                device_credential=device_credential,
+                invite_token=None,
+                device_digest=device_digest,
+                now=now,
+            )
+
+    def start_crew_room_operation(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        device_credential: str,
+        operation: dict[str, str],
+        bearer_token: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        clean_operation = self._validate_crew_room_operation(operation, bearer_token)
+        invite_token = "cri1_" + base64url(secrets.token_bytes(32))
+        with session.begin():
+            room, device = self._authorise_crew_room_device(
+                session,
+                alias=normalised_alias,
+                device_id=device_id,
+                credential=device_credential,
+                owner_required=True,
+            )
+            room.operation_ciphertext = self._cipher.encrypt_json(
+                clean_operation,
+                associated_data=self._crew_room_aad(room.id, "operation"),
+            )
+            room.operation_generation += 1
+            room.operation_expires_at = now + timedelta(hours=self._settings.ride_retention_hours)
+            room.invite_token_hash = token_hash(invite_token)
+            room.updated_at = now
+            device.last_seen_at = now
+            return self._crew_room_response(
+                room,
+                device_credential=device_credential,
+                invite_token=invite_token,
+                device_digest=device.device_digest,
+                now=now,
+            )
+
+    def list_crew_room_devices(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        device_credential: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        with session.begin():
+            room, requesting_device = self._authorise_crew_room_device(
+                session,
+                alias=normalised_alias,
+                device_id=device_id,
+                credential=device_credential,
+                owner_required=True,
+            )
+            requesting_device.last_seen_at = now
+            devices = []
+            for device in sorted(room.devices, key=lambda item: item.created_at):
+                profile = self._decrypt_crew_room_profile(device)
+                devices.append(
+                    {
+                        **profile,
+                        "owner": hmac.compare_digest(
+                            room.owner_device_digest, device.device_digest
+                        ),
+                        "revoked": device.revoked_at is not None,
+                        "lastSeenAt": self._as_utc(device.last_seen_at),
+                    }
+                )
+            return {"alias": normalised_alias, "devices": devices}
+
+    def rename_crew_room(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        new_alias: str,
+        device_id: str,
+        device_credential: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        normalised_new_alias = self._normalise_crew_room_alias(new_alias)
+        new_digest = self._crew_room_alias_digest(normalised_new_alias)
+        with session.begin():
+            room, device = self._authorise_crew_room_device(
+                session,
+                alias=normalised_alias,
+                device_id=device_id,
+                credential=device_credential,
+                owner_required=True,
+            )
+            conflict = session.scalar(
+                select(CrewRoom.id).where(
+                    CrewRoom.alias_digest == new_digest, CrewRoom.id != room.id
+                )
+            )
+            if conflict is not None:
+                raise RelayServiceError(409, "Crew room alias is already in use")
+            room.alias_digest = new_digest
+            room.alias_ciphertext = self._cipher.encrypt_json(
+                {"alias": normalised_new_alias},
+                associated_data=self._crew_room_aad(room.id, "alias"),
+            )
+            room.updated_at = now
+            device.last_seen_at = now
+            return {"roomId": room.id, "alias": normalised_new_alias}
+
+    def transfer_crew_room(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        device_credential: str,
+        target_device_id: str,
+        now: datetime | None = None,
+    ) -> None:
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        with session.begin():
+            room, device = self._authorise_crew_room_device(
+                session,
+                alias=normalised_alias,
+                device_id=device_id,
+                credential=device_credential,
+                owner_required=True,
+            )
+            target_digest = self._crew_room_device_digest(room.id, target_device_id)
+            target = session.scalar(
+                select(CrewRoomDevice).where(
+                    CrewRoomDevice.room_id == room.id,
+                    CrewRoomDevice.device_digest == target_digest,
+                    CrewRoomDevice.revoked_at.is_(None),
+                )
+            )
+            if target is None:
+                raise RelayServiceError(404, "Crew room device is not active")
+            room.owner_device_digest = target_digest
+            room.updated_at = now
+            device.last_seen_at = now
+
+    def revoke_crew_room_device(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        device_credential: str,
+        target_device_id: str,
+        now: datetime | None = None,
+    ) -> None:
+        now = now or datetime.now(UTC)
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        with session.begin():
+            room, device = self._authorise_crew_room_device(
+                session,
+                alias=normalised_alias,
+                device_id=device_id,
+                credential=device_credential,
+                owner_required=True,
+            )
+            target_digest = self._crew_room_device_digest(room.id, target_device_id)
+            if hmac.compare_digest(target_digest, room.owner_device_digest):
+                raise RelayServiceError(409, "Transfer the crew room before revoking its owner")
+            target = session.scalar(
+                select(CrewRoomDevice).where(
+                    CrewRoomDevice.room_id == room.id,
+                    CrewRoomDevice.device_digest == target_digest,
+                    CrewRoomDevice.revoked_at.is_(None),
+                )
+            )
+            if target is None:
+                raise RelayServiceError(404, "Crew room device is not active")
+            target.revoked_at = now
+            room.updated_at = now
+            device.last_seen_at = now
+
+    def delete_crew_room(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        device_credential: str,
+    ) -> None:
+        normalised_alias = self._normalise_crew_room_alias(alias)
+        with session.begin():
+            room, _ = self._authorise_crew_room_device(
+                session,
+                alias=normalised_alias,
+                device_id=device_id,
+                credential=device_credential,
+                owner_required=True,
+            )
+            session.delete(room)
+
     def create_plan(
         self,
         session: Session,
@@ -705,6 +1067,156 @@ class RelayService:
     @staticmethod
     def _join_code_aad(ride_code: str) -> bytes:
         return f"join-code:{ride_code}".encode()
+
+    @staticmethod
+    def _normalise_crew_room_alias(alias: str) -> str:
+        normalised = alias.strip().upper()
+        if not CREW_ROOM_ALIAS.fullmatch(normalised):
+            raise RelayServiceError(400, "Crew room alias must be 5-12 letters or numbers")
+        return normalised
+
+    @staticmethod
+    def _validate_crew_room_profile(device_id: str, display_name: str) -> dict[str, str]:
+        clean_name = display_name.strip()
+        if not IDENTIFIER.fullmatch(device_id):
+            raise RelayServiceError(400, "Crew room device identity is invalid")
+        if not 1 <= len(clean_name) <= 80:
+            raise RelayServiceError(400, "Crew room device name is invalid")
+        return {"deviceId": device_id, "displayName": clean_name}
+
+    def _validate_crew_room_operation(
+        self,
+        operation: dict[str, str],
+        bearer_token: str,
+    ) -> dict[str, str]:
+        expected_fields = {"rideId", "rideCode", "inviteSecret", "resolveToken"}
+        if set(operation) != expected_fields or not all(
+            isinstance(operation.get(field), str) for field in expected_fields
+        ):
+            raise RelayServiceError(400, "Crew room operation is invalid")
+        clean = {field: operation[field] for field in expected_fields}
+        self._validate_join_code(clean["rideCode"])
+        self._validate_join_credential(clean["rideId"], clean["inviteSecret"], bearer_token)
+        if not 16 <= len(clean["resolveToken"]) <= 128:
+            raise RelayServiceError(400, "Invalid ride credential")
+        return clean
+
+    def _crew_room_alias_digest(self, alias: str) -> bytes:
+        return self._cipher.blind_index(alias, namespace="crew-room-alias-v1")
+
+    def _crew_room_device_digest(self, room_id: str, device_id: str) -> bytes:
+        if not IDENTIFIER.fullmatch(device_id):
+            raise RelayServiceError(400, "Crew room device identity is invalid")
+        return self._cipher.blind_index(
+            device_id,
+            namespace=f"crew-room-device-v1:{room_id}",
+        )
+
+    @staticmethod
+    def _crew_room_aad(room_id: str, value: str) -> bytes:
+        return f"crew-room:{room_id}:{value}".encode()
+
+    @staticmethod
+    def _crew_room_device_aad(room_id: str, device_digest: bytes) -> bytes:
+        return f"crew-room:{room_id}:device:{device_digest.hex()}".encode()
+
+    def _authorise_crew_room_device(
+        self,
+        session: Session,
+        *,
+        alias: str,
+        device_id: str,
+        credential: str,
+        owner_required: bool = False,
+    ) -> tuple[CrewRoom, CrewRoomDevice]:
+        if not CREW_ROOM_DEVICE_CREDENTIAL.fullmatch(credential):
+            raise RelayServiceError(404, "Crew room is not available")
+        room = session.scalar(
+            select(CrewRoom).where(CrewRoom.alias_digest == self._crew_room_alias_digest(alias))
+        )
+        if room is None:
+            raise RelayServiceError(404, "Crew room is not available")
+        device_digest = self._crew_room_device_digest(room.id, device_id)
+        device = session.scalar(
+            select(CrewRoomDevice).where(
+                CrewRoomDevice.room_id == room.id,
+                CrewRoomDevice.device_digest == device_digest,
+            )
+        )
+        if (
+            device is None
+            or device.revoked_at is not None
+            or not hmac.compare_digest(device.credential_hash, token_hash(credential))
+            or (owner_required and not hmac.compare_digest(room.owner_device_digest, device_digest))
+        ):
+            raise RelayServiceError(404, "Crew room is not available")
+        return room, device
+
+    def _decrypt_crew_room_operation(self, room: CrewRoom) -> dict[str, str]:
+        try:
+            value = self._cipher.decrypt_json(
+                room.operation_ciphertext,
+                associated_data=self._crew_room_aad(room.id, "operation"),
+            )
+        except ValueError as error:
+            raise RelayServiceError(500, "Crew room record is invalid") from error
+        if not isinstance(value, dict) or set(value) != {
+            "rideId",
+            "rideCode",
+            "inviteSecret",
+            "resolveToken",
+        }:
+            raise RelayServiceError(500, "Crew room record is invalid")
+        if not all(isinstance(item, str) for item in value.values()):
+            raise RelayServiceError(500, "Crew room record is invalid")
+        return {key: value[key] for key in value}
+
+    def _decrypt_crew_room_profile(self, device: CrewRoomDevice) -> dict[str, str]:
+        try:
+            value = self._cipher.decrypt_json(
+                device.profile_ciphertext,
+                associated_data=self._crew_room_device_aad(device.room_id, device.device_digest),
+            )
+        except ValueError as error:
+            raise RelayServiceError(500, "Crew room device record is invalid") from error
+        if (
+            not isinstance(value, dict)
+            or not isinstance(value.get("deviceId"), str)
+            or not isinstance(value.get("displayName"), str)
+        ):
+            raise RelayServiceError(500, "Crew room device record is invalid")
+        return {"deviceId": value["deviceId"], "displayName": value["displayName"]}
+
+    def _crew_room_response(
+        self,
+        room: CrewRoom,
+        *,
+        device_credential: str,
+        invite_token: str | None,
+        device_digest: bytes,
+        now: datetime,
+    ) -> dict[str, Any]:
+        try:
+            alias_value = self._cipher.decrypt_json(
+                room.alias_ciphertext,
+                associated_data=self._crew_room_aad(room.id, "alias"),
+            )
+        except ValueError as error:
+            raise RelayServiceError(500, "Crew room record is invalid") from error
+        alias = alias_value.get("alias") if isinstance(alias_value, dict) else None
+        if not isinstance(alias, str):
+            raise RelayServiceError(500, "Crew room record is invalid")
+        operation_is_active = self._as_utc(room.operation_expires_at) > now
+        return {
+            "roomId": room.id,
+            "alias": alias,
+            "deviceCredential": device_credential,
+            **({"inviteToken": invite_token} if invite_token is not None else {}),
+            "operationGeneration": room.operation_generation,
+            "operation": self._decrypt_crew_room_operation(room) if operation_is_active else None,
+            "operationExpiresAt": self._as_utc(room.operation_expires_at),
+            "owner": hmac.compare_digest(room.owner_device_digest, device_digest),
+        }
 
     def _store_replay(
         self,

--- a/apps/server/tests/test_compatibility.py
+++ b/apps/server/tests/test_compatibility.py
@@ -7,6 +7,7 @@ from balloon_crumbs_server.app import create_app
 SECRET = "0123456789abcdef0123456789abcdef"
 CURRENT_CAPABILITIES = [
     "crew-flight-lifecycle-v1",
+    "crew-rooms-v1",
     "ride-start-v1",
     "live-presence-v2",
     "membership-v1",

--- a/apps/server/tests/test_crew_rooms.py
+++ b/apps/server/tests/test_crew_rooms.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from balloon_crumbs_server.app import create_app
+from balloon_crumbs_server.models import CrewRoom
+
+from .conftest import ride_token
+
+SECRET_ONE = "0123456789abcdef0123456789abcdef"
+SECRET_TWO = "fedcba9876543210fedcba9876543210"
+RESOLVE_ONE = "resolve-token-operation-one"
+RESOLVE_TWO = "resolve-token-operation-two"
+
+
+def _operation(
+    ride_id: str = "operation-one",
+    ride_code: str = "123456",
+    secret: str = SECRET_ONE,
+    resolve_token: str = RESOLVE_ONE,
+) -> dict[str, str]:
+    return {
+        "rideId": ride_id,
+        "rideCode": ride_code,
+        "inviteSecret": secret,
+        "resolveToken": resolve_token,
+    }
+
+
+def _create(client, *, alias: str = "TUCKER"):
+    operation = _operation()
+    return client.post(
+        "/api/v1/crew-rooms/create",
+        json={
+            "alias": alias,
+            "deviceId": "room-device-owner",
+            "displayName": "Oliver",
+            "operation": operation,
+        },
+        headers={
+            "authorization": f"Bearer {ride_token(operation['rideId'], operation['inviteSecret'])}"
+        },
+    )
+
+
+def _auth(created: dict[str, object], *, device_id: str = "room-device-owner"):
+    return {
+        "alias": created["alias"],
+        "deviceId": device_id,
+        "deviceCredential": created["deviceCredential"],
+    }
+
+
+def test_room_alias_is_not_a_credential_and_stays_encrypted_at_rest(client, settings) -> None:
+    response = _create(client, alias="tucker")
+    assert response.status_code == 201
+    created = response.json()
+    assert created["alias"] == "TUCKER"
+    assert created["owner"] is True
+    assert created["operation"] == _operation()
+    assert created["operationGeneration"] == 1
+
+    # There is deliberately no alias-only operation lookup. Guessing a valid
+    # alias with an invented returning credential reveals the same 404 as a
+    # room that does not exist.
+    guessed = client.post(
+        "/api/v1/crew-rooms/open",
+        json={
+            "alias": "TUCKER",
+            "deviceId": "guessed-device",
+            "deviceCredential": "crd1_" + "A" * 43,
+        },
+    )
+    missing = client.post(
+        "/api/v1/crew-rooms/open",
+        json={
+            "alias": "ABSENT",
+            "deviceId": "guessed-device",
+            "deviceCredential": "crd1_" + "A" * 43,
+        },
+    )
+    assert guessed.status_code == missing.status_code == 404
+    assert guessed.json() == missing.json() == {"error": "Crew room is not available"}
+
+    factory = client.app.state.session_factory
+    with factory() as session:
+        stored = session.scalar(select(CrewRoom))
+        assert stored is not None
+        assert b"TUCKER" not in stored.alias_ciphertext
+        assert SECRET_ONE.encode() not in stored.operation_ciphertext
+        assert RESOLVE_ONE.encode() not in stored.operation_ciphertext
+
+
+def test_private_invite_enrols_a_returning_device_and_qr_operation(client) -> None:
+    created = _create(client).json()
+    joined = client.post(
+        "/api/v1/crew-rooms/join",
+        json={
+            "alias": "TUCKER",
+            "inviteToken": created["inviteToken"],
+            "deviceId": "room-device-chaser",
+            "displayName": "Nigel",
+        },
+    )
+    assert joined.status_code == 200
+    member = joined.json()
+    assert member["owner"] is False
+    assert member["operation"] == _operation()
+    assert member["deviceCredential"].startswith("crd1_")
+
+    reopened = client.post(
+        "/api/v1/crew-rooms/open",
+        json=_auth(member, device_id="room-device-chaser"),
+    )
+    assert reopened.status_code == 200
+    assert reopened.json()["operation"] == _operation()
+
+
+def test_reusing_alias_starts_a_fresh_isolated_operation(client) -> None:
+    first = _create(client).json()
+    second_operation = _operation(
+        ride_id="operation-two",
+        ride_code="654321",
+        secret=SECRET_TWO,
+        resolve_token=RESOLVE_TWO,
+    )
+    second_bearer = ride_token(second_operation["rideId"], second_operation["inviteSecret"])
+    started = client.post(
+        "/api/v1/crew-rooms/start-operation",
+        json={**_auth(first), "operation": second_operation},
+        headers={"authorization": f"Bearer {second_bearer}"},
+    )
+    assert started.status_code == 200
+    current = started.json()
+    assert current["alias"] == "TUCKER"
+    assert current["operationGeneration"] == 2
+    assert current["operation"] == second_operation
+    assert current["inviteToken"] != first["inviteToken"]
+
+    # The previous invitation cannot enrol a device into the new operation.
+    old_invite = client.post(
+        "/api/v1/crew-rooms/join",
+        json={
+            "alias": "TUCKER",
+            "inviteToken": first["inviteToken"],
+            "deviceId": "late-device",
+            "displayName": "Late join",
+        },
+    )
+    assert old_invite.status_code == 404
+
+
+def test_owner_can_list_transfer_rename_revoke_and_delete(client) -> None:
+    owner = _create(client).json()
+    joined_response = client.post(
+        "/api/v1/crew-rooms/join",
+        json={
+            "alias": "TUCKER",
+            "inviteToken": owner["inviteToken"],
+            "deviceId": "room-device-chaser",
+            "displayName": "Nigel",
+        },
+    )
+    member = joined_response.json()
+
+    devices = client.post("/api/v1/crew-rooms/devices", json=_auth(owner))
+    assert devices.status_code == 200
+    assert [(item["displayName"], item["owner"]) for item in devices.json()["devices"]] == [
+        ("Oliver", True),
+        ("Nigel", False),
+    ]
+
+    transferred = client.post(
+        "/api/v1/crew-rooms/transfer",
+        json={**_auth(owner), "targetDeviceId": "room-device-chaser"},
+    )
+    assert transferred.status_code == 204
+    old_owner_rename = client.post(
+        "/api/v1/crew-rooms/rename",
+        json={**_auth(owner), "newAlias": "GRAVES"},
+    )
+    assert old_owner_rename.status_code == 404
+
+    renamed = client.post(
+        "/api/v1/crew-rooms/rename",
+        json={**_auth(member, device_id="room-device-chaser"), "newAlias": "GRAVES"},
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["alias"] == "GRAVES"
+    member["alias"] = "GRAVES"
+
+    revoked = client.post(
+        "/api/v1/crew-rooms/revoke-device",
+        json={
+            **_auth(member, device_id="room-device-chaser"),
+            "targetDeviceId": "room-device-owner",
+        },
+    )
+    assert revoked.status_code == 204
+    owner["alias"] = "GRAVES"
+    assert client.post("/api/v1/crew-rooms/open", json=_auth(owner)).status_code == 404
+
+    deleted = client.post(
+        "/api/v1/crew-rooms/delete",
+        json=_auth(member, device_id="room-device-chaser"),
+    )
+    assert deleted.status_code == 204
+    assert (
+        client.post(
+            "/api/v1/crew-rooms/open",
+            json=_auth(member, device_id="room-device-chaser"),
+        ).status_code
+        == 404
+    )
+
+
+def test_expired_operation_does_not_reappear_as_active(client) -> None:
+    created = _create(client).json()
+    factory = client.app.state.session_factory
+    with factory() as session, session.begin():
+        room = session.scalar(select(CrewRoom))
+        assert room is not None
+        room.operation_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+
+    opened = client.post("/api/v1/crew-rooms/open", json=_auth(created))
+    assert opened.status_code == 200
+    assert opened.json()["operation"] is None
+
+
+def test_crew_room_requests_are_rate_limited(settings) -> None:
+    limited = settings.model_copy(update={"crew_room_rate_limit_requests": 1})
+    with TestClient(create_app(limited)) as client:
+        first = client.post(
+            "/api/v1/crew-rooms/open",
+            json={
+                "alias": "TUCKER",
+                "deviceId": "some-device",
+                "deviceCredential": "crd1_" + "A" * 43,
+            },
+        )
+        second = client.post(
+            "/api/v1/crew-rooms/open",
+            json={
+                "alias": "TUCKER",
+                "deviceId": "some-device",
+                "deviceCredential": "crd1_" + "A" * 43,
+            },
+        )
+    assert first.status_code == 404
+    assert second.status_code == 429

--- a/apps/server/tests/test_discovery_withdrawn.py
+++ b/apps/server/tests/test_discovery_withdrawn.py
@@ -77,7 +77,8 @@ def test_the_migration_chain_stays_linear() -> None:
         revisions[revision.group(1)] = down.group(1)
 
     assert revisions["0011"] == "0010"
+    assert revisions["0012"] == "0011"
     parents = [parent for parent in revisions.values() if parent is not None]
     assert len(parents) == len(set(parents)), "a revision is claimed as parent twice"
     heads = set(revisions) - set(parents)
-    assert heads == {"0011"}, heads
+    assert heads == {"0012"}, heads

--- a/docs/field-operations-recovery-plan.md
+++ b/docs/field-operations-recovery-plan.md
@@ -259,6 +259,10 @@ contacts remain a separate private overlay.
 - [#75 — optional OS final-approach basemap](https://github.com/osholt/balloon-crumbs/issues/75)
 - [#76 — device-local privacy-governed land access notes](https://github.com/osholt/balloon-crumbs/issues/76)
 
+Implementation evidence for #71 is recorded in
+[Reusable crew rooms](reusable-crew-rooms.md), including its authority,
+revocation, offline and storage boundaries.
+
 ## Delivery evidence
 
 - Shared release, LANDED, retraction and recovery-complete semantics are

--- a/docs/reusable-crew-rooms.md
+++ b/docs/reusable-crew-rooms.md
@@ -1,0 +1,89 @@
+# Reusable crew rooms
+
+Status: **implemented for the private tester relay**
+
+Ticket: [#71](https://github.com/osholt/balloon-crumbs/issues/71)
+
+## What a room is
+
+A crew room is a persistent, memorable label for a regular balloon recovery
+team. `TUCKER` can be opened again on another day, but it is not a flight code
+and it is never accepted as proof of access.
+
+Every launch beneath a room has a fresh operation ID, six-digit flight code,
+event journal, invitation secret, relay credential and retention window. Starting
+a fresh operation rotates the private invitation and prevents old tracks or
+events appearing in the new flight.
+
+## Joining and returning
+
+- The owner creates a 5–12 character alphanumeric alias while creating a normal
+  private group flight.
+- The flight QR always contains the current operation bootstrap, so a nearby
+  device can still join the flight while the internet relay is unavailable.
+- When online, the same QR also carries a single current room invitation. A new
+  device exchanges it for its own returning-device credential.
+- A returning device keeps that credential in platform secure storage and can
+  open the current room operation without entering the human alias again.
+- An owner can rename the room, transfer ownership, revoke a returning device or
+  delete the room. Transfer, revocation and deletion require an explicit
+  confirmation in the app.
+
+If online room enrolment fails after an offline QR join, the device remains in
+the current flight but does not silently gain returning access. It must scan a
+current invitation again when connectivity is restored.
+
+## Authority and privacy model
+
+The relay deliberately exposes only generic POST endpoints under
+`/api/v1/crew-rooms/`; aliases and credentials do not appear in URL paths or
+ordinary access logs. Missing rooms, guessed aliases and invalid device
+credentials return the same bounded response. Attempts are rate limited.
+
+At rest on the relay:
+
+- aliases and device profiles are encrypted;
+- alias and device lookup values use namespace-separated keyed blind indexes;
+- returning-device credentials and room invitation tokens are stored only as
+  one-way token hashes;
+- the current operation bootstrap is encrypted with room-scoped associated
+  data; and
+- exact device identifiers and membership profiles are not stored in cleartext.
+
+On a phone, returning credentials are isolated in `FlutterSecureStorage` rather
+than the ordinary session preferences. Existing account-free flight membership,
+event authentication and encrypted relay retention continue to apply to each
+fresh operation.
+
+The room owner can see the encrypted profile names of enrolled devices because
+they need that information to transfer or revoke access. No public room lookup,
+roster, discovery feed or account directory exists.
+
+## Revocation and retention
+
+Revocation prevents the device credential opening the room or accessing later
+operations. It does not remotely erase a current flight already bootstrapped on
+that device; that flight remains governed by its own credential and normal
+retention window. Starting a fresh operation rotates the room invitation, so a
+previous QR cannot enrol another device into the next flight.
+
+Deleting a room revokes all future returning access. It does not claim to remove
+copies of a still-retained operation from participant devices. Expiring an
+operation hides it from room-open responses without deleting the room alias or
+returning membership.
+
+## Verification evidence
+
+Automated coverage exercises:
+
+- two isolated operations under `TUCKER` with invitation rotation;
+- rejection of an alias without private authority;
+- first-time QR enrolment and returning-device access;
+- encrypted/keyed server storage and generic request paths;
+- rename, ownership transfer, revocation and deletion;
+- expired-operation handling and request rate limits;
+- secure mobile persistence and corrupt-state removal; and
+- backward-compatible offline QR parsing and operation join.
+
+The user-facing reachability test also keeps the optional reusable-room field and
+its “alias is not a password” explanation discoverable in group-flight setup.


### PR DESCRIPTION
## Outcome
- adds reusable 5–12 character crew aliases with fresh isolated operations
- keeps aliases non-authoritative through per-device credentials and rotating private invitations
- supports offline QR flight bootstrap plus online returning-device enrolment
- adds rename, ownership transfer, revocation and deletion with secure storage and confirmations
- adds encrypted/keyed relay persistence, generic rate-limited endpoints, migration and operational documentation

## Verification
- `cd apps/mobile && flutter analyze`
- `cd apps/mobile && flutter test --reporter compact` (1,799 passed; 24 expected skips before the final reachability test)
- targeted crew-room and reachability suite after final UI confirmation changes (19 passed)
- `cd apps/server && uv run ruff format --check . && uv run ruff check . && uv run pytest -q` (145 passed)

Closes #71