### PR TITLE
feat: make live recovery map road first

### DIFF
--- a/apps/mobile/lib/domain/map_orientation.dart
+++ b/apps/mobile/lib/domain/map_orientation.dart
@@ -1,0 +1,14 @@
+enum MapOrientationMode {
+  northUp,
+  directionUp;
+
+  String get label => switch (this) {
+    MapOrientationMode.northUp => 'North up',
+    MapOrientationMode.directionUp => 'Direction up',
+  };
+
+  MapOrientationMode get toggled => switch (this) {
+    MapOrientationMode.northUp => MapOrientationMode.directionUp,
+    MapOrientationMode.directionUp => MapOrientationMode.northUp,
+  };
+}

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -22,6 +22,7 @@ import '../../domain/altitude.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/hazard.dart';
 import '../../domain/imported_route.dart';
+import '../../domain/map_orientation.dart';
 import '../../domain/quick_message.dart';
 import '../../domain/recorded_route_store.dart';
 import '../../domain/ride_role.dart';
@@ -282,6 +283,9 @@ class RideMapFeature extends StatefulWidget {
     this.aeronauticalChartConfiguration =
         const AeronauticalChartConfiguration(),
     this.windForecastController,
+    this.mapOrientation = MapOrientationMode.directionUp,
+    this.onMapOrientationChanged,
+    this.showAeronauticalChart = false,
   });
 
   factory RideMapFeature.fromEnvironment({
@@ -347,6 +351,9 @@ class RideMapFeature extends StatefulWidget {
     bool? showForecastContext,
     AeronauticalChartConfiguration? aeronauticalChartConfiguration,
     WindForecastController? windForecastController,
+    MapOrientationMode mapOrientation = MapOrientationMode.directionUp,
+    ValueChanged<MapOrientationMode>? onMapOrientationChanged,
+    bool showAeronauticalChart = false,
   }) => RideMapFeature(
     key: key,
     currentPosition: currentPosition,
@@ -413,6 +420,9 @@ class RideMapFeature extends StatefulWidget {
         aeronauticalChartConfiguration ??
         AeronauticalChartConfiguration.fromEnvironment(),
     windForecastController: windForecastController,
+    mapOrientation: mapOrientation,
+    onMapOrientationChanged: onMapOrientationChanged,
+    showAeronauticalChart: showAeronauticalChart,
   );
 
   final ValueListenable<GeoPoint?>? currentPosition;
@@ -515,6 +525,9 @@ class RideMapFeature extends StatefulWidget {
   final bool? showForecastContext;
   final AeronauticalChartConfiguration aeronauticalChartConfiguration;
   final WindForecastController? windForecastController;
+  final MapOrientationMode mapOrientation;
+  final ValueChanged<MapOrientationMode>? onMapOrientationChanged;
+  final bool showAeronauticalChart;
 
   @override
   State<RideMapFeature> createState() => _RideMapFeatureState();
@@ -678,6 +691,9 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         showForecastContext: widget.showForecastContext,
         aeronauticalChartConfiguration: widget.aeronauticalChartConfiguration,
         windForecastController: widget.windForecastController,
+        mapOrientation: widget.mapOrientation,
+        onMapOrientationChanged: widget.onMapOrientationChanged,
+        showAeronauticalChart: widget.showAeronauticalChart,
       );
     },
   );
@@ -780,6 +796,9 @@ class RideMapScreen extends StatefulWidget {
     this.aeronauticalChartConfiguration =
         const AeronauticalChartConfiguration(),
     this.windForecastController,
+    this.mapOrientation = MapOrientationMode.directionUp,
+    this.onMapOrientationChanged,
+    this.showAeronauticalChart = false,
   });
 
   final RouteStore routeStore;
@@ -904,6 +923,9 @@ class RideMapScreen extends StatefulWidget {
   final bool? showForecastContext;
   final AeronauticalChartConfiguration aeronauticalChartConfiguration;
   final WindForecastController? windForecastController;
+  final MapOrientationMode mapOrientation;
+  final ValueChanged<MapOrientationMode>? onMapOrientationChanged;
+  final bool showAeronauticalChart;
 
   @override
   State<RideMapScreen> createState() => _RideMapScreenState();
@@ -939,8 +961,14 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _isBalloonView ? CraftIconStyle.balloon : widget.localMotorcycleStyle;
 
   bool get _showAeronauticalChart =>
+      widget.showAeronauticalChart &&
       _showsForecastContext &&
       widget.aeronauticalChartConfiguration.isCurrentAt(DateTime.now());
+
+  double get _effectiveCameraBearingDegrees =>
+      widget.mapOrientation == MapOrientationMode.northUp
+      ? 0
+      : _cameraBearingDegrees;
 
   bool get _showWindForecast {
     final controller = widget.windForecastController;
@@ -1306,6 +1334,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
       oldWidget.windForecastController?.removeListener(_onWindForecastChanged);
       widget.windForecastController?.addListener(_onWindForecastChanged);
       _onWindForecastChanged();
+    }
+    if (oldWidget.mapOrientation != widget.mapOrientation && _navigationMode) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) unawaited(_followNavigationCamera(force: true));
+      });
     }
     if (oldWidget.speedLimitDisplay != widget.speedLimitDisplay) {
       if (_ownsSpeedLimitDisplay) _speedLimitDisplay.dispose();
@@ -2248,6 +2281,28 @@ class _RideMapScreenState extends State<RideMapScreen> {
               label: const Text('Follow me'),
             )
           : null;
+      final orientation = widget.onMapOrientationChanged == null
+          ? null
+          : FilledButton.tonalIcon(
+              key: const Key('map-orientation-toggle'),
+              onPressed: () => widget.onMapOrientationChanged!(
+                widget.mapOrientation.toggled,
+              ),
+              icon: Icon(
+                widget.mapOrientation == MapOrientationMode.northUp
+                    ? Icons.explore_outlined
+                    : Icons.navigation_outlined,
+              ),
+              label: Text(widget.mapOrientation.label),
+            );
+      final cameraControls = orientation == null && followMe == null
+          ? null
+          : Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [?orientation, ?followMe],
+            );
 
       if (landscape) {
         final actionLeft =
@@ -2359,7 +2414,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                 child: _chromeRail(
                   key: const Key('map-landscape-right-rail'),
                   alignment: CrossAxisAlignment.end,
-                  children: [?followMe, ?guidance],
+                  children: [?cameraControls, ?guidance],
                 ),
               ),
             ),
@@ -2472,8 +2527,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
                   // Rare, and its own run: it appears only when the map is off
                   // the rider, and the alternative was shrinking a target to fit
                   // it beside three others.
