### PR TITLE
feat: add recovery-first CarPlay navigation

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -251,11 +251,15 @@ jobs:
             echo "::error::The IPA has no applinks entitlement. Does the provisioning profile include Associated Domains?" >&2
             exit 1
           fi
+          if ! grep -q 'com.apple.developer.carplay-maps' <<<"$entitlements"; then
+            echo "::error::The IPA has no CarPlay maps entitlement. Regenerate and install the distribution profile after Apple grants the request." >&2
+            exit 1
+          fi
           if ! codesign -dv --verbose=2 "$app" 2>&1 | grep -q "Authority=Apple Distribution"; then
             echo "::error::The IPA is not signed for distribution." >&2
             exit 1
           fi
-          echo "Signed for distribution, applinks entitlement present, build $(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Info.plist")."
+          echo "Signed for distribution, applinks and CarPlay maps entitlements present, build $(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Info.plist")."
 
       - name: Upload to TestFlight
         working-directory: ${{ env.MOBILE_DIR }}

--- a/apps/mobile/ios/ExportOptions-TestFlight.plist
+++ b/apps/mobile/ios/ExportOptions-TestFlight.plist
@@ -4,12 +4,10 @@
 <dict>
   <key>method</key>
   <string>app-store-connect</string>
-  <!-- Automatic, because this app has no restricted entitlements. The
-       inherited file named a manual profile - "Hot Pursuit CarPlay Navigation
-       App Store", from two product names ago - which existed only because
-       CarPlay entitlements cannot be minted automatically. Nothing here needs
-       that, and a stale profile name fails the export with "No profile found"
-       rather than falling back to something sensible. -->
+  <!-- Automatic remains in place until Apple grants the requested CarPlay maps
+       entitlement and the regenerated Balloon Crumbs distribution profile is
+       installed. The release gate verifies the signed archive carries
+       com.apple.developer.carplay-maps before any CarPlay-capable upload. -->
   <key>signingStyle</key>
   <string>automatic</string>
   <key>teamID</key>

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -397,6 +397,10 @@ import UserNotifications
     carPlayChannel?.invokeMethod("leaveRide", arguments: nil)
   }
 
+  func toggleCarPlayMapOrientation() {
+    carPlayChannel?.invokeMethod("toggleMapOrientation", arguments: nil)
+  }
+
   /// Requests the final lifecycle transition for a ride already configured on
   /// the phone. Dart revalidates leadership, location readiness and lifecycle
   /// state because the native snapshot may have become stale before the tap.

--- a/apps/mobile/ios/Runner/CarPlaySceneDelegate.swift
+++ b/apps/mobile/ios/Runner/CarPlaySceneDelegate.swift
@@ -53,6 +53,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
   private var surfaceMode = "unavailable"
   private var canPlanRoute = false
   private var canFreeRoam = false
+  private var mapOrientation = "directionUp"
   private var submittedSearchText = ""
   private weak var interfaceController: CPInterfaceController?
   private var sceneLifecycle = CarPlaySceneLifecycle()
