### PR TITLE
fix: keep OpenAIP in the optional planner only

### DIFF
--- a/.github/workflows/android-internal.yml
+++ b/.github/workflows/android-internal.yml
@@ -114,7 +114,6 @@ jobs:
         env:
           TESTER_NOTES_URL: https://github.com/${{ github.repository }}/blob/${{ github.sha }}/docs/tester-release-notes.md
           BALLOON_CRUMBS_API_BASE_URL: ${{ vars.BALLOON_CRUMBS_API_BASE_URL }}
-          BALLOON_CRUMBS_OPENAIP_API_KEY: ${{ secrets.BALLOON_CRUMBS_OPENAIP_API_KEY }}
           BALLOON_CRUMBS_FIREBASE_API_KEY: ${{ vars.BALLOON_CRUMBS_FIREBASE_API_KEY }}
           BALLOON_CRUMBS_FIREBASE_PROJECT_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_PROJECT_ID }}
           BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.BALLOON_CRUMBS_FIREBASE_MESSAGING_SENDER_ID }}
@@ -132,10 +131,6 @@ jobs:
               exit 1
               ;;
           esac
-          if test -z "${BALLOON_CRUMBS_OPENAIP_API_KEY:-}"; then
-            echo "::error::Missing BALLOON_CRUMBS_OPENAIP_API_KEY; tester releases must include the selected advisory airspace layer." >&2
-            exit 1
-          fi
           push_enabled=false
           if test -n "${BALLOON_CRUMBS_FIREBASE_API_KEY:-}" \
             && test -n "${BALLOON_CRUMBS_FIREBASE_PROJECT_ID:-}" \
@@ -153,7 +148,6 @@ jobs:
             --dart-define=BALLOON_CRUMBS_BUILD_TIMESTAMP="$BALLOON_CRUMBS_BUILD_TIMESTAMP" \
             --dart-define=BALLOON_CRUMBS_TESTER_NOTES_URL="$TESTER_NOTES_URL" \
             --dart-define=BALLOON_CRUMBS_API_BASE_URL="${BALLOON_CRUMBS_API_BASE_URL:-}" \
-            --dart-define=BALLOON_CRUMBS_OPENAIP_API_KEY="$BALLOON_CRUMBS_OPENAIP_API_KEY" \
             --dart-define=BALLOON_CRUMBS_PUSH_ENABLED="$push_enabled" \
             --dart-define=BALLOON_CRUMBS_FIREBASE_API_KEY="${BALLOON_CRUMBS_FIREBASE_API_KEY:-}" \
             --dart-define=BALLOON_CRUMBS_FIREBASE_PROJECT_ID="${BALLOON_CRUMBS_FIREBASE_PROJECT_ID:-}" \

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -163,7 +163,6 @@ jobs:
         working-directory: ${{ env.MOBILE_DIR }}
         env:
           BALLOON_CRUMBS_API_BASE_URL: ${{ vars.BALLOON_CRUMBS_API_BASE_URL }}
-          BALLOON_CRUMBS_OPENAIP_API_KEY: ${{ secrets.BALLOON_CRUMBS_OPENAIP_API_KEY }}
         run: |
           set -euo pipefail
           eval "$("$GITHUB_WORKSPACE/tools/build-identity.sh" pubspec.yaml testflight "$BUILD_NUMBER" | sed 's/^/export /')"
@@ -178,10 +177,6 @@ jobs:
               exit 1
               ;;
           esac
-          if [ -z "${BALLOON_CRUMBS_OPENAIP_API_KEY:-}" ]; then
-            echo "::error::Missing BALLOON_CRUMBS_OPENAIP_API_KEY; tester releases must include the selected advisory airspace layer." >&2
-            exit 1
-          fi
           flutter pub get
           flutter build ios --release --no-codesign \
             --build-name="$BALLOON_CRUMBS_APP_VERSION" \
@@ -191,7 +186,6 @@ jobs:
             --dart-define=BALLOON_CRUMBS_DISTRIBUTION_TRACK="$BALLOON_CRUMBS_DISTRIBUTION_TRACK" \
             --dart-define=BALLOON_CRUMBS_BUILD_TIMESTAMP="$BALLOON_CRUMBS_BUILD_TIMESTAMP" \
             --dart-define=BALLOON_CRUMBS_API_BASE_URL="${BALLOON_CRUMBS_API_BASE_URL:-}" \
-            --dart-define=BALLOON_CRUMBS_OPENAIP_API_KEY="$BALLOON_CRUMBS_OPENAIP_API_KEY" \
             --dart-define=BALLOON_CRUMBS_PUSH_ENABLED=false \
             --dart-define=BALLOON_CRUMBS_RIDE_DIAGNOSTICS=true
 

--- a/apps/mobile/test/services/planner_only_airspace_contract_test.dart
+++ b/apps/mobile/test/services/planner_only_airspace_contract_test.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('mobile release workflows never embed an OpenAIP credential', () {
+    for (final path in [
+      '../../.github/workflows/testflight.yml',
+      '../../.github/workflows/android-internal.yml',
+    ]) {
+      final source = File(path).readAsStringSync();
+      expect(
+        source,
+        isNot(contains('BALLOON_CRUMBS_OPENAIP_API_KEY')),
+        reason: path,
+      );
+    }
+  });
+
+  test('the live flight shell cannot enable aeronautical tiles', () {
+    final source = File(
+      'lib/features/ride/active_ride_shell.dart',
+    ).readAsStringSync();
+    expect(source, isNot(contains('showAeronauticalChart:')));
+    expect(source, isNot(contains('AeronauticalChartConfiguration')));
+  });
+
+  test('the relay keeps OpenAIP behind a bounded planner-only path', () {
+    final source = File('../../deploy/Caddyfile.oracle').readAsStringSync();
+    expect(source, contains('^/maps/openaip/'));
+    expect(source, contains('x-openaip-api-key'));
+    expect(source, contains('BALLOON_CRUMBS_OPENAIP_API_KEY'));
+  });
+}