-                  if (followMe != null)
-                    Align(alignment: Alignment.centerLeft, child: followMe),
+                  if (cameraControls != null)
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: cameraControls,
+                    ),
                   ?actionCluster,
                   ?completionSuggestion,
                 ],
@@ -3173,11 +3231,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
     );
     var target = lookAhead == 0
         ? position
-        : _pointAhead(position, _cameraBearingDegrees, lookAhead);
+        : _pointAhead(position, _effectiveCameraBearingDegrees, lookAhead);
     if (lateralOffset != 0) {
       target = _pointAhead(
         target,
-        _cameraBearingDegrees + (lateralOffset > 0 ? 90 : -90),
+        _effectiveCameraBearingDegrees + (lateralOffset > 0 ? 90 : -90),
         lateralOffset.abs(),
       );
     }
@@ -3897,7 +3955,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         longitude: framing.target.longitude,
         zoom: cameraPlan.zoom,
         tilt: _basemap.usesMapLibre ? cameraPlan.tilt : 0,
-        bearing: _cameraBearingDegrees,
+        bearing: _effectiveCameraBearingDegrees,
         sourceViewportHeightPixels: _mapViewportHeightPixels,
         sourceViewportWidthPixels: _mapViewportWidthPixels,
         riderViewportFraction: cameraPlan.riderViewportFraction,
@@ -3919,7 +3977,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       longitude: framing.target.longitude,
       zoom: cameraPlan.zoom,
       tilt: cameraPlan.tilt,
-      bearing: _cameraBearingDegrees,
+      bearing: _effectiveCameraBearingDegrees,
     )) {
       return;
     }
@@ -3940,7 +3998,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
               ),
               zoom: cameraPlan.zoom,
               tilt: cameraPlan.tilt,
-              bearing: _cameraBearingDegrees,
+              bearing: _effectiveCameraBearingDegrees,
             ),
           ),
           duration: cameraDuration,
@@ -3957,7 +4015,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _mapController.moveAndRotateAnimatedRaw(
         _latLng(framing.target),
         cameraPlan.zoom,
-        _cameraBearingDegrees,
+        _effectiveCameraBearingDegrees,
         offset: Offset.zero,
         duration: cameraDuration,
         curve: transitionDuration == null
@@ -3981,8 +4039,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
   }
 
   /// A balloon needs geographic context, not a tilted road corridor. It stays
-  /// north-up at a deliberately wider scale, centred on the aircraft, while a
-  /// pan still hands control back to the pilot until they tap Follow me.
+  /// centred at a deliberately wider scale while the selected orientation sets
+  /// the map bearing. A pan still hands control back until Follow me is tapped.
   Future<void> _followBalloonCamera({
     bool force = false,
     Duration? transitionDuration,
@@ -4011,7 +4069,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         longitude: position.longitude,
         zoom: zoom,
         tilt: 0,
-        bearing: 0,
+        bearing: _effectiveCameraBearingDegrees,
         sourceViewportHeightPixels: _mapViewportHeightPixels,
         sourceViewportWidthPixels: _mapViewportWidthPixels,
         riderViewportFraction: 0.5,
@@ -4031,7 +4089,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
               target: ml.LatLng(position.latitude, position.longitude),
               zoom: zoom,
               tilt: 0,
-              bearing: 0,
+              bearing: _effectiveCameraBearingDegrees,
             ),
           ),
           duration: transitionDuration ?? const Duration(milliseconds: 480),
@@ -4040,7 +4098,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         _mapController.moveAndRotateAnimatedRaw(
           _latLng(position),
           zoom,
-          0,
+          _effectiveCameraBearingDegrees,
           offset: Offset.zero,
           duration: transitionDuration ?? const Duration(milliseconds: 480),
           curve: Curves.easeInOutCubic,
@@ -4130,12 +4188,15 @@ class _RideMapScreenState extends State<RideMapScreen> {
     final style = overlay.motorcycleStyle;
     return style == null
         ? _IconBadge(icon: overlay.icon, badgeColor: overlay.color, size: 34)
-        : RiderMarkerBadge(
-            style: style,
-            symbol: overlay.riderSymbol,
-            displayName: overlay.riderDisplayName ?? overlay.label,
-            badgeColor: overlay.color,
-            size: 34,
+        : GestureDetector(
+            onTap: () => _showMessage(overlay.label),
+            child: RiderMarkerBadge(
+              style: style,
+              symbol: overlay.riderSymbol,
+              displayName: overlay.riderDisplayName ?? overlay.label,
+              badgeColor: overlay.color,
+              size: 34,
+            ),
           );
   }
 

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -38,6 +38,7 @@ import '../../domain/hazard.dart';
 import '../../domain/imported_route.dart' as route_domain;
 import '../../domain/landing_zone.dart';
 import '../../domain/live_route_state.dart';
+import '../../domain/map_orientation.dart';
 import '../../domain/operational_boundary.dart';
 import '../../domain/map_style_mode.dart';
 import '../../domain/quick_message.dart';
@@ -76,6 +77,7 @@ import '../../services/fixed_speed_camera_provider.dart';
 import '../../services/gpx_import_source.dart';
 import '../../services/measurement_formatter.dart';
 import '../../services/live_flight_projection.dart';
+import '../../services/map_orientation_preferences.dart';
 import '../../services/native_push_token_source.dart';
 import '../../services/open_meteo_wind.dart';
 import '../../services/operational_boundary_monitor.dart';
@@ -379,6 +381,8 @@ class _CraftMapLocation {
     required this.riderSymbol,
     required this.riderColor,
     required this.altitudeMeters,
+    required this.speedMetersPerSecond,
+    required this.headingDegrees,
     required this.point,
   });
 
@@ -391,8 +395,36 @@ class _CraftMapLocation {
   final RiderSymbol riderSymbol;
   final RiderColor riderColor;
   final double? altitudeMeters;
+  final double? speedMetersPerSecond;
+  final double? headingDegrees;
   final route_domain.GeoPoint point;
 }
+
+@visibleForTesting
+String? craftGroundMotionLabel({
+  required double? speedMetersPerSecond,
+  required double? headingDegrees,
+}) {
+  final parts = <String>[];
+  if (speedMetersPerSecond != null &&
+      speedMetersPerSecond.isFinite &&
+      speedMetersPerSecond >= 0) {
+    parts.add('${(speedMetersPerSecond * 3.6).round()} km/h');
+  }
+  if (headingDegrees != null && headingDegrees.isFinite) {
+    final heading = headingDegrees.round() % 360;
+    const compass = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+    parts.add('${compass[((heading + 22.5) ~/ 45) % 8]} $heading°');
+  }
+  return parts.isEmpty ? null : parts.join(' · ');
+}
+
+@visibleForTesting
+bool roleShowsLiveRecoveryProjection(FlightRole? role) =>
+    role == FlightRole.pilot ||
+    role == FlightRole.balloonCrew ||
+    role == FlightRole.chaseDriver ||
+    role == FlightRole.chaseCrew;
 
 /// What the ride map should present of the quick messages in the journal, and
 /// the most urgent one per sender so their marker can say what they raised.
@@ -1414,6 +1446,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         LiveFlightProjectionStatus.noStructuredPlan,
       );
   String? _liveFlightProjectionFingerprint;