@@ -272,12 +273,12 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     if navigationSession == nil || routeID != activeRouteID {
       navigationSession?.cancelTrip()
       let origin = MKMapItem(placemark: MKPlacemark(coordinate: first))
-      origin.name = "Ride start"
+      origin.name = "Recovery start"
       let destination = MKMapItem(placemark: MKPlacemark(coordinate: last))
       destination.name = routeName
       let choice = CPRouteChoice(
         summaryVariants: [routeName],
-        additionalInformationVariants: ["Group motorcycle route"],
+        additionalInformationVariants: ["Recovery road route"],
         selectionSummaryVariants: [routeName]
       )
       let trip = CPTrip(origin: origin, destination: destination, routeChoices: [choice])
@@ -424,6 +425,9 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     surfaceMode = nonEmptyString(snapshot["surfaceMode"]) ?? "unavailable"
     canPlanRoute = (snapshot["canPlanRoute"] as? NSNumber)?.boolValue ?? false
     canFreeRoam = (snapshot["canFreeRoam"] as? NSNumber)?.boolValue ?? false
+    mapOrientation = snapshot["mapOrientation"] as? String == "northUp"
+      ? "northUp"
+      : "directionUp"
     guard let mapTemplate else { return }
 
     // Active-ride actions are app-owned buttons on the map canvas, matching the
@@ -431,11 +435,28 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     // blue template buttons duplicated those actions and obscured the road.
     // Route entry remains a template interaction on the stationary home map.
     var buttons: [CPMapButton] = []
-    if surfaceMode != "activeRide" {
+    if surfaceMode == "activeRide" {
+      buttons.append(mapOrientationButton())
+    } else {
       if canPlanRoute { buttons.append(planRouteButton()) }
       if canFreeRoam { buttons.append(freeRoamButton()) }
     }
     mapTemplate.mapButtons = buttons
+  }
+
+  private func mapOrientationButton() -> CPMapButton {
+    let button = CPMapButton { _ in
+      (UIApplication.shared.delegate as? AppDelegate)?.toggleCarPlayMapOrientation()
+    }
+    let northUp = mapOrientation == "northUp"
+    button.image = mapButtonImage(
+      named: northUp ? "location.north.fill" : "location.north.line.fill",
+      color: CarPlayPalette.actionInk,
+      accessibilityLabel: northUp
+        ? "North-up map. Switch to direction-up"
+        : "Direction-up map. Switch to north-up"
+    )
+    return button
   }
 
   private func planRouteButton() -> CPMapButton {
@@ -623,10 +644,10 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     let actions: [CPAlertAction]
     if surfaceMode == "home" {
       actions = [
-        CPAlertAction(title: "Ride solo", style: .default) { [weak self] _ in
+        CPAlertAction(title: "Drive solo", style: .default) { [weak self] _ in
           self?.requestDestinationPlan(destination, groupRide: false)
         },
-        CPAlertAction(title: "Create group ride", style: .default) { [weak self] _ in
+        CPAlertAction(title: "Create crew flight", style: .default) { [weak self] _ in
           self?.requestDestinationPlan(destination, groupRide: true)
         },
         CPAlertAction(title: "Cancel", style: .cancel) { _ in
@@ -644,7 +665,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
       ]
     }
     let sheet = CPActionSheetTemplate(
-      title: "Ride to \(shortLabel)?",
+      title: "Route to \(shortLabel)?",
       message: label,
       actions: actions
     )
@@ -691,7 +712,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     else { return }
     let sheet = CPActionSheetTemplate(
       title: "Start free roam?",
-      message: "Starts a solo ride with no planned route. Your track is still recorded.",
+      message: "Starts a recovery session with no planned road route. Your track is still recorded.",
       actions: [
         CPAlertAction(title: "Start free roam", style: .default) { [weak self] _ in
           interfaceController.dismissTemplate(animated: true) { _, _ in
@@ -797,10 +818,10 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     let warning = nonEmptyString(prompt["warning"])
     let message = [detail, warning].compactMap { $0 }.joined(separator: "\n\n")
     let sheet = CPActionSheetTemplate(
-      title: "Start prepared ride?",
+      title: "Start prepared flight?",
       message: message.isEmpty ? nil : message,
       actions: [
-        CPAlertAction(title: "Start ride", style: .default) { [weak self] _ in
+        CPAlertAction(title: "Start flight", style: .default) { [weak self] _ in
           interfaceController.dismissTemplate(animated: true) { _, error in
             if let error {
               NSLog("CarPlay start sheet could not be dismissed: %@", error.localizedDescription)
@@ -843,12 +864,6 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
       title: "Report to group",
       message: "Uses your current position",
       actions: [
-        CPAlertAction(title: "Speed camera", style: .default) { _ in
-          report("speedCamera")
-        },
-        CPAlertAction(title: "Police", style: .default) { _ in
-          report("policeActivity")
-        },
         CPAlertAction(title: "Road hazard", style: .default) { _ in
           report("other")
         },
@@ -900,10 +915,10 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
   private func presentLeaveConfirmation() {
     guard sceneLifecycle.rootReady, let interfaceController else { return }
     let sheet = CPActionSheetTemplate(
-      title: "Leave this ride?",
-      message: "Stops sharing this rider's position and returns the phone and CarPlay to the home map.",
+      title: "Leave this flight?",
+      message: "Stops sharing this crew device's position and returns the phone and CarPlay to the home map.",
       actions: [
-        CPAlertAction(title: "Leave ride", style: .destructive) { _ in
+        CPAlertAction(title: "Leave flight", style: .destructive) { _ in
           interfaceController.dismissTemplate(animated: true) { _, error in
             if let error {
               NSLog("CarPlay leave sheet could not be dismissed: %@", error.localizedDescription)
@@ -1003,7 +1018,7 @@ private enum CarPlayPalette {
   static let rider = UIColor(red: 0x6E / 255, green: 0xD8 / 255, blue: 0x9A / 255, alpha: 1)
   static let alerting = UIColor(red: 0xFF / 255, green: 0x5D / 255, blue: 0x73 / 255, alpha: 1)
 
-  /// The ride chrome's card fill and its label ink, from the phone's TEC card.
+  /// The recovery chrome's card fill and label ink, matching the phone.
   static let cardFill = UIColor(red: 0x25 / 255, green: 0x2E / 255, blue: 0x39 / 255, alpha: 0.90)
   static let primaryPanelFill = UIColor(
     red: 0x25 / 255,
@@ -1037,7 +1052,6 @@ private final class CarPlayNavigationViewController: UIViewController,
   MLNMapViewDelegate
 {
   private var mapView: MLNMapView?
-  private let tecBadge = CarPlayTecBadge()
   private let speedBadge = CarPlaySpeedLimitBadge()
   private let compassBadge = CarPlayCompassBadge()
   private let groupMiniMap = CarPlayGroupMiniMapView()
@@ -1046,6 +1060,7 @@ private final class CarPlayNavigationViewController: UIViewController,
   private let guidanceView = CarPlayGuidanceView()
   private let rideActionsView = CarPlayRideActionsView()
   private var routeSource: MLNShapeSource?
+  private var sharedTraceSources: [String: MLNShapeSource] = [:]
   private var routeCoordinates: [CLLocationCoordinate2D] = []
   private var routeID: String?
   private var routeProjectionKey: String?
@@ -1054,6 +1069,7 @@ private final class CarPlayNavigationViewController: UIViewController,
   private var localHeading: CLLocationDirection?
   private var followsLocalRider = true
   private var snapshotWantsRiderFollow = false
+  private var mapOrientation = "directionUp"
   private var panGestureStartCoordinate: CLLocationCoordinate2D?
   private var hasFramedFirstFix = false
   private var surfaceMode = "unavailable"
@@ -1112,8 +1128,6 @@ private final class CarPlayNavigationViewController: UIViewController,
     // CarPlay keeps the same information hierarchy as the phone in landscape:
     // route/status cards form a left column, the rider and road ahead stay
     // clear through the middle, and the speed pair remains top-trailing.
-    tecBadge.translatesAutoresizingMaskIntoConstraints = false
-    view.addSubview(tecBadge)
     speedBadge.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(speedBadge)
     compassBadge.translatesAutoresizingMaskIntoConstraints = false
@@ -1155,16 +1169,6 @@ private final class CarPlayNavigationViewController: UIViewController,
         constant: -3
       ),
       compassBadge.topAnchor.constraint(equalTo: speedBadge.topAnchor),
-      tecBadge.leadingAnchor.constraint(
-        equalTo: groupMiniMap.leadingAnchor
-      ),
-      tecBadge.trailingAnchor.constraint(
-        equalTo: groupMiniMap.trailingAnchor
-      ),
-      tecBadge.bottomAnchor.constraint(
-        equalTo: groupMiniMap.topAnchor,
-        constant: -8
-      ),
       // Scale with the head unit instead of assuming a phone-sized 196-point
       // card. The overview can never escape the left 28% status rail.
       groupMiniMap.widthAnchor.constraint(
@@ -1193,8 +1197,8 @@ private final class CarPlayNavigationViewController: UIViewController,
         equalTo: view.safeAreaLayoutGuide.topAnchor,
         constant: 12
       ),
-      // Keep all group-wide status in one left-hand reading column: journey
-      // ETA, TEC gap, then the group overview. The manoeuvre remains the only
+      // Keep group-wide status in one left-hand reading column: journey ETA,
+      // then the recovery overview. The manoeuvre remains the only
       // bottom-trailing card, leaving the rider and road ahead unobstructed.
       routeProgressView.leadingAnchor.constraint(
         equalTo: groupMiniMap.leadingAnchor
@@ -1203,7 +1207,7 @@ private final class CarPlayNavigationViewController: UIViewController,
         equalTo: groupMiniMap.trailingAnchor
       ),
       routeProgressView.bottomAnchor.constraint(
-        equalTo: tecBadge.topAnchor,
+        equalTo: groupMiniMap.topAnchor,
         constant: -8
       ),
       guidanceView.trailingAnchor.constraint(
@@ -1237,6 +1241,9 @@ private final class CarPlayNavigationViewController: UIViewController,
 
   func apply(snapshot: [String: Any]) {
     latestSnapshot = snapshot
+    mapOrientation = snapshot["mapOrientation"] as? String == "northUp"
+      ? "northUp"
+      : "directionUp"
     updateStyleURLs(snapshot["basemap"] as? [String: Any])
     guard let mapView else { return }
     surfaceMode = snapshot["surfaceMode"] as? String ?? "activeRide"
@@ -1269,6 +1276,7 @@ private final class CarPlayNavigationViewController: UIViewController,
       routeID = incomingRouteID
       routeProjectionKey = routeKey
     }
+    updateSharedTraces(snapshot["sharedTraces"])
     updateRiders(snapshot)
     if surfaceMode == "home" {
       groupMiniMap.isHidden = true
@@ -1279,7 +1287,6 @@ private final class CarPlayNavigationViewController: UIViewController,
         styleJSON: phoneStyleJSON
       )
     }
-    tecBadge.apply(snapshot["tec"] as? [String: Any])
     speedBadge.apply(snapshot["speed"] as? [String: Any])
     routeProgressView.apply(
       snapshot["journeyProgress"] as? [String: Any],
@@ -1542,7 +1549,10 @@ private final class CarPlayNavigationViewController: UIViewController,
     let adjustedZoom = phoneZoom + log2(heightRatio)
     let rawTilt = (viewport["tilt"] as? NSNumber)?.doubleValue ?? 0
     let tilt = min(60, max(0, rawTilt))
-    let bearing = (viewport["bearing"] as? NSNumber)?.doubleValue ?? 0
+    let publishedBearing = (viewport["bearing"] as? NSNumber)?.doubleValue ?? 0
+    let bearing = mapOrientation == "northUp"
+      ? 0
+      : (localHeading ?? publishedBearing)
     let riderVerticalFraction = min(
       0.8,
       max(0.35, (viewport["riderViewportFraction"] as? NSNumber)?.doubleValue ?? 0.64)
@@ -1675,6 +1685,7 @@ private final class CarPlayNavigationViewController: UIViewController,
       mapView.removeAnnotations(previousAnnotations)
     }
     routeSource = nil
+    sharedTraceSources = [:]
     riderAnnotations = []
     routeID = nil
     routeProjectionKey = nil
@@ -1683,6 +1694,106 @@ private final class CarPlayNavigationViewController: UIViewController,
   }
 
   // MARK: - Content
+
+  private func updateSharedTraces(_ raw: Any?) {
+    guard let mapView, let style = mapView.style else { return }
+    let traces = raw as? [[String: Any]] ?? []
+    var groups: [String: (color: UIColor, width: CGFloat, casing: CGFloat,
+      dash: [NSNumber]?, shapes: [MLNPolylineFeature])] = [:]
+
+    for trace in traces {
+      guard
+        let kind = trace["kind"] as? String,
+        let colorArgb = (trace["colorArgb"] as? NSNumber)?.uint32Value,
+        let width = (trace["width"] as? NSNumber)?.doubleValue,
+        let casing = (trace["casingWidth"] as? NSNumber)?.doubleValue
+      else { continue }
+      var coordinates = (trace["points"] as? [[String: Any]] ?? [])
+        .compactMap(coordinate(from:))
+      guard coordinates.count >= 2 else { continue }
+      let feature = MLNPolylineFeature(
+        coordinates: &coordinates,
+        count: UInt(coordinates.count)
+      )
+      let key = "\(kind)-\(colorArgb)"
+      let color = colorFromArgb(colorArgb)
+      if var group = groups[key] {
+        group.shapes.append(feature)
+        groups[key] = group
+      } else {
+        groups[key] = (
+          color: color,
+          width: CGFloat(width),
+          casing: CGFloat(casing),
+          dash: trace["dash"] as? [NSNumber],
+          shapes: [feature]
+        )
+      }
+    }
+
+    for (key, source) in sharedTraceSources where groups[key] == nil {
+      source.shape = nil
+    }
+    for (key, group) in groups {
+      let identifier = "balloon-crumbs-shared-\(safeStyleIdentifier(key))"
+      let source: MLNShapeSource
+      if let existing = sharedTraceSources[key] {
+        source = existing
+      } else if
+        let existing = style.source(withIdentifier: identifier) as? MLNShapeSource
+      {
+        source = existing
+        sharedTraceSources[key] = existing
+      } else {
+        let created = MLNShapeSource(identifier: identifier, shape: nil, options: nil)
+        style.addSource(created)
+        sharedTraceSources[key] = created
+        source = created
+      }
+      let casingID = "\(identifier)-casing"
+      if style.layer(withIdentifier: casingID) == nil {
+        let layer = MLNLineStyleLayer(identifier: casingID, source: source)
+        layer.lineColor = NSExpression(forConstantValue: CarPlayPalette.casing)
+        layer.lineWidth = NSExpression(forConstantValue: group.casing)
+        layer.lineCap = NSExpression(forConstantValue: "round")
+        layer.lineJoin = NSExpression(forConstantValue: "round")
+        if let dash = group.dash { layer.lineDashPattern = NSExpression(forConstantValue: dash) }
+        if let routeLayer = style.layer(withIdentifier: "balloon-crumbs-route-ahead-casing") {
+          style.insertLayer(layer, below: routeLayer)
+        } else {
+          style.addLayer(layer)
+        }
+      }
+      let lineID = "\(identifier)-line"
+      if style.layer(withIdentifier: lineID) == nil {
+        let layer = MLNLineStyleLayer(identifier: lineID, source: source)
+        layer.lineColor = NSExpression(forConstantValue: group.color)
+        layer.lineWidth = NSExpression(forConstantValue: group.width)
+        layer.lineCap = NSExpression(forConstantValue: "round")
+        layer.lineJoin = NSExpression(forConstantValue: "round")
+        if let dash = group.dash { layer.lineDashPattern = NSExpression(forConstantValue: dash) }
+        if let routeLayer = style.layer(withIdentifier: "balloon-crumbs-route-ahead-casing") {
+          style.insertLayer(layer, below: routeLayer)
+        } else {
+          style.addLayer(layer)
+        }
+      }
+      source.shape = MLNShapeCollectionFeature(shapes: group.shapes)
+    }
+  }
+
+  private func colorFromArgb(_ argb: UInt32) -> UIColor {
+    UIColor(
+      red: CGFloat((argb >> 16) & 0xFF) / 255,
+      green: CGFloat((argb >> 8) & 0xFF) / 255,
+      blue: CGFloat(argb & 0xFF) / 255,
+      alpha: CGFloat((argb >> 24) & 0xFF) / 255
+    )
+  }
+
+  private func safeStyleIdentifier(_ value: String) -> String {
+    value.unicodeScalars.map { String(format: "%02x", $0.value) }.joined()
+  }
 
   private func updateRoute(_ raw: Any?, remaining: Any?) {
     let allPoints = (raw as? [[String: Any]] ?? []).compactMap(coordinate(from:))
@@ -1708,9 +1819,9 @@ private final class CarPlayNavigationViewController: UIViewController,
   /// matching the phone navigation surface.
   private func updateRemainingRoute(_ points: [CLLocationCoordinate2D]) {
     guard let mapView, let style = mapView.style else { return }
-    let sourceIdentifier = "tailendcharlie-route-ahead-source"
-    let casingIdentifier = "tailendcharlie-route-ahead-casing"
-    let lineIdentifier = "tailendcharlie-route-ahead-line"
+    let sourceIdentifier = "balloon-crumbs-route-ahead-source"
+    let casingIdentifier = "balloon-crumbs-route-ahead-casing"
+    let lineIdentifier = "balloon-crumbs-route-ahead-line"
     let source: MLNShapeSource
     if let routeSource {
       source = routeSource
@@ -1798,14 +1909,17 @@ private final class CarPlayNavigationViewController: UIViewController,
       let isLocal = (rider["isLocal"] as? NSNumber)?.boolValue ?? false
       let annotation = CarPlayRiderAnnotation(
         coordinate: coordinate,
-        title: rider["label"] as? String ?? "Rider",
-        subtitle: rider["role"] as? String,
+        title: rider["label"] as? String ?? "Craft",
+        subtitle: (rider["detail"] as? String) ?? (rider["role"] as? String),
         isLocal: isLocal,
         isTec: (rider["isTec"] as? NSNumber)?.boolValue ?? false,
         needsAttention: (rider["needsAttention"] as? NSNumber)?.boolValue ?? false,
-        riderSymbol: rider["riderSymbol"] as? String ?? "motorcycle",
-        motorcycleStyle: rider["motorcycleStyle"] as? String ?? "adventureTourer",
-        riderColor: rider["riderColor"] as? String ?? "green"
+        riderSymbol: rider["riderSymbol"] as? String ?? "craft",
+        craftStyle: (rider["craftStyle"] as? String)
+          ?? (rider["motorcycleStyle"] as? String)
+          ?? "fourByFour",
+        riderColor: rider["riderColor"] as? String ?? "green",
+        riderColorArgb: (rider["riderColorArgb"] as? NSNumber)?.uint32Value
       )
       riderAnnotations.append(annotation)
       if isLocal {
@@ -1918,8 +2032,9 @@ private final class CarPlayRiderAnnotation: NSObject, MLNAnnotation {
   let isTec: Bool
   let needsAttention: Bool
   let riderSymbol: String
-  let motorcycleStyle: String
+  let craftStyle: String
   let riderColor: String
+  let riderColorArgb: UInt32?
 
   init(
     coordinate: CLLocationCoordinate2D,
@@ -1929,8 +2044,9 @@ private final class CarPlayRiderAnnotation: NSObject, MLNAnnotation {
     isTec: Bool,
     needsAttention: Bool,
     riderSymbol: String,
-    motorcycleStyle: String,
-    riderColor: String
+    craftStyle: String,
+    riderColor: String,
+    riderColorArgb: UInt32?
   ) {
     self.coordinate = coordinate
     self.title = title
@@ -1939,8 +2055,9 @@ private final class CarPlayRiderAnnotation: NSObject, MLNAnnotation {
     self.isTec = isTec
     self.needsAttention = needsAttention
     self.riderSymbol = riderSymbol
-    self.motorcycleStyle = motorcycleStyle
+    self.craftStyle = craftStyle
     self.riderColor = riderColor
+    self.riderColorArgb = riderColorArgb
   }
 }
 
@@ -1985,7 +2102,8 @@ private final class CarPlayRiderAnnotationView: MLNAnnotationView {
   func apply(_ rider: CarPlayRiderAnnotation) {
     frame = CGRect(x: 0, y: 0, width: 38, height: 38)
     layer.cornerRadius = 19
-    backgroundColor = identityColor(named: rider.riderColor)
+    backgroundColor = rider.riderColorArgb.map(colorFromArgb)
+      ?? identityColor(named: rider.riderColor)
     layer.borderColor = CarPlayPalette.casing.cgColor
     label.text = nil
     label.attributedText = nil
@@ -1993,6 +2111,13 @@ private final class CarPlayRiderAnnotationView: MLNAnnotationView {
     label.shadowColor = nil
     label.shadowOffset = .zero
     imageView.image = nil
+    isAccessibilityElement = true
+    accessibilityLabel = [rider.title, rider.subtitle]
+      .compactMap { value in
+        guard let value, !value.isEmpty else { return nil }
+        return value
+      }
+      .joined(separator: ". ")
 
     if let initials = initialsIdentity(
       symbol: rider.riderSymbol,
@@ -2010,7 +2135,7 @@ private final class CarPlayRiderAnnotationView: MLNAnnotationView {
       label.text = String(rider.riderSymbol.dropFirst("emoji:".count))
       label.font = .systemFont(ofSize: 21)
     } else {
-      imageView.image = motorcycleImage(for: rider.motorcycleStyle)
+      imageView.image = craftImage(for: rider.craftStyle)
     }
     setNeedsLayout()
   }
@@ -2098,32 +2223,32 @@ private final class CarPlayRiderAnnotationView: MLNAnnotationView {
     }
   }
 
-  private func motorcycleImage(for style: String) -> UIImage? {
-    let fileName = Self.motorcycleFiles[style] ?? "00_adventure_tourer"
-    let asset = "assets/icons/motorcycles/\(fileName).png"
+  private func colorFromArgb(_ argb: UInt32) -> UIColor {
+    UIColor(
+      red: CGFloat((argb >> 16) & 0xFF) / 255,
+      green: CGFloat((argb >> 8) & 0xFF) / 255,
+      blue: CGFloat(argb & 0xFF) / 255,
+      alpha: CGFloat((argb >> 24) & 0xFF) / 255
+    )
+  }
+
+  private func craftImage(for style: String) -> UIImage? {
+    let fileName = Self.craftFiles[style] ?? "1_four_by_four"
+    let asset = "assets/icons/craft/\(fileName).png"
     let key = FlutterDartProject.lookupKey(forAsset: asset)
     guard let path = Bundle.main.path(forResource: key, ofType: nil) else {
-      return UIImage(systemName: "motorcycle.fill")?.withRenderingMode(.alwaysTemplate)
+      let symbol = style == "balloon" ? "balloon.fill" : "car.fill"
+      return UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
     }
     return UIImage(contentsOfFile: path)?.withRenderingMode(.alwaysTemplate)
   }
 
-  private static let motorcycleFiles = [
-    "adventureTourer": "00_adventure_tourer",
-    "roadster": "01_roadster",
-    "dualSport": "02_dual_sport",
-    "sportNaked": "03_sport_naked",
-    "cruiserClassic": "04_cruiser_classic",
-    "standardTwin": "05_standard_twin",
-    "cafeRacer": "06_cafe_racer",
-    "dirtBike": "07_dirt_bike",
-    "fullTourer": "08_full_tourer",
-    "cruiserBagger": "09_cruiser_bagger",
-    "scrambler": "10_scrambler",
-    "sportTouring": "11_sport_touring",
-    "scooter": "12_scooter",
-    "sidecarRig": "13_sidecar_rig",
-    "streetFighter": "14_street_fighter",
+  private static let craftFiles = [
+    "balloon": "0_balloon",
+    "fourByFour": "1_four_by_four",
+    "pickup": "2_pickup",
+    "van": "3_van",
+    "trailer": "4_trailer",
   ]
 }
 
@@ -2854,69 +2979,7 @@ private final class CarPlaySpeedLimitBadge: UIView {
   }
 }
 
-/// The persistent back-marker readout on the CarPlay map canvas.
-///
-/// The ride-status list already carries the full sentence, but it is a template
-/// a rider has to navigate to. This is the version that is simply *there* while
-/// the map is up, which is the whole point on a screen nobody should be reading
-/// for more than a moment.
-///
-/// Colour is never the only signal: the trend arrow is already in the text, and
-/// the states differ in words as well as tint. Riders wear tinted visors in
-/// direct sunlight, and some cannot tell the tints apart at all.
-private final class CarPlayTecBadge: UIView {
-  private let label = UILabel()
-
-  init() {
-    super.init(frame: .zero)
-    isHidden = true
-    layer.cornerRadius = 8
-    layer.cornerCurve = .continuous
-    backgroundColor = CarPlayPalette.cardFill
-    label.translatesAutoresizingMaskIntoConstraints = false
-    label.font = .systemFont(ofSize: 15, weight: .semibold)
-    label.textColor = CarPlayPalette.cardTitle
-    label.numberOfLines = 1
-    label.adjustsFontSizeToFitWidth = true
-    label.minimumScaleFactor = 0.72
-    addSubview(label)
-    NSLayoutConstraint.activate([
-      label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
-      label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
-      label.topAnchor.constraint(equalTo: topAnchor, constant: 6),
-      label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
-    ])
-  }
-
-  @available(*, unavailable)
-  required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
-
-  func apply(_ tec: [String: Any]?) {
-    // No TEC block at all means no ride is being projected yet, which is not
-    // the same as a ride with no back-marker - that arrives with state "none"
-    // and is shown, deliberately, as "No TEC".
-    guard let tec, let headline = tec["headline"] as? String else {
-      isHidden = true
-      return
-    }
-    isHidden = false
-    label.text = headline
-    // The card keeps the app's own fill and the *ink* carries the state, for the
-    // same reason the trend is a word and an arrow rather than a colour: a
-    // tinted visor in daylight flattens these, and some riders cannot tell them
-    // apart at all. The headline already says which state it is in words.
-    switch tec["state"] as? String {
-    case "none":
-      label.textColor = CarPlayPalette.alerting
-    case "stale", "awaitingLocation":
-      label.textColor = CarPlayPalette.cardLabel
-    default:
-      label.textColor = CarPlayPalette.cardTitle
-    }
-  }
-}
-
-/// Compact route-wide timing above TEC in the left status column.
+/// Compact route-wide timing above the recovery overview.
 ///
 /// Dart owns the estimate and waypoint selection so the phone and car never
 /// disagree. Native only formats the rider's units and local clock convention.

--- a/apps/mobile/ios/Runner/CarPlayStatusTemplate.swift
+++ b/apps/mobile/ios/Runner/CarPlayStatusTemplate.swift
@@ -16,11 +16,11 @@ enum CarPlayStatusTemplate {
     let routeName = (snapshot["routeName"] as? String).flatMap {
       $0.isEmpty ? nil : $0
     }
-    let rideState = snapshot["rideState"] as? String
+    let flightState = snapshot["rideState"] as? String
     items.append(
       CPListItem(
         text: routeName ?? "No route selected",
-        detailText: rideState
+        detailText: flightState
       )
     )
 
@@ -57,19 +57,30 @@ enum CarPlayStatusTemplate {
     }
 
     if let groupStatus = snapshot["groupStatus"] as? String {
-      items.append(CPListItem(text: "Group", detailText: groupStatus))
+      items.append(CPListItem(text: "Recovery crew", detailText: groupStatus))
     }
 
-    if let riders = snapshot["riders"] as? [[String: Any]] {
-      for rider in riders.prefix(4) {
-        guard let label = rider["label"] as? String else { continue }
-        let isLocal = (rider["isLocal"] as? NSNumber)?.boolValue ?? false
-        let role = rider["role"] as? String ?? ""
-        let needsAttention = (rider["needsAttention"] as? NSNumber)?.boolValue ?? false
-        var detail = role
-        if needsAttention {
-          detail = detail.isEmpty ? "Off route" : "\(detail) · Off route"
-        }
+    if let landing = snapshot["confirmedLanding"] as? [String: Any] {
+      items.append(
+        CPListItem(
+          text: "LANDED",
+          detailText: landing["label"] as? String ?? "Confirmed landing point"
+        )
+      )
+    } else if let intended = snapshot["intendedLandingArea"] as? [String: Any] {
+      items.append(
+        CPListItem(
+          text: "Intended landing area",
+          detailText: intended["label"] as? String
+        )
+      )
+    }
+
+    if let craft = snapshot["riders"] as? [[String: Any]] {
+      for item in craft.prefix(6) {
+        guard let label = item["label"] as? String else { continue }
+        let isLocal = (item["isLocal"] as? NSNumber)?.boolValue ?? false
+        let detail = (item["detail"] as? String) ?? (item["role"] as? String) ?? ""
         items.append(
           CPListItem(
             text: isLocal ? "\(label) (you)" : label,
@@ -80,7 +91,7 @@ enum CarPlayStatusTemplate {
     }
 
     if items.isEmpty {
-      items = [CPListItem(text: "Balloon Crumbs", detailText: "Waiting for ride data…")]
+      items = [CPListItem(text: "Balloon Crumbs", detailText: "Waiting for flight data…")]
     }
 
     template.updateSections([CPListSection(items: items)])

--- a/apps/mobile/ios/Runner/DebugProfile.entitlements
+++ b/apps/mobile/ios/Runner/DebugProfile.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>applinks:balloon-crumbs.tailendcharlie.app</string>
 	</array>
+	<key>com.apple.developer.carplay-maps</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array/>
 </dict>

--- a/apps/mobile/ios/Runner/Info.plist
+++ b/apps/mobile/ios/Runner/Info.plist
@@ -110,6 +110,17 @@
 		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>
+				</dict>
+			</array>
 			<key>UIWindowSceneSessionRoleApplication</key>
 			<array>
 				<dict>

--- a/apps/mobile/ios/Runner/Release.entitlements
+++ b/apps/mobile/ios/Runner/Release.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>applinks:balloon-crumbs.tailendcharlie.app</string>
 	</array>
+	<key>com.apple.developer.carplay-maps</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array/>
 </dict>

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -1475,6 +1475,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   int _routeGeneration = 0;
   int _selectedIndex = 0;
   late MapOrientationMode _mapOrientationMode;
+  MapOrientationMode _carPlayOrientationMode = MapOrientationMode.directionUp;
   MapOrientationPreferences? _mapOrientationPreferences;
   Object? _changeRouteRequestToken;
   PickedGpxFile? _pendingSharedGpxFile;
@@ -1531,6 +1532,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         widget.rideController.session?.flightRole.isAboardBalloon == true
         ? MapOrientationMode.northUp
         : MapOrientationMode.directionUp;
+    _carPlayOrientationMode = MapOrientationMode.directionUp;
     unawaited(_loadMapOrientation());
     WidgetsBinding.instance.addObserver(this);
     // Headless and test surfaces have no audio to speak through, and must not
@@ -1617,6 +1619,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         if (!mounted) return;
         _updateMapOverlays(updateDerivedState: false);
       },
+      onMapOrientationToggleRequested: _toggleCarPlayMapOrientation,
     );
   }
 
@@ -1631,10 +1634,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     );
     final fallback = _mapOrientationMode;
     final stored = preferences.read(_mapOrientationScope, fallback: fallback);
+    final storedCarPlay = preferences.read(
+      MapOrientationScope.carPlay,
+      fallback: MapOrientationMode.directionUp,
+    );
     if (!mounted) return;
     setState(() {
       _mapOrientationPreferences = preferences;
       _mapOrientationMode = stored;
+      _carPlayOrientationMode = storedCarPlay;
     });
   }
 
@@ -1645,6 +1653,18 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (preferences != null) {
       await preferences.write(_mapOrientationScope, mode);
     }
+  }
+
+  Future<void> _toggleCarPlayMapOrientation() async {
+    final mode = _carPlayOrientationMode.toggled;
+    _carPlayOrientationMode = mode;
+    final preferences =
+        _mapOrientationPreferences ??
+        MapOrientationPreferences(await SharedPreferences.getInstance());
+    _mapOrientationPreferences ??= preferences;
+    await preferences.write(MapOrientationScope.carPlay, mode);
+    if (!mounted) return;
+    _updateMapOverlays(updateDerivedState: false);
   }
 
   /// A GPX file can arrive (via the platform's "Open in..." delivery) while
@@ -3045,6 +3065,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 : navigationPosition?.speedMetersPerSecond,
             now: DateTime.now(),
           );
+    final intendedLanding = widget.rideController.landingZone;
+    final confirmedLanding = widget.rideController.flightLanding.landing;
     unawaited(
       bridge.publish(
         session: session,
@@ -3073,6 +3095,36 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             !widget.rideController.rideStarted &&
             !widget.rideController.rideEnded &&
             !widget.rideController.busy,
+        localRider: session == null
+            ? null
+            : CarPlayLocalRider(
+                riderId: session.localRiderId,
+                displayName: session.displayName,
+                motorcycleStyle: session.flightRole.isAboardBalloon
+                    ? CraftIconStyle.balloon
+                    : session.motorcycleStyle,
+                riderSymbol: session.riderSymbol,
+                riderColor: session.riderColor,
+                roleLabel: session.flightRole.label,
+                detail: [
+                  session.flightRole.isAboardBalloon
+                      ? 'Balloon'
+                      : 'Chase vehicle',
+                  ?craftGroundMotionLabel(
+                    speedMetersPerSecond:
+                        navigationPosition?.speedMetersPerSecond,
+                    headingDegrees: navigationPosition?.headingDegrees,
+                  ),
+                  if (session.flightRole.isAboardBalloon &&
+                      navigationPosition?.altitudeMeters != null)
+                    '${navigationPosition!.altitudeMeters!.round()} m',
+                  navigationPosition == null
+                      ? 'unknown'
+                      : localSpeedIsAgeing
+                      ? 'stale'
+                      : 'live',
+                ].join(' · '),
+              ),
         basemap: selectedBasemap,
         mapStyleJson: _carPlayMapStyleJson,
         localPosition: _mapPosition.value,
@@ -3088,8 +3140,175 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         speedLimitUnlimited: widget.speedLimitDisplay.limit?.unlimited ?? false,
         routeProgress: routeProgress,
         journeyProgress: journeyProgress,
+        craftLocations: _carPlayCraftLocations(),
+        sharedTraces: _carPlaySharedTraces(),
+        intendedLandingArea: intendedLanding == null
+            ? null
+            : CarPlayLandingArea(
+                label: intendedLanding.label,
+                center: route_domain.GeoPoint(
+                  latitude: intendedLanding.center.latitude,
+                  longitude: intendedLanding.center.longitude,
+                ),
+                radiusMeters: intendedLanding.radiusMeters,
+                confirmed: false,
+              ),
+        confirmedLanding: confirmedLanding?.location == null
+            ? null
+            : CarPlayLandingArea(
+                label: 'Confirmed landing',
+                center: route_domain.GeoPoint(
+                  latitude: confirmedLanding!.location!.position.latitude,
+                  longitude: confirmedLanding.location!.position.longitude,
+                ),
+                radiusMeters: 35,
+                confirmed: true,
+              ),
+        mapOrientation: _carPlayOrientationMode,
       ),
     );
+  }
+
+  List<CarPlayCraftLocation> _carPlayCraftLocations() {
+    if (_isSimulation) {
+      return [
+        for (final craft
+            in _simulationController?.riders ??
+                const <SimulatedRiderSnapshot>[])
+          CarPlayCraftLocation(
+            id: craft.id,
+            label: craft.displayName,
+            detail: [
+              craft.role == RideRole.lead ? 'Balloon' : 'Chase vehicle',
+              ?craftGroundMotionLabel(
+                speedMetersPerSecond: craft.speedMetersPerSecond,
+                headingDegrees: craft.headingDegrees,
+              ),
+              if (craft.role == RideRole.lead && craft.altitudeMeters != null)
+                '${craft.altitudeMeters!.round()} m',
+              'bundled rehearsal · now',
+            ].join(' · '),
+            point: route_domain.GeoPoint(
+              latitude: craft.position.latitude,
+              longitude: craft.position.longitude,
+            ),
+            craftStyle: craft.role == RideRole.lead
+                ? CraftIconStyle.balloon
+                : craft.motorcycleStyle,
+            riderSymbol: craft.role == RideRole.lead
+                ? riderSymbolDefault
+                : craft.riderSymbol,
+            colorArgb: craft.riderColor.color.toARGB32(),
+            headingDegrees: craft.headingDegrees,
+          ),
+      ];
+    }
+    final session = widget.rideController.session;
+    if (session == null) return const [];
+    final freshness = {
+      for (final presence in _reconciledLivePresence())
+        presence.riderId: presence,
+    };
+    final roster = widget.rideController.resolveCraftRoster();
+    return [
+      for (final craft in _productionCraftMapLocations(
+        roster,
+        localRiderId: session.localRiderId,
+      ))
+        CarPlayCraftLocation(
+          id: craft.id,
+          label: craft.displayName,
+          detail: [
+            craft.isBalloon ? 'Balloon' : 'Chase vehicle',
+            ?craftGroundMotionLabel(
+              speedMetersPerSecond: craft.speedMetersPerSecond,
+              headingDegrees: craft.headingDegrees,
+            ),
+            if (craft.isBalloon && craft.altitudeMeters != null)
+              '${craft.altitudeMeters!.round()} m',
+            freshness[craft.freshnessDeviceId]?.freshnessLabel ?? 'unknown',
+          ].join(' · '),
+          point: craft.point,
+          craftStyle: craft.motorcycleStyle,
+          riderSymbol: craft.riderSymbol,
+          colorArgb: craft.riderColor.color.toARGB32(),
+          headingDegrees: craft.headingDegrees,
+        ),
+    ];
+  }
+
+  List<CarPlayMapTrace> _carPlaySharedTraces() {
+    final projected = <CarPlayMapTrace>[];
+    final intended = widget.rideController.landingZone;
+    final landed = widget.rideController.flightLanding.landing;
+    final traces = <MapOverlayTrace>[
+      ..._riderTrails.value,
+      if (intended != null)
+        MapOverlayTrace(
+          id: 'carplay-intended-landing-area',
+          points: MapLandingZone(
+            center: route_domain.GeoPoint(
+              latitude: intended.center.latitude,
+              longitude: intended.center.longitude,
+            ),
+            label: intended.label,
+            radiusMeters: intended.radiusMeters,
+          ).boundary,
+          label:
+              '${intended.label} · intended area; access and suitability unverified',
+          kind: RiderTrailKind.liveLandingEnvelope,
+        ),
+      if (landed?.location != null)
+        MapOverlayTrace(
+          id: 'carplay-confirmed-landing',
+          points: MapLandingZone(
+            center: route_domain.GeoPoint(
+              latitude: landed!.location!.position.latitude,
+              longitude: landed.location!.position.longitude,
+            ),
+            label: 'Confirmed landing',
+            radiusMeters: 35,
+          ).boundary,
+          label: 'Confirmed landing point',
+          kind: RiderTrailKind.operationalBoundary,
+          color: const Color(0xFF72D5A4),
+        ),
+    ];
+    for (final trace in traces) {
+      final style = trace.style;
+      final altitudeStyled =
+          trace.kind == RiderTrailKind.balloonGroundTrack ||
+          trace.kind == RiderTrailKind.forecastTrack ||
+          trace.kind == RiderTrailKind.liveProjectionTrack;
+      final parts = altitudeStyled
+          ? [
+              for (final (index, segment) in BalloonAltitudeStyle.segments(
+                trace.points,
+              ).indexed)
+                (
+                  id: '${trace.id}-altitude-$index',
+                  points: segment.points,
+                  color: segment.color,
+                ),
+            ]
+          : [(id: trace.id, points: trace.points, color: trace.effectiveColor)];
+      for (final part in parts) {
+        if (part.points.length < 2) continue;
+        projected.add(
+          CarPlayMapTrace(
+            id: part.id,
+            kind: trace.kind.name,
+            label: trace.label,
+            points: part.points,
+            colorArgb: part.color.toARGB32(),
+            width: style.widthPixels,
+            casingWidth: style.casingWidthPixels,
+            dash: style.maplibreDashArray,
+          ),
+        );
+      }
+    }
+    return List.unmodifiable(projected);
   }
 
   Future<List<CarPlayDestination>> _searchCarPlayDestinations(

--- a/apps/mobile/lib/services/carplay_bridge.dart
+++ b/apps/mobile/lib/services/carplay_bridge.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import '../domain/hazard.dart';
 import '../domain/imported_route.dart';
 import '../domain/distance_unit.dart';
+import '../domain/map_orientation.dart';
 import '../domain/rider_color.dart';
 import '../domain/ride_role.dart';
 import '../domain/ride_session.dart';
@@ -18,6 +19,107 @@ import 'route_progress.dart';
 import 'route_journey_progress.dart';
 
 enum CarPlaySurfaceMode { home, preRide, activeRide, endedRide }
+
+class CarPlayCraftLocation {
+  const CarPlayCraftLocation({
+    required this.id,
+    required this.label,
+    required this.detail,
+    required this.point,
+    required this.craftStyle,
+    required this.riderSymbol,
+    required this.colorArgb,
+    this.headingDegrees,
+  });
+
+  final String id;
+  final String label;
+  final String detail;
+  final GeoPoint point;
+  final CraftIconStyle craftStyle;
+  final RiderSymbol riderSymbol;
+  final int colorArgb;
+  final double? headingDegrees;
+
+  Map<String, Object?> toSnapshot() => {
+    'riderId': id,
+    'label': label,
+    'detail': detail,
+    'isLocal': false,
+    'role': detail,
+    'riderSymbol': riderSymbol.storageValue,
+    'craftStyle': craftStyle.name,
+    // Retained for one additive compatibility release. New native surfaces
+    // read craftStyle; older builds still degrade to their known key.
+    'motorcycleStyle': craftStyle.name,
+    'riderColorArgb': colorArgb,
+    'latitude': point.latitude,
+    'longitude': point.longitude,
+    'headingDegrees': headingDegrees,
+  };
+}
+
+class CarPlayMapTrace {
+  const CarPlayMapTrace({
+    required this.id,
+    required this.kind,
+    required this.label,
+    required this.points,
+    required this.colorArgb,
+    required this.width,
+    required this.casingWidth,
+    this.dash,
+  });
+
+  final String id;
+  final String kind;
+  final String label;
+  final List<GeoPoint> points;
+  final int colorArgb;
+  final double width;
+  final double casingWidth;
+  final List<double>? dash;
+
+  Map<String, Object?> toSnapshot() => {
+    'id': id,
+    'kind': kind,
+    'label': label,
+    'points': [
+      for (final point in points)
+        {
+          'latitude': point.latitude,
+          'longitude': point.longitude,
+          'altitudeMeters': point.elevationMeters,
+        },
+    ],
+    'colorArgb': colorArgb,
+    'width': width,
+    'casingWidth': casingWidth,
+    if (dash != null) 'dash': dash,
+  };
+}
+
+class CarPlayLandingArea {
+  const CarPlayLandingArea({
+    required this.label,
+    required this.center,
+    required this.radiusMeters,
+    required this.confirmed,
+  });
+
+  final String label;
+  final GeoPoint center;
+  final double radiusMeters;
+  final bool confirmed;
+
+  Map<String, Object?> toSnapshot() => {
+    'label': label,
+    'latitude': center.latitude,
+    'longitude': center.longitude,
+    'radiusMeters': radiusMeters,
+    'confirmed': confirmed,
+  };
+}
 
 /// A submitted CarPlay search result. Coordinates are carried with the label so
 /// choosing the second of several places with the same name cannot silently
@@ -73,6 +175,7 @@ class CarPlayLocalRider {
     required this.riderSymbol,
     required this.riderColor,
     this.roleLabel = 'Chaser',
+    this.detail,
   });
 
   final String riderId;
@@ -81,6 +184,7 @@ class CarPlayLocalRider {
   final RiderSymbol riderSymbol;
   final RiderColor riderColor;
   final String roleLabel;
+  final String? detail;
 }
 
 String _readableCarPlayError(Object error, {required String fallback}) =>
@@ -114,6 +218,7 @@ class CarPlayBridge {
     this.onDestinationSelected,
     this.onFreeRoamRequested,
     this.onStateRequested,
+    this.onMapOrientationToggleRequested,
     @visibleForTesting MethodChannel? channel,
     @visibleForTesting DateTime Function()? clock,
     @visibleForTesting
@@ -172,6 +277,9 @@ class CarPlayBridge {
   /// as an explicit read request prevents CarPlay opening with an earlier empty
   /// roster or world-sized camera.
   final Future<void> Function()? onStateRequested;
+
+  /// Persists a CarPlay-only camera choice on the phone, then republishes it.
+  final Future<void> Function()? onMapOrientationToggleRequested;
   DateTime? _lastPublishedAt;
 
   String? _publishedRideStartKey;
@@ -298,6 +406,9 @@ class CarPlayBridge {
           _publishedMapStyleJson = null;
           await publishViewport(viewport);
         }
+      case 'toggleMapOrientation':
+        _lastPublishedAt = null;
+        await onMapOrientationToggleRequested?.call();
     }
   }
 
@@ -332,6 +443,11 @@ class CarPlayBridge {
     bool localSpeedIsAgeing = false,
     RouteProgressGeometry? routeProgress,
     RouteJourneyProgress? journeyProgress,
+    List<CarPlayCraftLocation> craftLocations = const [],
+    List<CarPlayMapTrace> sharedTraces = const [],
+    CarPlayLandingArea? intendedLandingArea,
+    CarPlayLandingArea? confirmedLanding,
+    MapOrientationMode mapOrientation = MapOrientationMode.directionUp,
   }) async {
     final now = _clock();
     // A question addressed to this rider is an event, not a state refresh. It
@@ -390,6 +506,10 @@ class CarPlayBridge {
       ),
       'distanceUnit': distanceUnit?.name,
       'groupStatus': groupStatus,
+      'mapOrientation': mapOrientation.name,
+      'sharedTraces': [for (final trace in sharedTraces) trace.toSnapshot()],
+      'intendedLandingArea': intendedLandingArea?.toSnapshot(),
+      'confirmedLanding': confirmedLanding?.toSnapshot(),
       'rideStart': rideStart?.toSnapshot(),
       'speed': !speedLimitEnabled
           ? null
@@ -428,9 +548,12 @@ class CarPlayBridge {
           'label': localRider?.displayName ?? session!.displayName,
           'isLocal': true,
           'role': localRider?.roleLabel ?? session!.role.label,
+          'detail': localRider?.detail,
           'riderSymbol':
               localRider?.riderSymbol.storageValue ??
               session!.riderSymbol.storageValue,
+          'craftStyle':
+              localRider?.motorcycleStyle.name ?? session!.motorcycleStyle.name,
           'motorcycleStyle':
               localRider?.motorcycleStyle.name ?? session!.motorcycleStyle.name,
           'riderColor': localRider?.riderColor.name ?? session!.riderColor.name,
@@ -439,26 +562,30 @@ class CarPlayBridge {
           'headingDegrees': localHeadingDegrees,
         },
       'updatedAtMillis': now.millisecondsSinceEpoch,
-      'riders': [
-        for (final location in riderLocations)
-          {
-            'riderId': location.riderId,
-            'label': location.displayName,
-            'isLocal':
-                session != null && location.riderId == session.localRiderId,
-            'role': location.role.label,
-            // Project the same identity the rider chose on the phone. CarPlay
-            // used to replace the local rider with a blue "You" pill and every
-            // peer with a role-coloured initial, so the two screens described
-            // the same group with different people.
-            'riderSymbol': location.riderSymbol.storageValue,
-            'motorcycleStyle': location.motorcycleStyle.name,
-            'riderColor': location.riderColor.name,
-            'latitude': location.sample.position.latitude,
-            'longitude': location.sample.position.longitude,
-            'headingDegrees': location.sample.headingDegrees,
-          },
-      ],
+      'riders': craftLocations.isNotEmpty
+          ? [for (final location in craftLocations) location.toSnapshot()]
+          : [
+              for (final location in riderLocations)
+                {
+                  'riderId': location.riderId,
+                  'label': location.displayName,
+                  'isLocal':
+                      session != null &&
+                      location.riderId == session.localRiderId,
+                  'role': location.role.label,
+                  // Project the same identity the rider chose on the phone. CarPlay
+                  // used to replace the local rider with a blue "You" pill and every
+                  // peer with a role-coloured initial, so the two screens described
+                  // the same group with different people.
+                  'riderSymbol': location.riderSymbol.storageValue,
+                  'craftStyle': location.motorcycleStyle.name,
+                  'motorcycleStyle': location.motorcycleStyle.name,
+                  'riderColor': location.riderColor.name,
+                  'latitude': location.sample.position.latitude,
+                  'longitude': location.sample.position.longitude,
+                  'headingDegrees': location.sample.headingDegrees,
+                },
+            ],
       'alert': _topHazardMessage(activeHazards),
     };
     try {

--- a/apps/mobile/test/features/carplay/carplay_entitlement_contract_test.dart
+++ b/apps/mobile/test/features/carplay/carplay_entitlement_contract_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'every signed iOS configuration requests the CarPlay maps entitlement',
+    () {
+      for (final path in [
+        'ios/Runner/DebugProfile.entitlements',
+        'ios/Runner/Release.entitlements',
+      ]) {
+        final source = File(path).readAsStringSync();
+        expect(
+          source,
+          contains('<key>com.apple.developer.carplay-maps</key>'),
+          reason: path,
+        );
+        expect(source, contains('<true/>'), reason: path);
+      }
+    },
+  );
+
+  test('Info.plist registers the CarPlay navigation scene', () {
+    final source = File('ios/Runner/Info.plist').readAsStringSync();
+    expect(
+      source,
+      contains('<key>CPTemplateApplicationSceneSessionRoleApplication</key>'),
+    );
+    expect(source, contains('<string>CPTemplateApplicationScene</string>'));
+    expect(
+      source,
+      contains('<string>\$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>'),
+    );
+  });
+
+  test(
+    'both distribution paths reject an IPA without the granted entitlement',
+    () {
+      final workflow = File(
+        '../../.github/workflows/testflight.yml',
+      ).readAsStringSync();
+      final localUpload = File(
+        '../../tools/testflight/build-and-upload.sh',
+      ).readAsStringSync();
+      expect(workflow, contains('com.apple.developer.carplay-maps'));
+      expect(workflow, contains('The IPA has no CarPlay maps entitlement'));
+      expect(localUpload, contains('com.apple.developer.carplay-maps'));
+      expect(localUpload, contains('signed IPA is missing'));
+    },
+  );
+}

--- a/apps/mobile/test/features/carplay/carplay_layout_test.dart
+++ b/apps/mobile/test/features/carplay/carplay_layout_test.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// #442 and #533's CarPlay layout faults, asserted where they live.
+/// CarPlay's recovery layout contracts, asserted where they live.
 ///
 /// A head unit is not reachable from a test here, so these read the Swift the
 /// same way the #439 reachability check reads Dart: what broke is *placement*,
@@ -12,24 +12,25 @@ void main() {
     'ios/Runner/CarPlaySceneDelegate.swift',
   ).readAsStringSync();
 
-  group('the speed pair stays trailing while status moves left (#533)', () {
-    test('the TEC message joins the left status column', () {
+  group('the speed pair stays trailing while recovery status stays left', () {
+    test('the recovery overview is not displaced by inherited branding', () {
+      expect(source, isNot(contains('tecBadge')));
+      expect(source, isNot(contains('CarPlayTecBadge')));
+      expect(source, isNot(contains('NO RIDE LEADER')));
       expect(
         source,
         contains(
-          'tecBadge.leadingAnchor.constraint(\n'
-          '        equalTo: groupMiniMap.leadingAnchor',
+          'groupMiniMap.leadingAnchor.constraint(\n'
+          '        equalTo: view.safeAreaLayoutGuide.leadingAnchor',
         ),
       );
       expect(
         source,
         contains(
-          'tecBadge.trailingAnchor.constraint(\n'
-          '        equalTo: groupMiniMap.trailingAnchor',
+          'routeProgressView.bottomAnchor.constraint(\n'
+          '        equalTo: groupMiniMap.topAnchor',
         ),
       );
-      expect(source, contains('tecBadge.bottomAnchor.constraint('));
-      expect(source, contains('equalTo: groupMiniMap.topAnchor'));
       expect(source, isNot(contains('equalTo: speedBadge.bottomAnchor')));
     });
 
@@ -117,7 +118,7 @@ void main() {
       expect(source, isNot(contains('clockLabel.bottomAnchor.constraint(')));
     });
 
-    test('route progress sits above TEC in the left status stack', () {
+    test('route progress sits directly above the recovery overview', () {
       expect(source, contains('routeProgressView.leadingAnchor.constraint('));
       expect(source, contains('routeProgressView.trailingAnchor.constraint('));
       expect(source, contains('routeProgressView.bottomAnchor.constraint('));
@@ -148,7 +149,7 @@ void main() {
         source,
         contains(
           'routeProgressView.bottomAnchor.constraint(\n'
-          '        equalTo: tecBadge.topAnchor',
+          '        equalTo: groupMiniMap.topAnchor',
         ),
       );
       expect(source, contains('private final class CarPlayGuidanceView'));

--- a/apps/mobile/test/services/carplay_bridge_test.dart
+++ b/apps/mobile/test/services/carplay_bridge_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/domain/distance_unit.dart';
 import 'package:balloon_crumbs/domain/hazard.dart';
+import 'package:balloon_crumbs/domain/map_orientation.dart';
 import 'package:balloon_crumbs/domain/ride_role.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart' as presence;
@@ -80,6 +81,10 @@ void main() {
       'guidanceSecondsRemaining': null,
       'distanceUnit': null,
       'groupStatus': '5 riders visible',
+      'mapOrientation': 'directionUp',
+      'sharedTraces': <Object?>[],
+      'intendedLandingArea': null,
+      'confirmedLanding': null,
       'rideStart': null,
       'speed': null,
       'basemap': null,
@@ -118,6 +123,84 @@ void main() {
     });
   });
 
+  test('publishes recovery craft, shared tracks and landing areas', () async {
+    MethodCall? received;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      received = call;
+      return null;
+    });
+    final bridge = CarPlayBridge(channel: channel);
+    addTearDown(bridge.dispose);
+
+    await bridge.publish(
+      session: null,
+      riderLocations: const [],
+      activeHazards: const [],
+      mapOrientation: MapOrientationMode.northUp,
+      craftLocations: const [
+        CarPlayCraftLocation(
+          id: 'balloon',
+          label: 'Balloon',
+          detail: 'Live now · 18 km/h NE · 420 m MSL',
+          point: GeoPoint(latitude: 51.45, longitude: -2.58),
+          craftStyle: CraftIconStyle.balloon,
+          riderSymbol: RiderSymbol.emoji('🎈'),
+          colorArgb: 0xff43d98c,
+          headingDegrees: 45,
+        ),
+      ],
+      sharedTraces: const [
+        CarPlayMapTrace(
+          id: 'balloon-track-0',
+          kind: 'balloonTrack',
+          label: 'Balloon track · 300–600 m',
+          points: [
+            GeoPoint(latitude: 51.45, longitude: -2.58, elevationMeters: 300),
+            GeoPoint(latitude: 51.46, longitude: -2.57, elevationMeters: 600),
+          ],
+          colorArgb: 0xff64e572,
+          width: 6,
+          casingWidth: 9,
+          dash: [2, 1],
+        ),
+      ],
+      intendedLandingArea: const CarPlayLandingArea(
+        label: 'Intended landing area',
+        center: GeoPoint(latitude: 51.48, longitude: -2.54),
+        radiusMeters: 250,
+        confirmed: false,
+      ),
+      confirmedLanding: const CarPlayLandingArea(
+        label: 'Confirmed landing',
+        center: GeoPoint(latitude: 51.49, longitude: -2.53),
+        radiusMeters: 35,
+        confirmed: true,
+      ),
+    );
+
+    final snapshot = received!.arguments as Map;
+    expect(snapshot['mapOrientation'], 'northUp');
+    expect(snapshot['riders'], hasLength(1));
+    expect(
+      (snapshot['riders'] as List).single,
+      containsPair('craftStyle', 'balloon'),
+    );
+    expect(
+      (snapshot['riders'] as List).single,
+      containsPair('detail', contains('Live now')),
+    );
+    expect(snapshot['sharedTraces'], hasLength(1));
+    expect(
+      ((snapshot['sharedTraces'] as List).single as Map)['points'],
+      hasLength(2),
+    );
+    expect(
+      snapshot['intendedLandingArea'],
+      containsPair('radiusMeters', 250.0),
+    );
+    expect(snapshot['confirmedLanding'], containsPair('confirmed', isTrue));
+  });
+
   test('projects the phone home map and saved rider identity', () async {
     MethodCall? received;
     messenger.setMockMethodCallHandler(channel, (call) async {
@@ -142,6 +225,7 @@ void main() {
         motorcycleStyle: CraftIconStyle.van,
         riderSymbol: RiderSymbol.emoji('🦊'),
         riderColor: RiderColor.purple,
+        detail: 'Chase vehicle · 42 km/h · live',
       ),
     );
 
@@ -154,7 +238,9 @@ void main() {
       'label': 'Oliver',
       'isLocal': true,
       'role': 'Chaser',
+      'detail': 'Chase vehicle · 42 km/h · live',
       'riderSymbol': 'emoji:🦊',
+      'craftStyle': 'van',
       'motorcycleStyle': 'van',
       'riderColor': 'purple',
       'latitude': 51.46,
@@ -602,7 +688,9 @@ void main() {
         'label': 'Oliver Holt',
         'isLocal': true,
         'role': 'Pilot',
+        'detail': null,
         'riderSymbol': 'initials',
+        'craftStyle': 'fourByFour',
         'motorcycleStyle': 'fourByFour',
         'riderColor': 'orange',
         'latitude': 51.45,
@@ -765,6 +853,25 @@ void main() {
     );
 
     expect(starts, 1);
+  });
+
+  test('relays the CarPlay map-orientation toggle to the phone', () async {
+    var toggles = 0;
+    final bridge = CarPlayBridge(
+      channel: channel,
+      onMapOrientationToggleRequested: () async {
+        toggles += 1;
+      },
+    );
+    addTearDown(bridge.dispose);
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      channel.codec.encodeMethodCall(const MethodCall('toggleMapOrientation')),
+      (_) {},
+    );
+
+    expect(toggles, 1);
   });
 
   test('relays a CarPlay-confirmed leave request to the ride owner', () async {

--- a/docs/carplay-entitlement.md
+++ b/docs/carplay-entitlement.md
@@ -1,0 +1,83 @@
+# CarPlay navigation entitlement and acceptance
+
+Status: implementation complete; Apple managed-capability grant and physical
+vehicle acceptance pending (2026-08-23).
+
+## Requested capability
+
+- App: Balloon Crumbs
+- Bundle ID: `dev.osholt.ballooncrumbs`
+- Category: navigation
+- Entitlement: `com.apple.developer.carplay-maps`
+- Apple request: <https://developer.apple.com/contact/request/carplay/>
+
+Request description:
+
+> Balloon Crumbs is an account-free, offline-first hot-air-balloon recovery
+> coordination app. It shares one balloon's and its private chase crew's live
+> positions, recent tracks, fix freshness, intended or confirmed landing area,
+> and a safe road-accessible rendezvous. CarPlay is the chase driver's primary
+> low-interaction surface. Planning, weather detail, pilot controls and personal
+> land-access notes remain on the phone.
+
+CarPlay behaviour:
+
+> The navigation scene presents a two-dimensional road map with the local chase
+> vehicle, balloon, other chase vehicles, shared trails, fix age/state, intended
+> landing area, confirmed landing point and forecast landing envelope. It gives
+> lawful road guidance, manoeuvre distance, ETA, spoken instructions and dynamic
+> rerouting to either the current safe rendezvous near the balloon or the crew's
+> published landing target. Drivers have one-tap Follow and North-up/Direction-up
+> controls and bounded CarPlay-template actions. It never routes directly
+> off-road, presents aviation/weather controls, or asks the pilot to operate it.
+
+Submitting the request also requires the account holder to accept Apple's
+CarPlay Entitlement Addendum. Keep the final submission with the account holder;
+do not automate acceptance of that agreement.
+
+## Repository and signing gates
+
+- Debug, profile and release targets declare the maps entitlement.
+- `Info.plist` registers `CarPlaySceneDelegate` for the CarPlay template scene.
+- The TestFlight workflow and local uploader inspect the signed IPA with
+  `codesign` and refuse upload without the granted maps entitlement.
+- After Apple grants the capability, regenerate both development and App Store
+  provisioning profiles for the Balloon Crumbs App ID. Never reuse the inherited
+  Tail End Charlie or Hot Pursuit profile.
+
+## Implemented driver surface
+
+- MapLibre road basemap using the phone's resolved light/dark style.
+- One balloon plus independent chase vehicles with explicit craft icons,
+  heading, ground speed, altitude where applicable, and `live`, `stale` or
+  `unknown` detail.
+- Balloon trace split into the same altitude-coloured segments as the phone and
+  web planner; recent vehicle traces remain separately identifiable.
+- Intended landing envelope and confirmed landing area.
+- Persisted North-up/Direction-up camera toggle and Follow control.
+- Road route, remaining/ridden geometry, manoeuvre, distance, ETA and rerouting.
+- Recovery-specific status/actions with inherited TEC leader/rider branding
+  removed.
+- Speed-limit presentation remains gated to the chase-driver role.
+
+## Acceptance matrix
+
+| Evidence | Status | Requirement |
+| --- | --- | --- |
+| Flutter analysis and focused projection tests | Pass | No Dart/static failures; snapshot contract covered |
+| Native iOS simulator build | Pass | Swift scene and MapLibre renderer compile |
+| iOS 17.5 CarPlay Home | Pass | Balloon Crumbs appears with the navigation entitlement |
+| Signed development archive | Pending grant | Embedded profile and app signature contain maps entitlement |
+| Signed TestFlight IPA | Pending grant | CI's entitlement gate passes before upload |
+| Minimum 748x456, standard 800x480, portrait 768x1024, high-res 1920x720 | Pending final visual run | No clipped controls or hidden attribution |
+| Locked iPhone | Physical test required | Recovery map and guidance continue while phone is locked |
+| Wired and wireless CarPlay | Physical test required | Connect/reconnect, voice/audio ducking and reroutes work |
+| North-up/Direction-up, Follow, landing target and balloon target | Physical test required | Controls remain bounded and responsive in motion |
+| Full launch-to-LANDED-to-recovery rehearsal | Physical test required | No phone interaction is required from the driver |
+
+Apple explicitly says Simulator is not sufficient for locked-phone, Siri or
+audio behaviour, so physical evidence is a release gate. On Xcode 26.5's iOS
+26.5 runtime, Apple's `CarPlayTemplateUIHost` currently aborts while evaluating
+destination sharing (`vehicleSupportsDestinationSharing`). That is an Apple
+host-process regression, not a Runner crash; the iOS 17.5 runtime is retained
+for projected-display visual testing until the runtime is fixed.

--- a/docs/testflight.md
+++ b/docs/testflight.md
@@ -58,17 +58,20 @@ and internal testers re-added by hand — build history does not follow.
 
 The inherited `ios/ExportOptions-TestFlight.plist` used **manual** signing and
 named the profile `Hot Pursuit CarPlay Navigation App Store` — a product name
-from two renames ago. Manual signing existed for one reason: CarPlay
-entitlements are restricted, and automatic signing will not mint a profile
-carrying them.
+from two renames ago. Manual signing existed because CarPlay entitlements are
+restricted, but the inherited profile was tied to an unrelated App ID and
+product name. Balloon Crumbs now requests `com.apple.developer.carplay-maps` for
+its recovery-driver surface; see
+[carplay-entitlement.md](carplay-entitlement.md).
 
-Balloon Crumbs declares no CarPlay entitlements, so that constraint is gone with
-the surfaces it belonged to (CarPlay for the chase driver is #15, still an
-evaluation). Automatic signing now applies, which means no certificate to
-export, no profile to download, no name to keep synchronised across three files,
-and nothing secret in the repository. A stale profile name is not a soft
-failure: the export dies with "No profile found", which is what that file would
-have done on its first use.
+Local development stays on automatic signing. After Apple grants the managed
+capability, Xcode can create a development profile containing it for the
+registered Balloon Crumbs App ID. CI remains explicit: import a freshly
+generated App Store distribution profile for `dev.osholt.ballooncrumbs` and let
+the workflow discover its installed name. Both release paths inspect the signed
+IPA and fail before upload when the CarPlay maps entitlement is absent. A stale
+or pre-grant profile is therefore a hard, visible failure rather than a tester
+build that silently loses CarPlay.
 
 `Release` also pinned `CODE_SIGN_IDENTITY = "Apple Development"`. A development
 certificate cannot sign an App Store archive, so the first archive would have

--- a/tools/testflight/build-and-upload.sh
+++ b/tools/testflight/build-and-upload.sh
@@ -120,6 +120,17 @@ if [ -z "$ipa" ]; then
 fi
 echo "Built $ipa (version $BALLOON_CRUMBS_APP_VERSION build $BALLOON_CRUMBS_APP_BUILD)."
 
+entitlement_work="$(mktemp -d)"
+trap 'rm -rf "$entitlement_work"' EXIT
+unzip -q "$ipa" -d "$entitlement_work"
+app="$(find "$entitlement_work/Payload" -maxdepth 1 -type d -name '*.app' -print -quit)"
+entitlements="$(codesign -d --entitlements :- "$app" 2>/dev/null)"
+if ! grep -q 'com.apple.developer.carplay-maps' <<<"$entitlements"; then
+  echo "build-and-upload: signed IPA is missing com.apple.developer.carplay-maps." >&2
+  echo "  Wait for Apple's grant, regenerate the App Store profile, and build again." >&2
+  exit 1
+fi
+
 if [ "$upload" = false ]; then
   echo "Skipping upload as asked."
   exit 0


### PR DESCRIPTION
## Summary
- restore the CarPlay navigation scene for live balloon recovery
- project balloon/chaser craft, altitude-coloured trails, landing areas, route progress and freshness
- persist North-up/Direction-up and enforce signed-IPA CarPlay entitlement gates
- document the Apple entitlement request and physical acceptance matrix

Relates to #15 and #73. These issues remain open until Apple grants the capability and physical head-unit acceptance is complete.

## Verification
- `flutter analyze`
- `flutter test` (1810 passed, 24 skipped)
- `flutter build ios --simulator --debug`
- iOS 17.5 CarPlay Home entitlement discovery
