### PR TITLE
test: add launch-to-recovery acceptance matrix

### DIFF
--- a/apps/mobile/test/fixtures/launch_recovery_acceptance.json
+++ b/apps/mobile/test/fixtures/launch_recovery_acceptance.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "name": "Synthetic long launch-to-recovery",
+  "seed": 742023,
+  "generatedCoordinates": true,
+  "startTime": "2026-08-24T09:00:00Z",
+  "preLaunchSeconds": 2700,
+  "crafts": [
+    {"id": "synthetic-balloon", "kind": "balloon"},
+    {"id": "synthetic-vehicle-a", "kind": "vehicle"},
+    {"id": "synthetic-vehicle-b", "kind": "vehicle"},
+    {"id": "synthetic-vehicle-c", "kind": "vehicle"}
+  ],
+  "devices": [
+    {"id": "synthetic-pilot", "role": "pilot", "craftId": "synthetic-balloon"},
+    {"id": "synthetic-balloon-crew", "role": "balloonCrew", "craftId": "synthetic-balloon"},
+    {"id": "synthetic-driver-a", "role": "chaseDriver", "craftId": "synthetic-vehicle-a"},
+    {"id": "synthetic-crew-b", "role": "chaseCrew", "craftId": "synthetic-vehicle-b"},
+    {"id": "synthetic-driver-c", "role": "chaseDriver", "craftId": "synthetic-vehicle-c"}
+  ],
+  "timeline": [
+    {"atSeconds": 0, "event": "settingUp"},
+    {"atSeconds": 900, "event": "deviceReconnect", "deviceId": "synthetic-crew-b"},
+    {"atSeconds": 2700, "event": "flightStartedByCrew", "deviceId": "synthetic-driver-a"},
+    {"atSeconds": 3900, "event": "intendedLandingUpdated", "deviceId": "synthetic-pilot"},
+    {"atSeconds": 6600, "event": "flightLanded", "evidence": "radioConfirmed"},
+    {"atSeconds": 7200, "event": "flightLandingRetracted"},
+    {"atSeconds": 7320, "event": "flightLanded", "evidence": "witnessed"},
+    {"atSeconds": 7800, "event": "recoveryComplete"}
+  ],
+  "faults": [
+    {"atSeconds": 3000, "kind": "gpsLoss", "deviceId": "synthetic-pilot", "durationSeconds": 55},
+    {"atSeconds": 3300, "kind": "staleWind", "durationSeconds": 600},
+    {"atSeconds": 4200, "kind": "relayDelay", "durationSeconds": 40},
+    {"atSeconds": 4260, "kind": "outOfOrderReplay", "deviceId": "synthetic-driver-c"}
+  ],
+  "carPlay": {
+    "orientations": ["northUp", "directionUp"],
+    "targets": ["balloonRendezvous", "intendedLandingArea"],
+    "reconnectAtSeconds": 4500
+  }
+}

--- a/apps/mobile/test/services/launch_recovery_acceptance_fixture_test.dart
+++ b/apps/mobile/test/services/launch_recovery_acceptance_fixture_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Map<String, Object?> fixture;
+
+  setUpAll(() {
+    fixture = Map<String, Object?>.from(
+      jsonDecode(
+            File(
+              'test/fixtures/launch_recovery_acceptance.json',
+            ).readAsStringSync(),
+          )
+          as Map,
+    );
+  });
+
+  test('the acceptance fixture is deterministic and wholly synthetic', () {
+    expect(fixture['schemaVersion'], 1);
+    expect(fixture['seed'], 742023);
+    expect(fixture['generatedCoordinates'], isTrue);
+    expect(DateTime.parse(fixture['startTime']! as String).isUtc, isTrue);
+
+    final encoded = jsonEncode(fixture).toLowerCase();
+    for (final privateField in ['phone', 'email', 'contact', 'tucker']) {
+      expect(encoded, isNot(contains(privateField)));
+    }
+  });
+
+  test('five devices occupy one balloon and three independent vehicles', () {
+    final crafts = (fixture['crafts']! as List).cast<Map<String, Object?>>();
+    final devices = (fixture['devices']! as List).cast<Map<String, Object?>>();
+    final craftIds = {for (final craft in crafts) craft['id']};
+
+    expect(fixture['preLaunchSeconds'], greaterThanOrEqualTo(45 * 60));
+    expect(devices, hasLength(5));
+    expect({for (final device in devices) device['id']}, hasLength(5));
+    expect(crafts.where((craft) => craft['kind'] == 'balloon'), hasLength(1));
+    expect(crafts.where((craft) => craft['kind'] == 'vehicle'), hasLength(3));
+    expect(
+      devices.every((device) => craftIds.contains(device['craftId'])),
+      isTrue,
+    );
+  });
+
+  test('the timeline and fault matrix cover the complete recovery loop', () {
+    final timeline = (fixture['timeline']! as List)
+        .cast<Map<String, Object?>>();
+    final events = {for (final item in timeline) item['event']};
+    expect(
+      events,
+      containsAll({
+        'settingUp',
+        'deviceReconnect',
+        'flightStartedByCrew',
+        'intendedLandingUpdated',
+        'flightLanded',
+        'flightLandingRetracted',
+        'recoveryComplete',
+      }),
+    );
+    expect(
+      timeline.where((item) => item['event'] == 'flightLanded'),
+      hasLength(2),
+    );
+
+    final faults = (fixture['faults']! as List).cast<Map<String, Object?>>();
+    expect({
+      for (final fault in faults) fault['kind'],
+    }, containsAll({'gpsLoss', 'staleWind', 'relayDelay', 'outOfOrderReplay'}));
+
+    final carPlay = Map<String, Object?>.from(fixture['carPlay']! as Map);
+    expect(carPlay['orientations'], containsAll(['northUp', 'directionUp']));
+    expect(
+      carPlay['targets'],
+      containsAll(['balloonRendezvous', 'intendedLandingArea']),
+    );
+  });
+}