+  LocationSample? _balloonReferenceFix;
   String? _recordedWindContextFingerprint;
   bool _simulationRerouteInFlight = false;
   Duration? _lastSimulationRerouteElapsed;
@@ -1441,6 +1474,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   String? _trafficRerouteError;
   int _routeGeneration = 0;
   int _selectedIndex = 0;
+  late MapOrientationMode _mapOrientationMode;
+  MapOrientationPreferences? _mapOrientationPreferences;
   Object? _changeRouteRequestToken;
   PickedGpxFile? _pendingSharedGpxFile;
   PendingInAppRoute? _pendingInAppRoute;
@@ -1492,6 +1527,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   @override
   void initState() {
     super.initState();
+    _mapOrientationMode =
+        widget.rideController.session?.flightRole.isAboardBalloon == true
+        ? MapOrientationMode.northUp
+        : MapOrientationMode.directionUp;
+    unawaited(_loadMapOrientation());
     WidgetsBinding.instance.addObserver(this);
     // Headless and test surfaces have no audio to speak through, and must not
     // construct a platform speech engine.
@@ -1578,6 +1618,33 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         _updateMapOverlays(updateDerivedState: false);
       },
     );
+  }
+
+  MapOrientationScope get _mapOrientationScope =>
+      widget.rideController.session?.flightRole.isAboardBalloon == true
+      ? MapOrientationScope.phoneBalloon
+      : MapOrientationScope.phoneChase;
+
+  Future<void> _loadMapOrientation() async {
+    final preferences = MapOrientationPreferences(
+      await SharedPreferences.getInstance(),
+    );
+    final fallback = _mapOrientationMode;
+    final stored = preferences.read(_mapOrientationScope, fallback: fallback);
+    if (!mounted) return;
+    setState(() {
+      _mapOrientationPreferences = preferences;
+      _mapOrientationMode = stored;
+    });
+  }
+
+  Future<void> _setMapOrientation(MapOrientationMode mode) async {
+    if (_mapOrientationMode == mode) return;
+    setState(() => _mapOrientationMode = mode);
+    final preferences = _mapOrientationPreferences;
+    if (preferences != null) {
+      await preferences.write(_mapOrientationScope, mode);
+    }
   }
 
   /// A GPX file can arrive (via the platform's "Open in..." delivery) while
@@ -2616,6 +2683,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               : reporter?.riderSymbol ?? riderSymbolDefault,
           riderColor: reporter?.riderColor ?? riderColorDefault,
           altitudeMeters: sample.altitudeMeters,