--- a/docs/aeronautical-chart-source.md
+++ b/docs/aeronautical-chart-source.md
@@ -1,27 +1,28 @@
 # Aeronautical chart source
 
-OpenAIP is the selected advisory aeronautical layer for tester builds. The app
-uses OpenAIP's combined raster aeronautical chart and visibly attributes it as
-`© openAIP contributors · CC BY-NC 4.0`.
+OpenAIP is the selected advisory aeronautical layer for the optional web
+planner. The live iOS and Android recovery maps are road-first and never load
+OpenAIP tiles. The planner uses OpenAIP's combined raster aeronautical chart and
+visibly attributes it as `© openAIP contributors · CC BY-NC 4.0`.
 
 The service describes itself as TMS, but OpenAIP's current first-party
 MapLibre style consumes the published `{z}/{x}/{y}` coordinates as XYZ. The app
 matches that live contract and renders the combined chart opaquely instead of
 blending it into the ordinary road basemap.
 
-Release workflows require this Actions secret:
+The deployed planner relay requires this host-side secret:
 
 ```text
 BALLOON_CRUMBS_OPENAIP_API_KEY
 ```
 
 The key is a third-party application key created from the OpenAIP user profile.
-It is passed as a `--dart-define`, never committed. OpenAIP's tile endpoint is
-built into the app only because the provider has now been explicitly selected.
+It is supplied only to the relay's bounded `/maps/openaip/` proxy and is never
+committed, placed in planner JavaScript, or compiled into a mobile tester build.
 
-The build timestamp starts a 28-day configuration window. An unstamped local
-build, missing key, future timestamp, or tester build beyond that window does
-not draw the chart; the balloon map labels it unavailable or stale instead.
+The dormant mobile provider boundary remains so a future pilot-only product can
+opt in without changing the chase map. Its default is off and no production
+call site enables it. Planner availability is independent of live recovery.
 
 ## Limitations
 

--- a/docs/android-internal-testing.md
+++ b/docs/android-internal-testing.md
@@ -52,13 +52,11 @@ secrets. The repository environment is already restricted to workflow runs from
 | `ANDROID_KEY_ALIAS` | `balloon-crumbs-upload`, or the alias chosen above |
 | `ANDROID_KEY_PASSWORD` | Upload-key password |
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Full service-account JSON key |
-| `BALLOON_CRUMBS_OPENAIP_API_KEY` | OpenAIP third-party application key for the advisory airspace layer |
 
 On macOS, `base64 -i balloon-crumbs-upload.jks | pbcopy` copies the first value
 without writing another file. Never commit the keystore, passwords, or JSON.
-The OpenAIP key is compiled into the tester app because OpenAIP's tile API is
-designed for map clients; keep it in Actions secrets so it is absent from the
-repository and can be rotated independently.
+OpenAIP is planner-only and is fetched through the relay's server-side proxy;
+Android tester bundles deliberately contain no OpenAIP credential.
 
 Repository variables:
 

--- a/docs/testflight.md
+++ b/docs/testflight.md
@@ -154,7 +154,6 @@ Create these once, under Settings → Secrets and variables → Actions:
 | `APPSTORE_CONNECT_REVIEW_API_KEY_ID` | the App Manager-role review key's ID |
 | `APPSTORE_CONNECT_REVIEW_API_ISSUER_ID` | the review key account's issuer ID |
 | `APPSTORE_CONNECT_REVIEW_API_PRIVATE_KEY_BASE64` | the review key's `.p8`, base64 |
-| `BALLOON_CRUMBS_OPENAIP_API_KEY` | OpenAIP third-party application key for the advisory airspace layer |
 
 Set the `BALLOON_CRUMBS_API_BASE_URL` **variable** (not a secret) to
 `https://balloon-crumbs.pages.dev/api`. Set
@@ -166,6 +165,10 @@ Developer privilege; assigning an external group and creating its beta review
 submission uses the separate App Manager key. The `submit_external` workflow
 input defaults to true and the operation is idempotent: a retry leaves an
 existing group assignment or active review submission in place.
+
+OpenAIP is not a mobile release secret. Aeronautical charts are optional
+planner-only context and the planner reaches them through the relay's bounded
+server-side proxy, so TestFlight binaries contain no OpenAIP credential.
 
 To produce the two base64 values:
 


### PR DESCRIPTION
## Summary
- remove OpenAIP credentials and build gates from iOS and Android tester binaries
- retain the bounded server-side OpenAIP proxy for the optional web planner
- document the planner-only boundary and enforce it with contract tests

Closes #17

## Verification
- flutter test test/services/planner_only_airspace_contract_test.dart test/features/map/balloon_map_presentation_test.dart test/services/aeronautical_chart_configuration_test.dart