--- a/apps/server/tests/test_pre_start_presence.py
+++ b/apps/server/tests/test_pre_start_presence.py
@@ -14,15 +14,20 @@ from .conftest import event, ride_token
 SECRET = "0123456789abcdef0123456789abcdef"
 
 
-def _position(latitude: float) -> dict:
+def _position(
+    latitude: float,
+    *,
+    recorded_at: datetime | None = None,
+    display_name: str = "Alex",
+) -> dict:
     return {
-        "displayName": "Alex",
+        "displayName": display_name,
         "role": "rider",
         "motorcycleStyle": "adventure",
         "riderColor": "blue",
         "sample": {
             "position": {"latitude": latitude, "longitude": -2.4},
-            "recordedAt": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "recordedAt": (recorded_at or datetime.now(UTC)).isoformat().replace("+00:00", "Z"),
             "accuracyMeters": 4,
             "speedMetersPerSecond": 0,
             "headingDegrees": 90,
@@ -156,3 +161,70 @@ def test_presence_requires_matching_authenticated_device(client, synchronize) ->
     )
 
     assert response.status_code == 400
+
+
+def test_five_devices_survive_a_45_minute_pre_launch_without_ghosts(client, synchronize) -> None:
+    """The long field lobby is a heartbeat test, not a sleep in CI.
+
+    Five synthetic devices publish every 30 seconds for the observed 45-minute
+    setup window. Reusing one installation id after a process restart must
+    replace that row rather than invent a sixth crew member.
+    """
+
+    ride_id = "synthetic-long-pre-launch"
+    bearer_token = ride_token(ride_id, SECRET)
+    assert synchronize(client, ride_id=ride_id, secret=SECRET).status_code == 200
+    service = client.app.state.service
+    session_factory = client.app.state.session_factory
+    start = datetime(2026, 8, 24, 9, tzinfo=UTC)
+    devices = [f"synthetic-device-{index}" for index in range(5)]
+
+    def publish(device_id: str, at: datetime, *, restarted: bool = False) -> dict:
+        index = devices.index(device_id)
+        request = PresenceSyncRequest(
+            protocolVersion=1,
+            deviceId=device_id,
+            position=_position(
+                52.0 + index * 0.001,
+                recorded_at=at,
+                display_name=(
+                    f"Synthetic crew {index} (restarted)"
+                    if restarted
+                    else f"Synthetic crew {index}"
+                ),
+            ),
+        )
+        with session_factory() as session:
+            return service.synchronize_pre_start_presence(
+                session,
+                ride_id=ride_id,
+                bearer_token=bearer_token,
+                device_header=device_id,
+                request=request,
+                live_presence=True,
+                now=at,
+            )
+
+    latest: dict = {}
+    for heartbeat in range(91):
+        at = start + timedelta(seconds=heartbeat * 30)
+        for device_id in devices:
+            latest = publish(device_id, at)
+        assert len(latest["positions"]) == 5
+        assert {item["riderId"] for item in latest["positions"]} == set(devices)
+
+    restarted_at = start + timedelta(minutes=45, seconds=5)
+    latest = publish(devices[2], restarted_at, restarted=True)
+
+    assert len(latest["positions"]) == 5
+    restarted = next(item for item in latest["positions"] if item["riderId"] == devices[2])
+    assert restarted["displayName"].endswith("(restarted)")
+    with session_factory() as session:
+        assert (
+            session.scalar(
+                select(func.count())
+                .select_from(PreStartPosition)
+                .where(PreStartPosition.ride_id == ride_id)
+            )
+            == 5
+        )

--- a/docs/launch-recovery-acceptance.md
+++ b/docs/launch-recovery-acceptance.md
@@ -1,0 +1,59 @@
+# Launch-to-recovery acceptance matrix
+
+Status: automated matrix implemented; physical CarPlay evidence remains tracked
+by [#15](https://github.com/osholt/balloon-crumbs/issues/15).
+
+This matrix starts when the crew assembles, 45 minutes before release, and ends
+only when recovery is complete. The checked-in fixture is generated,
+deterministic and contains no real flight, precise field or contact data:
+`apps/mobile/test/fixtures/launch_recovery_acceptance.json`.
+
+## Automated matrix
+
+| Stage or failure | Required result | Evidence |
+| --- | --- | --- |
+| 45-minute pre-launch lobby | Five devices remain present; a restart with the same installation identity replaces rather than duplicates the member | `apps/server/tests/test_pre_start_presence.py::test_five_devices_survive_a_45_minute_pre_launch_without_ghosts` |
+| Craft assignment | Two balloon devices resolve to one balloon while three vehicles remain independent | `launch_recovery_acceptance_fixture_test.dart`, `ride_controller_craft_test.dart` |
+| Release | Chase crew can start the live phase and the event records actor and flight role | `ride_controller_test.dart::chase crew can start live tracking at balloon release` |
+| Live positions and tracks | Balloon and vehicle traces stay distinct; duplicate or out-of-order fixes do not rewind them | `craft_track_reducer_test.dart`, `rider_trail_recorder_test.dart`, `live_presence_two_device_test.dart` |
+| Fix/wind/relay degradation | GPS loss, stale forecast wind, delayed relay and out-of-order replay degrade or freeze without inventing live state | `craft_roster_test.dart`, `live_flight_projection_test.dart`, `internet_relay_worker_test.dart` |
+| Landing intent | A missing intent is valid; a revision remains separate from the calculated landing envelope | `landing_zone_test.dart`, `live_flight_projection_test.dart` |
+| LANDED and retraction | Aboard, witnessed, radio-confirmed and manually marked evidence stay attributable; a later valid declaration wins | `flight_landing_test.dart`, `ride_controller_test.dart`, `widget_test.dart` |
+| Recovery phase | LANDED does not end the operation; chase movement and location sharing continue until recovery complete | `fiesta_flight_simulation_test.dart`, `ride_controller_test.dart` |
+| CarPlay | North-up/Direction-up and balloon/landing targets survive bridge updates and reconnect | `carplay_bridge_test.dart`, `map_orientation_preferences_test.dart`; physical checks remain below |
+
+The bounded CI set is deliberately virtual-time driven. It does not sleep for
+45 minutes and it never publishes synthetic positions to a live relay.
+
+## Physical run record
+
+Create one table per run in the field-test issue or release evidence. Do not put
+join secrets, exact tracks or private land contacts in it.
+
+| Field | Record |
+| --- | --- |
+| Date / tester build | |
+| Phone models | |
+| iOS / Android versions | |
+| Vehicle / head unit | |
+| Wired or wireless CarPlay | |
+| Route duration and broad conditions | |
+| Pre-launch lobby duration / reconnects | |
+| Release actor and convergence time | |
+| GPS, altitude, wind and relay degradations | |
+| Landing evidence / retraction / recovery completion | |
+| North-up / Direction-up and target changes | |
+| Voice, Bluetooth and background behaviour | |
+| Battery / thermal observations | |
+| Driver-distraction or accessibility issues | |
+| Failures and follow-up tickets | |
+
+## Pass rule
+
+- All five devices are present after the pre-launch window with no ghost craft.
+- No stale or unknown fix uses the live visual state.
+- LANDED keeps sharing active and recovery complete stops it deliberately.
+- CarPlay never requires phone interaction from the driver during the moving
+  portion and reroutes only to a lawful road rendezvous.
+- Any failed physical row opens a blocking ticket; simulator success does not
+  waive the physical CarPlay gate.


### PR DESCRIPTION
Closes #74

## What changed
- adds a deterministic synthetic five-device launch-to-recovery acceptance fixture
- verifies a 45-minute pre-launch lobby with reconnect does not create ghost members
- documents automated evidence, a physical run record, and pass criteria

## Verification
- `flutter test test/services/launch_recovery_acceptance_fixture_test.dart`
- `uv run ruff format --check tests/test_pre_start_presence.py`
- `uv run ruff check tests/test_pre_start_presence.py`
- `uv run pytest tests/test_pre_start_presence.py -q`