+          speedMetersPerSecond: sample.speedMetersPerSecond,
+          headingDegrees: sample.headingDegrees,
           point: route_domain.GeoPoint(
             latitude: sample.position.latitude,
             longitude: sample.position.longitude,
@@ -2827,6 +2896,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                         riderSymbol: rider.riderSymbol,
                         riderColor: rider.riderColor,
                         altitudeMeters: rider.altitudeMeters,
+                        speedMetersPerSecond: rider.speedMetersPerSecond,
+                        headingDegrees: rider.headingDegrees,
                         point: route_domain.GeoPoint(
                           latitude: rider.position.latitude,
                           longitude: rider.position.longitude,
@@ -2862,6 +2933,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             final label = [
               location.displayName,
               roleSuffix,
+              ?craftGroundMotionLabel(
+                speedMetersPerSecond: location.speedMetersPerSecond,
+                headingDegrees: location.headingDegrees,
+              ),
               if (isBalloonCraft && location.altitudeMeters != null)
                 '${location.altitudeMeters!.round()} m',
               ?ageSuffix,
@@ -3266,6 +3341,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final tracks = const CraftTrackReducer().fromEvents(
       widget.rideController.events,
     );
+    final balloonTrack = tracks.where((track) => track.isBalloon).firstOrNull;
+    if (balloonTrack?.samples.firstOrNull case final reference?) {
+      final previous = _balloonReferenceFix;
+      if (previous == null ||
+          reference.recordedAt.isBefore(previous.recordedAt)) {
+        _balloonReferenceFix = reference;
+      }
+    }
     final roster = widget.rideController.resolveCraftRoster();
     _publishRiderTrails(
       [
@@ -3442,9 +3525,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   List<MapOverlayTrace> get _liveProjectionTraces {
-    final role = widget.rideController.session?.flightRole;
     final projection = _liveFlightProjection.projection;
-    if (role == FlightRole.chaseDriver || projection == null) return const [];
+    if (projection == null) return const [];
     final validAt = projection.windValidAt.toLocal();
     return [
       if (projection.track.length >= 2)
@@ -3452,7 +3534,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           id: 'live-flight-projection',
           points: _balloonTrailSimplifier.simplify(projection.track),
           label:
-              'Live projection · ${projection.windSource} · wind valid $validAt',
+              'Live projection · ${projection.windSource} · wind valid $validAt · ${projection.limitations}',
           kind: RiderTrailKind.liveProjectionTrack,
         ),
       if (projection.landingEnvelope.length >= 4)
@@ -3460,7 +3542,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           id: 'live-possible-landing-envelope',
           points: _trailSimplifier.simplify(projection.landingEnvelope),
           label:
-              'Live possible-landing envelope · forecast wind valid $validAt · suitability unverified',
+              'Live possible-landing envelope · forecast wind valid $validAt · ${projection.limitations} Landing suitability and access unverified.',
           kind: RiderTrailKind.liveLandingEnvelope,
         ),
     ];
@@ -3539,7 +3621,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     return WindForecastField(
       columns: [
         for (final point in windForecastGrid(flight.launch))
-          WindForecastColumn(position: point, vectors: vectors),
+          WindForecastColumn(
+            position: point,
+            vectors: vectors,
+            groundElevationMetersMsl: flight.launchElevationMetres,
+          ),
       ],
       validAt: sourceTime,
       fetchedAt: sourceTime,
@@ -3967,8 +4053,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   void _refreshWindForFlightContext() {
     final wind = _windForecastController;
-    final role = widget.rideController.session?.flightRole;
-    if (wind == null || role == FlightRole.chaseDriver) return;
+    if (wind == null) return;
     final balloon = _latestBalloonFix();
     final local = _mapPosition.value;
     final center =
@@ -4411,6 +4496,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           flightRole == FlightRole.pilot ||
           flightRole == FlightRole.balloonCrew ||
           flightRole == FlightRole.chaseCrew,
+      mapOrientation: _mapOrientationMode,
+      onMapOrientationChanged: (mode) => unawaited(_setMapOrientation(mode)),
     );
     if (!_selectingLandingZone &&
         !_selectingConfirmedLandingPoint &&
@@ -4784,10 +4871,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
   void _refreshLiveFlightProjection() {
     final role = widget.rideController.session?.flightRole;
-    final showsProjection =
-        role == FlightRole.pilot ||
-        role == FlightRole.balloonCrew ||
-        role == FlightRole.chaseCrew;
+    final showsProjection = roleShowsLiveRecoveryProjection(role);
     final plan = showsProjection
         ? _liveRoutes.sharedFlightPlan?.forecastPlan
         : null;
@@ -4811,6 +4895,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       balloonFix: fix,
       wind: field,
       now: now,
+      balloonReferenceFix: _balloonReferenceFix,
       allowReferenceWind: _isSimulation,
       flightLanded: widget.rideController.flightLanding.isLanded,
     );

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -433,6 +433,8 @@ class _RoleLivePanel extends StatelessWidget {
               ),
               const SizedBox(height: 12),
               _RoadRouteOverview(route: vehicleRoadRoute),
+              const SizedBox(height: 12),
+              _LiveProjectionSummary(assessment: liveFlightProjection),
               if (role == FlightRole.chaseCrew) ...[
                 const SizedBox(height: 12),
                 _FlightPlanOverview(summary: summary),
@@ -443,8 +445,6 @@ class _RoleLivePanel extends StatelessWidget {
                 ),
                 const SizedBox(height: 12),
                 _WindSummary(wind: wind),
-                const SizedBox(height: 12),
-                _LiveProjectionSummary(assessment: liveFlightProjection),
               ],
             ] else ...[
               _FlightPlanOverview(summary: summary, reduced: true),
@@ -587,16 +587,20 @@ class _LiveProjectionSummary extends StatelessWidget {
         icon: Icons.online_prediction_outlined,
         title: 'Live projection unavailable',
         detail:
-            '${value?.message ?? 'Waiting for structured plan, balloon telemetry and fresh wind.'} The original forecast remains unchanged.',
+            '${value?.message ?? 'Waiting for balloon telemetry, terrain reference and fresh wind.'} Any original forecast remains unchanged.',
       );
     }
     final landing = projection.computedAt.add(projection.duration);
+    final followsPlan =
+        projection.basis == LiveFlightProjectionBasis.structuredPlan;
     return _InformationRow(
       key: const Key('role-live-flight-projection'),
       icon: Icons.online_prediction,
-      title: 'Live projection · landing about ${_formatTime(context, landing)}',
+      title: followsPlan
+          ? 'Live projection · planned landing about ${_formatTime(context, landing)}'
+          : 'Live possible-landing estimate · 20–120 min range',
       detail:
-          '${projection.windSource} · wind valid ${_formatTime(context, projection.windValidAt)} · recalculated ${_compactAge(DateTime.now().difference(projection.computedAt))} ago · ${projection.landingEnvelope.isEmpty ? 'endpoint spread unavailable' : 'possible-landing envelope shown'}. Forecast model only; landing suitability and access are unverified.',
+          '${projection.windSource} · wind valid ${_formatTime(context, projection.windValidAt)} · recalculated ${_compactAge(DateTime.now().difference(projection.computedAt))} ago · ${projection.landingEnvelope.isEmpty ? 'endpoint spread unavailable' : 'possible-landing envelope shown'}. ${projection.limitations} Forecast model only; landing suitability and access are unverified.',
     );
   }
 }

--- a/apps/mobile/lib/services/live_flight_projection.dart
+++ b/apps/mobile/lib/services/live_flight_projection.dart
@@ -19,6 +19,8 @@ enum LiveFlightProjectionStatus {
   landed,
 }
 
+enum LiveFlightProjectionBasis { structuredPlan, liveRecoveryEstimate }
+
 class LiveFlightProjection {
   const LiveFlightProjection({
     required this.track,
@@ -28,6 +30,8 @@ class LiveFlightProjection {
     required this.windFetchedAt,
     required this.windSource,
     required this.duration,
+    required this.basis,
+    required this.limitations,
   });
 
   final List<route.GeoPoint> track;
@@ -37,6 +41,8 @@ class LiveFlightProjection {
   final DateTime windFetchedAt;
   final String windSource;
   final Duration duration;
+  final LiveFlightProjectionBasis basis;
+  final String limitations;
 }
 
 class LiveFlightProjectionAssessment {
@@ -51,13 +57,13 @@ class LiveFlightProjectionAssessment {
     LiveFlightProjectionStatus.available =>
       'Recalculated from the latest balloon fix and forecast wind.',
     LiveFlightProjectionStatus.noStructuredPlan =>
-      'A structured forecast plan is needed for a live projection.',
+      'A live estimate needs terrain-referenced altitude or a structured plan.',
     LiveFlightProjectionStatus.noBalloonFix =>
       'Waiting for the balloon position and altitude.',
     LiveFlightProjectionStatus.staleBalloonFix =>
       'The balloon fix is too old to project safely.',
     LiveFlightProjectionStatus.noCompatibleAltitude =>
-      'The balloon altitude datum cannot be compared with the plan.',
+      'The balloon altitude cannot yet be related to forecast height and terrain.',
     LiveFlightProjectionStatus.noWind => 'No forecast wind field is available.',
     LiveFlightProjectionStatus.staleWind =>
       'The forecast wind field is stale; the last projection is not extended.',
@@ -74,8 +80,9 @@ class LiveFlightProjectionAssessment {
 ///
 /// This is deliberately deterministic and has no network dependency. The wind
 /// controller fetches a bounded field; this engine only consumes a fresh field,
-/// applies the imported ascent/descent limits, and labels the result as model
-/// output. It never changes the pilot's intended landing area.
+/// applies imported ascent/descent limits when supplied, and otherwise explores
+/// a bounded range of plausible flight times and wind levels. Every result is
+/// labelled as model output. It never changes the pilot's intended landing area.
 class LiveFlightProjectionEngine {
   const LiveFlightProjectionEngine({
     this.maximumFixAge = const Duration(seconds: 45),
@@ -96,17 +103,13 @@ class LiveFlightProjectionEngine {
     required LocationSample? balloonFix,
     required WindForecastField? wind,
     required DateTime now,
+    LocationSample? balloonReferenceFix,
     bool allowReferenceWind = false,
     bool flightLanded = false,
   }) {
     if (flightLanded) {
       return const LiveFlightProjectionAssessment(
         LiveFlightProjectionStatus.landed,
-      );
-    }
-    if (plan == null) {
-      return const LiveFlightProjectionAssessment(
-        LiveFlightProjectionStatus.noStructuredPlan,
       );
     }
     if (balloonFix == null || balloonFix.altitudeMeters == null) {
@@ -118,12 +121,6 @@ class LiveFlightProjectionEngine {
     if (balloonFix.ageAt(utcNow) > maximumFixAge) {
       return const LiveFlightProjectionAssessment(
         LiveFlightProjectionStatus.staleBalloonFix,
-      );
-    }
-    final altitudeMsl = _altitudeMsl(plan, balloonFix);
-    if (altitudeMsl == null) {
-      return const LiveFlightProjectionAssessment(
-        LiveFlightProjectionStatus.noCompatibleAltitude,
       );
     }
     if (wind == null) {
@@ -149,18 +146,44 @@ class LiveFlightProjectionEngine {
       );
     }
 
-    final duration = _boundedDuration(plan);
+    final inputs = _projectionInputs(
+      plan: plan,
+      fix: balloonFix,
+      referenceFix: balloonReferenceFix,
+      wind: wind,
+    );
+    if (inputs == null) {
+      return const LiveFlightProjectionAssessment(
+        LiveFlightProjectionStatus.noCompatibleAltitude,
+      );
+    }
+
+    final duration = inputs.duration;
     final primary = _integrate(
       start: balloonFix.position,
-      startAltitudeMsl: altitudeMsl,
+      startAltitudeMsl: inputs.startAltitudeMsl,
       duration: duration,
       wind: wind,
-      altitudeAt: (fraction) =>
-          _plannedAltitude(plan, fraction, startAltitudeMsl: altitudeMsl),
-      constraints: plan.constraints,
+      altitudeAt: plan == null
+          ? (fraction) => _candidateAltitude(
+              fraction: fraction,
+              duration: duration,
+              startAltitudeMsl: inputs.startAltitudeMsl,
+              targetAltitudeMsl: inputs.startAltitudeMsl,
+              landingAltitudeMsl: inputs.landingAltitudeMsl,
+              maximumAscentRate:
+                  inputs.constraints.maximumAscentRateMetersPerSecond,
+              maximumDescentRate:
+                  inputs.constraints.maximumDescentRateMetersPerSecond,
+            )
+          : (fraction) => _plannedAltitude(
+              plan,
+              fraction,
+              startAltitudeMsl: inputs.startAltitudeMsl,
+            ),
+      constraints: inputs.constraints,
       retainTrack: true,
       startedAt: utcNow,
-      datum: balloonFix.altitudeDatum,
     );
     if (primary == null) {
       return const LiveFlightProjectionAssessment(
@@ -169,33 +192,42 @@ class LiveFlightProjectionEngine {
     }
 
     final endpoints = <route.GeoPoint>[];
-    for (final level in openMeteoWindAltitudeLevels) {
-      final target = math.min(
-        level.toDouble(),
-        plan.constraints.altitudeCeilingMetersMsl,
-      );
-      if (target < plan.launchElevationMetersMsl) continue;
-      final endpoint = _integrate(
-        start: balloonFix.position,
-        startAltitudeMsl: altitudeMsl,
-        duration: duration,
-        wind: wind,
-        altitudeAt: (fraction) => _candidateAltitude(
-          fraction: fraction,
-          duration: duration,
-          startAltitudeMsl: altitudeMsl,
-          targetAltitudeMsl: target,
-          landingAltitudeMsl: plan.launchElevationMetersMsl,
-          maximumAscentRate: plan.constraints.maximumAscentRateMetersPerSecond,
-          maximumDescentRate:
-              plan.constraints.maximumDescentRateMetersPerSecond,
-        ),
-        constraints: plan.constraints,
-        retainTrack: false,
-        startedAt: utcNow,
-        datum: balloonFix.altitudeDatum,
-      )?.last;
-      if (endpoint != null) endpoints.add(endpoint);
+    final candidateDurations = plan == null
+        ? [
+            for (final minutes in const [20, 40, 60, 90, 120])
+              Duration(minutes: minutes),
+          ]
+        : [duration];
+    for (final candidateDuration in candidateDurations) {
+      if (candidateDuration > maximumDuration) continue;
+      for (final level in openMeteoWindAltitudeLevels) {
+        final target = math.min(
+          level.toDouble(),
+          inputs.constraints.altitudeCeilingMetersMsl,
+        );
+        if (target < inputs.landingAltitudeMsl) continue;
+        final endpoint = _integrate(
+          start: balloonFix.position,
+          startAltitudeMsl: inputs.startAltitudeMsl,
+          duration: candidateDuration,
+          wind: wind,
+          altitudeAt: (fraction) => _candidateAltitude(
+            fraction: fraction,
+            duration: candidateDuration,
+            startAltitudeMsl: inputs.startAltitudeMsl,
+            targetAltitudeMsl: target,
+            landingAltitudeMsl: inputs.landingAltitudeMsl,
+            maximumAscentRate:
+                inputs.constraints.maximumAscentRateMetersPerSecond,
+            maximumDescentRate:
+                inputs.constraints.maximumDescentRateMetersPerSecond,
+          ),
+          constraints: inputs.constraints,
+          retainTrack: false,
+          startedAt: utcNow,
+        )?.last;
+        if (endpoint != null) endpoints.add(endpoint);
+      }
     }
     endpoints.add(primary.last);
     final envelope = _convexHull(endpoints);
@@ -209,8 +241,76 @@ class LiveFlightProjectionEngine {
         windFetchedAt: wind.fetchedAt.toUtc(),
         windSource: wind.sourceLabel,
         duration: duration,
+        basis: plan == null
+            ? LiveFlightProjectionBasis.liveRecoveryEstimate
+            : LiveFlightProjectionBasis.structuredPlan,
+        limitations: plan == null
+            ? 'No flight plan: explores 20–120 minute continuations and '
+                  'available wind levels using forecast terrain and 5 m/s '
+                  'vertical-rate bounds.'
+            : 'Uses the shared plan duration, altitude ceiling and vertical-rate bounds.',
       ),
     );
+  }
+
+  _ProjectionInputs? _projectionInputs({
+    required ForecastPlanDocument? plan,
+    required LocationSample fix,
+    required LocationSample? referenceFix,
+    required WindForecastField wind,
+  }) {
+    if (plan != null) {
+      final altitude = _altitudeMsl(plan, fix);
+      if (altitude == null) return null;
+      return _ProjectionInputs(
+        startAltitudeMsl: altitude,
+        landingAltitudeMsl: plan.launchElevationMetersMsl,
+        constraints: plan.constraints,
+        duration: _boundedDuration(plan),
+      );
+    }
+    final ground = wind.groundElevationAt(fix.position);
+    if (ground == null) return null;
+    final altitude = switch (fix.altitudeDatum) {
+      AltitudeDatum.wgs84Geoid => fix.altitudeMeters,
+      AltitudeDatum.relativeToLaunch => ground + fix.altitudeMeters!,
+      AltitudeDatum.wgs84Ellipsoid => _terrainReferencedEllipsoidAltitude(
+        fix: fix,
+        referenceFix: referenceFix,
+        wind: wind,
+      ),
+      AltitudeDatum.unknown => null,
+    };
+    if (altitude == null || !altitude.isFinite) return null;
+    final ceiling = math.max(altitude, 2000.0);
+    return _ProjectionInputs(
+      startAltitudeMsl: altitude,
+      landingAltitudeMsl: ground,
+      constraints: ForecastPlanConstraints(
+        altitudeCeilingMetersMsl: ceiling,
+        maximumAscentRateMetersPerSecond: 5,
+        maximumDescentRateMetersPerSecond: 5,
+        minimumDurationMinutes: 10,
+        maximumDurationMinutes: 120,
+      ),
+      duration: const Duration(minutes: 60),
+    );
+  }
+
+  static double? _terrainReferencedEllipsoidAltitude({
+    required LocationSample fix,
+    required LocationSample? referenceFix,
+    required WindForecastField wind,
+  }) {
+    if (referenceFix == null ||
+        referenceFix.altitudeDatum != AltitudeDatum.wgs84Ellipsoid ||
+        referenceFix.altitudeMeters == null) {
+      return null;
+    }
+    final referenceGround = wind.groundElevationAt(referenceFix.position);
+    if (referenceGround == null) return null;
+    return referenceGround +
+        math.max(0, fix.altitudeMeters! - referenceFix.altitudeMeters!);
   }
 
   Duration _boundedDuration(ForecastPlanDocument plan) {
@@ -300,15 +400,12 @@ class LiveFlightProjectionEngine {
     required ForecastPlanConstraints constraints,
     required bool retainTrack,
     required DateTime startedAt,
-    required AltitudeDatum datum,
   }) {
     final totalSeconds = duration.inMilliseconds / 1000;
     final stepSeconds = math.max(1.0, step.inMilliseconds / 1000);
     var position = start;
     var altitude = startAltitudeMsl;
-    final output = <route.GeoPoint>[
-      _routePoint(position, altitude, startedAt, datum),
-    ];
+    final output = <route.GeoPoint>[_routePoint(position, altitude, startedAt)];
     for (var elapsed = 0.0; elapsed < totalSeconds;) {
       final seconds = math.min(stepSeconds, totalSeconds - elapsed);
       final nextElapsed = elapsed + seconds;
@@ -336,7 +433,6 @@ class LiveFlightProjectionEngine {
             position,
             altitude,
             startedAt.add(Duration(milliseconds: (elapsed * 1000).round())),
-            datum,
           ),
         );
       }
@@ -348,15 +444,12 @@ class LiveFlightProjectionEngine {
     live.GeoPoint point,
     double altitudeMsl,
     DateTime recordedAt,
-    AltitudeDatum sourceDatum,
   ) => route.GeoPoint(
     latitude: point.latitude,
     longitude: point.longitude,
     elevationMeters: altitudeMsl,
     altitudeSource: AltitudeSource.unknown,
-    altitudeDatum: sourceDatum == AltitudeDatum.relativeToLaunch
-        ? AltitudeDatum.wgs84Geoid
-        : sourceDatum,
+    altitudeDatum: AltitudeDatum.wgs84Geoid,
     recordedAt: recordedAt,
   );
 
@@ -418,4 +511,18 @@ class LiveFlightProjectionEngine {
     if (hull.length < 3) return const [];
     return List.unmodifiable([...hull, hull.first]);
   }
+}
+
+class _ProjectionInputs {
+  const _ProjectionInputs({
+    required this.startAltitudeMsl,
+    required this.landingAltitudeMsl,
+    required this.constraints,
+    required this.duration,
+  });
+
+  final double startAltitudeMsl;
+  final double landingAltitudeMsl;
+  final ForecastPlanConstraints constraints;
+  final Duration duration;
 }

--- a/apps/mobile/lib/services/map_orientation_preferences.dart
+++ b/apps/mobile/lib/services/map_orientation_preferences.dart
@@ -1,0 +1,29 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../domain/map_orientation.dart';
+
+enum MapOrientationScope { phoneBalloon, phoneChase, carPlay }
+
+class MapOrientationPreferences {
+  const MapOrientationPreferences(this.preferences);
+
+  final SharedPreferences preferences;
+
+  static const _prefix = 'map_orientation';
+
+  MapOrientationMode read(
+    MapOrientationScope scope, {
+    required MapOrientationMode fallback,
+  }) {
+    final stored = preferences.getString(_key(scope));
+    return MapOrientationMode.values
+            .where((mode) => mode.name == stored)
+            .firstOrNull ??
+        fallback;
+  }
+
+  Future<void> write(MapOrientationScope scope, MapOrientationMode mode) =>
+      preferences.setString(_key(scope), mode.name);
+
+  static String _key(MapOrientationScope scope) => '$_prefix:${scope.name}';
+}

--- a/apps/mobile/lib/services/open_meteo_wind.dart
+++ b/apps/mobile/lib/services/open_meteo_wind.dart
@@ -76,10 +76,15 @@ class WindForecastVector {
 }
 
 class WindForecastColumn {
-  const WindForecastColumn({required this.position, required this.vectors});
+  const WindForecastColumn({
+    required this.position,
+    required this.vectors,
+    this.groundElevationMetersMsl,
+  });
 
   final GeoPoint position;
   final List<WindForecastVector> vectors;
+  final double? groundElevationMetersMsl;
 
   WindForecastVector? atAltitude(double altitudeMetersMsl) {
     if (vectors.isEmpty) return null;
@@ -153,6 +158,22 @@ class WindForecastField {
           : second,
     );
     return nearest.atAltitude(altitudeMetersMsl);
+  }
+
+  double? groundElevationAt(GeoPoint position) {
+    final available = columns
+        .where((column) => column.groundElevationMetersMsl != null)
+        .toList(growable: false);
+    if (available.isEmpty) return null;
+    return available
+        .reduce(
+          (first, second) =>
+              GeoCalculations.distanceMeters(position, first.position) <=
+                  GeoCalculations.distanceMeters(position, second.position)
+              ? first
+              : second,
+        )
+        .groundElevationMetersMsl;
   }
 
   List<WindForecastSample> vectorsAt(double altitudeMetersMsl) =>
@@ -243,6 +264,7 @@ class OpenMeteoWindProvider implements WindForecastProvider {
       if (entry is! Map) continue;
       final latitude = (entry['latitude'] as num?)?.toDouble();
       final longitude = (entry['longitude'] as num?)?.toDouble();
+      final groundElevation = (entry['elevation'] as num?)?.toDouble();
       final hourly = entry['hourly'];
       if (latitude == null || longitude == null || hourly is! Map) continue;
       final times = hourly['time'];
@@ -288,6 +310,9 @@ class OpenMeteoWindProvider implements WindForecastProvider {
           WindForecastColumn(
             position: GeoPoint(latitude: latitude, longitude: longitude),
             vectors: List.unmodifiable(vectors),
+            groundElevationMetersMsl: groundElevation?.isFinite == true
+                ? groundElevation
+                : null,
           ),
         );
       }

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:balloon_crumbs/domain/altitude.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/domain/map_orientation.dart';
 import 'package:balloon_crumbs/domain/route_store.dart';
 import 'package:balloon_crumbs/domain/distance_unit.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart' as live;
@@ -121,6 +122,7 @@ void main() {
         httpClient: MockClient((_) async => http.Response('', 404)),
       );
       addTearDown(cache.dispose);
+      MapOrientationMode? requestedOrientation;
 
       await tester.pumpWidget(
         MaterialApp(
@@ -142,6 +144,8 @@ void main() {
             onLeaveRide: () async {},
             onOpenRideMenu: () async {},
             perspective: RideMapPerspective.balloon,
+            mapOrientation: MapOrientationMode.northUp,
+            onMapOrientationChanged: (mode) => requestedOrientation = mode,
             distanceUnit: DistanceUnit.miles,
             localMotorcycleStyle: CraftIconStyle.fourByFour,
           ),
@@ -172,6 +176,7 @@ void main() {
           'emergency-alert-button',
           'leave-ride-button',
           'navigation-follow-button',
+          'map-orientation-toggle',
         ];
         final rects = <String, Rect>{};
         for (final key in requiredKeys) {
@@ -214,6 +219,9 @@ void main() {
       await expectUnclutteredChrome(const Size(390, 844));
 
       expect(find.byKey(const Key('balloon-altitude-card')), findsOneWidget);
+      expect(find.text('North up'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('map-orientation-toggle')));
+      expect(requestedOrientation, MapOrientationMode.directionUp);
       expect(find.byKey(const Key('ride-clock')), findsOneWidget);
       expect(
         tester.getTopLeft(find.byKey(const Key('ride-clock'))).dy,

--- a/apps/mobile/test/features/ride/recovery_map_presentation_test.dart
+++ b/apps/mobile/test/features/ride/recovery_map_presentation_test.dart
@@ -1,0 +1,29 @@
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/features/ride/active_ride_shell.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('all operational roles receive the live recovery projection', () {
+    for (final role in [
+      FlightRole.pilot,
+      FlightRole.balloonCrew,
+      FlightRole.chaseDriver,
+      FlightRole.chaseCrew,
+    ]) {
+      expect(roleShowsLiveRecoveryProjection(role), isTrue, reason: role.name);
+    }
+    expect(roleShowsLiveRecoveryProjection(FlightRole.observer), isFalse);
+    expect(roleShowsLiveRecoveryProjection(null), isFalse);
+  });
+
+  test('craft motion is rendered in metric speed and compass direction', () {
+    expect(
+      craftGroundMotionLabel(speedMetersPerSecond: 10, headingDegrees: 280),
+      '36 km/h · W 280°',
+    );
+    expect(
+      craftGroundMotionLabel(speedMetersPerSecond: null, headingDegrees: null),
+      isNull,
+    );
+  });
+}

--- a/apps/mobile/test/services/live_flight_projection_test.dart
+++ b/apps/mobile/test/services/live_flight_projection_test.dart
@@ -71,6 +71,85 @@ void main() {
     },
   );
 
+  test('forms a bounded live recovery envelope without an imported plan', () {
+    final now = DateTime.utc(2026, 8, 23, 7, 5);
+    final result = const LiveFlightProjectionEngine().evaluate(
+      plan: null,
+      balloonFix: LocationSample(
+        position: const GeoPoint(latitude: 51.5, longitude: -2.6),
+        recordedAt: now.subtract(const Duration(seconds: 5)),
+        accuracyMeters: 6,
+        altitudeMeters: 300,
+        altitudeSource: AltitudeSource.gnss,
+        altitudeDatum: AltitudeDatum.wgs84Geoid,
+      ),
+      wind: WindForecastField(
+        columns: const [
+          WindForecastColumn(
+            position: GeoPoint(latitude: 51.5, longitude: -2.6),
+            groundElevationMetersMsl: 92,
+            vectors: vectors,
+          ),
+        ],
+        validAt: now,
+        fetchedAt: now.subtract(const Duration(minutes: 3)),
+        origin: WindForecastOrigin.openMeteoUkmo,
+        sourceLabel: OpenMeteoWindProvider.sourceLabel,
+      ),
+      now: now,
+    );
+
+    expect(result.status, LiveFlightProjectionStatus.available);
+    expect(
+      result.projection?.basis,
+      LiveFlightProjectionBasis.liveRecoveryEstimate,
+    );
+    expect(result.projection?.track.first.elevationMeters, 300);
+    expect(result.projection?.landingEnvelope.length, greaterThanOrEqualTo(4));
+    expect(result.projection?.limitations, contains('20–120 minute'));
+  });
+
+  test('terrain-references Android ellipsoid movement from its first fix', () {
+    final now = DateTime.utc(2026, 8, 23, 7, 5);
+    const position = GeoPoint(latitude: 51.5, longitude: -2.6);
+    final result = const LiveFlightProjectionEngine().evaluate(
+      plan: null,
+      balloonReferenceFix: LocationSample(
+        position: position,
+        recordedAt: now.subtract(const Duration(minutes: 5)),
+        accuracyMeters: 6,
+        altitudeMeters: 150,
+        altitudeSource: AltitudeSource.gnss,
+        altitudeDatum: AltitudeDatum.wgs84Ellipsoid,
+      ),
+      balloonFix: LocationSample(
+        position: position,
+        recordedAt: now,
+        accuracyMeters: 6,
+        altitudeMeters: 350,
+        altitudeSource: AltitudeSource.gnss,
+        altitudeDatum: AltitudeDatum.wgs84Ellipsoid,
+      ),
+      wind: WindForecastField(
+        columns: const [
+          WindForecastColumn(
+            position: position,
+            groundElevationMetersMsl: 92,
+            vectors: vectors,
+          ),
+        ],
+        validAt: now,
+        fetchedAt: now,
+        origin: WindForecastOrigin.openMeteoUkmo,
+        sourceLabel: OpenMeteoWindProvider.sourceLabel,
+      ),
+      now: now,
+    );
+
+    expect(result.status, LiveFlightProjectionStatus.available);
+    expect(result.projection?.track.first.elevationMeters, 292);
+  });
+
   test('refuses stale fixes, stale wind and incompatible altitude data', () {
     final now = DateTime.utc(2026, 8, 23, 7, 5);
     final field = WindForecastField(

--- a/apps/mobile/test/services/map_orientation_preferences_test.dart
+++ b/apps/mobile/test/services/map_orientation_preferences_test.dart
@@ -1,0 +1,54 @@
+import 'package:balloon_crumbs/domain/map_orientation.dart';
+import 'package:balloon_crumbs/services/map_orientation_preferences.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test(
+    'phone balloon, phone chase and CarPlay orientations are independent',
+    () async {
+      SharedPreferences.setMockInitialValues(const {});
+      final preferences = MapOrientationPreferences(
+        await SharedPreferences.getInstance(),
+      );
+
+      expect(
+        preferences.read(
+          MapOrientationScope.phoneBalloon,
+          fallback: MapOrientationMode.northUp,
+        ),
+        MapOrientationMode.northUp,
+      );
+      await preferences.write(
+        MapOrientationScope.phoneChase,
+        MapOrientationMode.northUp,
+      );
+      await preferences.write(
+        MapOrientationScope.carPlay,
+        MapOrientationMode.directionUp,
+      );
+
+      expect(
+        preferences.read(
+          MapOrientationScope.phoneChase,
+          fallback: MapOrientationMode.directionUp,
+        ),
+        MapOrientationMode.northUp,
+      );
+      expect(
+        preferences.read(
+          MapOrientationScope.phoneBalloon,
+          fallback: MapOrientationMode.directionUp,
+        ),
+        MapOrientationMode.directionUp,
+      );
+      expect(
+        preferences.read(
+          MapOrientationScope.carPlay,
+          fallback: MapOrientationMode.northUp,
+        ),
+        MapOrientationMode.directionUp,
+      );
+    },
+  );
+}

--- a/apps/mobile/test/services/open_meteo_wind_test.dart
+++ b/apps/mobile/test/services/open_meteo_wind_test.dart
@@ -16,6 +16,7 @@ void main() {
           {
             'latitude': 51.4 + index * 0.001,
             'longitude': -2.7 + index * 0.001,
+            'elevation': 92 + index,
             'hourly': {
               'time': [
                 '2026-08-21T09:00',
@@ -55,6 +56,12 @@ void main() {
     );
     expect(field.validAt, DateTime.utc(2026, 8, 21, 10));
     expect(field.origin, WindForecastOrigin.openMeteoUkmo);
+    expect(
+      field.groundElevationAt(
+        const GeoPoint(latitude: 51.404, longitude: -2.696),
+      ),
+      96,
+    );
     final vector = field.at(
       const GeoPoint(latitude: 51.404, longitude: -2.696),
       500,

--- a/docs/road-first-recovery-map.md
+++ b/docs/road-first-recovery-map.md
@@ -1,0 +1,44 @@
+# Road-first live recovery map
+
+The active-flight map is a shared recovery picture and does not require an
+imported planner forecast. Its default basemap is the configured road map;
+aeronautical tiles remain planner-only context.
+
+## Shared live state
+
+- Every operational role receives balloon and chase positions, craft identity,
+  fix freshness, measured ground speed and direction.
+- Each device keeps its own lawful road route. Route geometry is never written
+  into the shared flight state and cannot overwrite another chaser's target.
+- Durable journal positions rebuild the complete bounded balloon and chase
+  tracks after a reconnect. Rendering simplification bounds map cost without
+  truncating the recorded history.
+- The balloon ground track is altitude-coloured. Forecast tracks and possible
+  landing envelopes use separate advisory styling and labels.
+- North-up and Direction-up are independently persisted for the balloon phone,
+  chase phone and CarPlay surface.
+
+## Live possible-landing estimate
+
+When there is no imported forecast, the app combines the latest usable balloon
+fix with the timestamped Open-Meteo UKMO wind field. It explores the published
+height levels and bounded 20–120 minute flight durations, using a 2,000 m MSL
+fallback ceiling when no planner constraints exist. This is deliberately a
+recovery estimate, not a flight plan or landing-suitability claim.
+
+On iOS, GNSS geoid altitude is used directly. Android GNSS ellipsoid movement
+is terrain-referenced against the balloon's first durable fix. If neither a
+usable altitude nor a terrain reference is available, the app explains that it
+cannot calculate the estimate.
+
+The forecast is removed rather than extrapolated when the balloon fix or wind
+field is stale, incompatible, or the flight has been marked LANDED. Its source,
+valid time and limitations are carried into the map label and recovery panel.
+
+## Driver boundary
+
+Chase drivers see the shared craft, tracks and live recovery estimate alongside
+their own road guidance. They do not receive wind-grid controls, aeronautical
+tiles, pilot controls or forecast data presented as authoritative guidance.
+Road routing continues to target a safe road-accessible rendezvous rather than
+an airborne or off-road coordinate.


### PR DESCRIPTION
Implements the phone/live-projection portion of #73.

- makes the live possible-landing estimate work without an imported plan
- exposes it to all operational flight roles, including chase drivers
- uses durable balloon altitude reference and timestamped Open-Meteo terrain/wind
- renders craft speed, direction, altitude and freshness on demand
- defaults the live map to road tiles, keeping aeronautical context out of the hierarchy
- persists separate North-up/Direction-up preferences for balloon, chase and CarPlay surfaces
- documents stale-data and safety boundaries

CarPlay rendering and physical evidence remain tracked in #15; this PR deliberately does not close #73 until that persisted CarPlay preference is wired.

Verification:
- flutter analyze
- flutter test (1,805 passed; 24 skipped)