### PR TITLE
feat: add private land access notes

### DIFF
--- a/apps/mobile/lib/app/balloon_crumbs_app.dart
+++ b/apps/mobile/lib/app/balloon_crumbs_app.dart
@@ -6,6 +6,7 @@ import '../controllers/chase_vehicle_controller.dart';
 import '../controllers/distance_unit_controller.dart';
 import '../controllers/completed_rides_controller.dart';
 import '../controllers/map_style_mode_controller.dart';
+import '../controllers/land_access_note_controller.dart';
 import '../controllers/ride_code_preference_controller.dart';
 import '../controllers/ride_controller.dart';
 import '../controllers/ride_invitation_link_controller.dart';
@@ -45,6 +46,7 @@ class BalloonCrumbsApp extends StatelessWidget {
     this.testControlRegistry,
     this.spokenGuidance,
     this.rideDiagnostics,
+    this.landAccessNotes,
     this.enableNativeServices = true,
     this.initializeController,
     this.startupFallbackAfter = const Duration(seconds: 2),
@@ -77,6 +79,7 @@ class BalloonCrumbsApp extends StatelessWidget {
   /// Records what the app said beside what the bike did, when an instrumented
   /// build has it switched on (#419). Null in an ordinary build.
   final RideDiagnosticsController? rideDiagnostics;
+  final LandAccessNoteController? landAccessNotes;
 
   final bool enableNativeServices;
 
@@ -146,6 +149,7 @@ class BalloonCrumbsApp extends StatelessWidget {
             testControl: testControl,
             spokenGuidance: spokenGuidance,
             rideDiagnostics: rideDiagnostics,
+            landAccessNotes: landAccessNotes,
             restoringRideCode: controller.session?.rideCode,
             restorationError: restorationError,
             onRetryRestoration: retryRestoration,
@@ -186,6 +190,7 @@ class BalloonCrumbsApp extends StatelessWidget {
             testControlRegistry: testControlRegistry,
             spokenGuidance: spokenGuidance,
             rideDiagnostics: rideDiagnostics,
+            landAccessNotes: landAccessNotes,
             onJoinGroupRequested: requestJoinGroup,
           );
         }
@@ -208,6 +213,7 @@ class BalloonCrumbsApp extends StatelessWidget {
           testControl: testControl,
           spokenGuidance: spokenGuidance,
           rideDiagnostics: rideDiagnostics,
+          landAccessNotes: landAccessNotes,
           openJoinGroup: openJoinGroup,
           onJoinGroupOpened: consumeJoinGroupRequest,
           enableNativeServices: enableNativeServices,

--- a/apps/mobile/lib/controllers/land_access_note_controller.dart
+++ b/apps/mobile/lib/controllers/land_access_note_controller.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/foundation.dart';
+import 'package:uuid/uuid.dart';
+
+import '../domain/land_access_note.dart';
+import '../domain/land_access_note_store.dart';
+import '../services/land_access_note_export.dart';
+
+class LandAccessNoteController extends ChangeNotifier {
+  LandAccessNoteController(
+    this._store, {
+    LandAccessNoteExportCodec? exportCodec,
+    Uuid? uuid,
+  }) : _exportCodec = exportCodec ?? LandAccessNoteExportCodec(),
+       _uuid = uuid ?? const Uuid();
+
+  final LandAccessNoteStore _store;
+  final LandAccessNoteExportCodec _exportCodec;
+  final Uuid _uuid;
+
+  List<LandAccessNote> _notes = const [];
+  bool _loaded = false;
+  bool _busy = false;
+  String? _errorMessage;
+  bool _showOnMap = false;
+
+  List<LandAccessNote> get notes => _notes;
+  bool get loaded => _loaded;
+  bool get busy => _busy;
+  String? get errorMessage => _errorMessage;
+  bool get showOnMap => _showOnMap;
+
+  void setShowOnMap(bool value) {
+    if (_showOnMap == value) return;
+    _showOnMap = value;
+    notifyListeners();
+  }
+
+  Future<void> load() async {
+    if (_busy) return;
+    _busy = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      _notes = await _store.loadNotes();
+      _loaded = true;
+    } on Object {
+      _errorMessage = 'Private land access notes could not be opened.';
+    } finally {
+      _busy = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> save(LandAccessNote note) async {
+    await _run(() async {
+      await _store.upsert(note);
+      _notes = await _store.loadNotes();
+      _loaded = true;
+    });
+  }
+
+  Future<void> delete(String noteId) async {
+    await _run(() async {
+      await _store.delete(noteId);
+      _notes = await _store.loadNotes();
+    });
+  }
+
+  Future<LandAccessNoteExport?> export({
+    required Iterable<String> noteIds,
+    required String passphrase,
+    DateTime? now,
+  }) async {
+    LandAccessNoteExport? result;
+    await _run(() async {
+      final selectedIds = noteIds.toSet();
+      final selected = _notes
+          .where((note) => selectedIds.contains(note.id))
+          .toList(growable: false);
+      final createdAt = (now ?? DateTime.now()).toUtc();
+      result = await _exportCodec.encrypt(
+        notes: selected,
+        passphrase: passphrase,
+        createdAt: createdAt,
+        exportId: _uuid.v4(),
+      );
+      await _store.recordExport(
+        LandAccessExportMetadata(
+          exportId: result!.exportId,
+          noteIds: result!.noteIds,
+          createdAt: createdAt,
+        ),
+      );
+    });
+    return result;
+  }
+
+  Future<int> import(Uint8List contents, String passphrase) async {
+    var imported = 0;
+    await _run(() async {
+      final incoming = await _exportCodec.decrypt(contents, passphrase);
+      final existing = {
+        for (final note in await _store.loadNotes()) note.id: note,
+      };
+      for (final note in incoming) {
+        final current = existing[note.id];
+        if (current == null || note.updatedAt.isAfter(current.updatedAt)) {
+          await _store.upsert(note);
+          imported += 1;
+        }
+      }
+      _notes = await _store.loadNotes();
+      _loaded = true;
+    });
+    return imported;
+  }
+
+  String newId() => _uuid.v4();
+
+  Future<void> _run(Future<void> Function() action) async {
+    if (_busy) return;
+    _busy = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      await action();
+    } on FormatException catch (error) {
+      _errorMessage = error.message;
+    } on Object {
+      _errorMessage = 'The private land access notes action failed.';
+    } finally {
+      _busy = false;
+      notifyListeners();
+    }
+  }
+}

--- a/apps/mobile/lib/data/secure_land_access_note_store.dart
+++ b/apps/mobile/lib/data/secure_land_access_note_store.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../domain/land_access_note.dart';
+import '../domain/land_access_note_store.dart';
+
+/// Device-local storage backed by the platform keychain/keystore.
+///
+/// The document is deliberately absent from SharedPreferences, SQLite, relay
+/// events and diagnostic logs because it may contain a private phone number.
+class SecureLandAccessNoteStore implements LandAccessNoteStore {
+  const SecureLandAccessNoteStore({FlutterSecureStorage? storage})
+    : _storage = storage ?? const FlutterSecureStorage();
+
+  static const _key = 'balloon_crumbs_land_access_notes_v1';
+  static const _maximumNotes = 500;
+  static const _maximumExports = 250;
+
+  final FlutterSecureStorage _storage;
+
+  Future<_StoredLandAccessDocument> _load() async {
+    final encoded = await _storage.read(key: _key);
+    if (encoded == null) return const _StoredLandAccessDocument();
+    try {
+      final value = Map<String, Object?>.from(jsonDecode(encoded) as Map);
+      if (value['schemaVersion'] != 1) {
+        throw const FormatException('Unsupported land access store.');
+      }
+      final notes = (value['notes'] as List? ?? const [])
+          .map(
+            (item) =>
+                LandAccessNote.fromJson(Map<String, Object?>.from(item as Map)),
+          )
+          .toList(growable: false);
+      final exports = (value['exports'] as List? ?? const [])
+          .map(
+            (item) => LandAccessExportMetadata.fromJson(
+              Map<String, Object?>.from(item as Map),
+            ),
+          )
+          .toList(growable: false);
+      if (notes.length > _maximumNotes ||
+          exports.length > _maximumExports ||
+          notes.map((note) => note.id).toSet().length != notes.length ||
+          exports.map((item) => item.exportId).toSet().length !=
+              exports.length) {
+        throw const FormatException('Land access store is invalid.');
+      }
+      return _StoredLandAccessDocument(notes: notes, exports: exports);
+    } on Object {
+      await _storage.delete(key: _key);
+      return const _StoredLandAccessDocument();
+    }
+  }
+
+  Future<void> _save(_StoredLandAccessDocument document) async {
+    if (document.notes.isEmpty && document.exports.isEmpty) {
+      await _storage.delete(key: _key);
+      return;
+    }
+    await _storage.write(
+      key: _key,
+      value: jsonEncode({
+        'schemaVersion': 1,
+        'notes': document.notes
+            .map((note) => note.toJson())
+            .toList(growable: false),
+        'exports': document.exports
+            .map((item) => item.toJson())
+            .toList(growable: false),
+      }),
+    );
+  }
+
+  @override
+  Future<List<LandAccessNote>> loadNotes() async =>
+      List.unmodifiable((await _load()).notes);
+
+  @override
+  Future<List<LandAccessExportMetadata>> loadExportMetadata() async =>
+      List.unmodifiable((await _load()).exports);
+
+  @override
+  Future<void> upsert(LandAccessNote note) async {
+    final document = await _load();
+    final notes = [...document.notes]
+      ..removeWhere((item) => item.id == note.id);
+    notes.add(note);
+    notes.sort((a, b) => b.confirmedAt.compareTo(a.confirmedAt));
+    if (notes.length > _maximumNotes) {
+      throw const FormatException(
+        'No more than 500 land access notes are kept.',
+      );
+    }
+    await _save(
+      _StoredLandAccessDocument(notes: notes, exports: document.exports),
+    );
+  }
+
+  @override
+  Future<void> delete(String noteId) async {
+    final document = await _load();
+    final notes = [...document.notes]..removeWhere((item) => item.id == noteId);
+    final exports = <LandAccessExportMetadata>[];
+    for (final item in document.exports) {
+      final remainingIds = item.noteIds
+          .where((id) => id != noteId)
+          .toList(growable: false);
+      if (remainingIds.isEmpty) continue;
+      exports.add(
+        LandAccessExportMetadata(
+          exportId: item.exportId,
+          noteIds: remainingIds,
+          createdAt: item.createdAt,
+        ),
+      );
+    }
+    await _save(_StoredLandAccessDocument(notes: notes, exports: exports));
+  }
+
+  @override
+  Future<void> recordExport(LandAccessExportMetadata metadata) async {
+    final document = await _load();
+    final exports = [...document.exports]
+      ..removeWhere((item) => item.exportId == metadata.exportId)
+      ..add(metadata);
+    exports.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    if (exports.length > _maximumExports) {
+      exports.removeRange(_maximumExports, exports.length);
+    }
+    await _save(
+      _StoredLandAccessDocument(notes: document.notes, exports: exports),
+    );
+  }
+}
+
+class _StoredLandAccessDocument {
+  const _StoredLandAccessDocument({
+    this.notes = const [],
+    this.exports = const [],
+  });
+
+  final List<LandAccessNote> notes;
+  final List<LandAccessExportMetadata> exports;
+}

--- a/apps/mobile/lib/domain/land_access_note.dart
+++ b/apps/mobile/lib/domain/land_access_note.dart
@@ -1,0 +1,223 @@
+import 'geo_point.dart';
+
+enum LandAccessGeometryKind { point, polygon }
+
+enum LandAccessOutcome {
+  unknown,
+  askFirst,
+  permissionConfirmed,
+  accessDeclined,
+}
+
+enum LandAccessProvenance { crewObservation, landContact, publicReference }
+
+enum LandAccessConsentStatus {
+  notRecorded,
+  verbal,
+  written,
+  contactRequestedRemoval,
+}
+
+class LandAccessGeometry {
+  LandAccessGeometry({required this.kind, required List<GeoPoint> points})
+    : points = List.unmodifiable(points) {
+    if (kind == LandAccessGeometryKind.point && points.length != 1) {
+      throw const FormatException('A point geometry needs exactly one point.');
+    }
+    if (kind == LandAccessGeometryKind.polygon && points.length < 3) {
+      throw const FormatException(
+        'A polygon geometry needs at least three points.',
+      );
+    }
+    if (points.length > 200) {
+      throw const FormatException('A land access geometry is too detailed.');
+    }
+  }
+
+  final LandAccessGeometryKind kind;
+  final List<GeoPoint> points;
+
+  GeoPoint get anchor => points.first;
+
+  Map<String, Object?> toJson() => {
+    'kind': kind.name,
+    'points': points.map((point) => point.toJson()).toList(growable: false),
+  };
+
+  factory LandAccessGeometry.fromJson(Map<String, Object?> json) {
+    final kind = LandAccessGeometryKind.values.byName(json['kind']! as String);
+    final rawPoints = json['points'];
+    if (rawPoints is! List) {
+      throw const FormatException('Land access geometry points are missing.');
+    }
+    return LandAccessGeometry(
+      kind: kind,
+      points: rawPoints
+          .map(
+            (item) => GeoPoint.fromJson(Map<String, Object?>.from(item as Map)),
+          )
+          .toList(growable: false),
+    );
+  }
+}
+
+class LandAccessNote {
+  LandAccessNote({
+    required this.id,
+    required this.geometry,
+    required this.outcome,
+    required this.confirmedAt,
+    required this.recordedBy,
+    required this.provenance,
+    required this.consentStatus,
+    required this.reviewAfter,
+    required this.createdAt,
+    required this.updatedAt,
+    this.firstName,
+    this.contactRole,
+    this.phoneNumber,
+    this.gateNotes = '',
+  }) {
+    if (id.trim().isEmpty || id.length > 80) {
+      throw const FormatException('Land access note id is invalid.');
+    }
+    if (reviewAfter.isBefore(confirmedAt)) {
+      throw const FormatException('Review date cannot predate confirmation.');
+    }
+    if (updatedAt.isBefore(createdAt)) {
+      throw const FormatException('Updated time cannot predate creation.');
+    }
+    _checkLength(firstName, 80, 'First name');
+    _checkLength(contactRole, 80, 'Contact role');
+    _checkLength(phoneNumber, 40, 'Phone number');
+    _checkLength(recordedBy, 80, 'Recorder');
+    _checkLength(gateNotes, 1000, 'Gate notes');
+  }
+
+  final String id;
+  final LandAccessGeometry geometry;
+  final LandAccessOutcome outcome;
+  final String? firstName;
+  final String? contactRole;
+  final String? phoneNumber;
+  final String gateNotes;
+  final DateTime confirmedAt;
+  final String recordedBy;
+  final LandAccessProvenance provenance;
+  final LandAccessConsentStatus consentStatus;
+  final DateTime reviewAfter;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  bool get hasPersonalContact =>
+      (firstName?.trim().isNotEmpty ?? false) ||
+      (contactRole?.trim().isNotEmpty ?? false) ||
+      (phoneNumber?.trim().isNotEmpty ?? false);
+
+  bool isExpiredAt(DateTime now) => !reviewAfter.isAfter(now.toUtc());
+
+  LandAccessNote copyWith({
+    LandAccessGeometry? geometry,
+    LandAccessOutcome? outcome,
+    String? firstName,
+    String? contactRole,
+    String? phoneNumber,
+    String? gateNotes,
+    DateTime? confirmedAt,
+    String? recordedBy,
+    LandAccessProvenance? provenance,
+    LandAccessConsentStatus? consentStatus,
+    DateTime? reviewAfter,
+    DateTime? updatedAt,
+  }) => LandAccessNote(
+    id: id,
+    geometry: geometry ?? this.geometry,
+    outcome: outcome ?? this.outcome,
+    firstName: firstName ?? this.firstName,
+    contactRole: contactRole ?? this.contactRole,
+    phoneNumber: phoneNumber ?? this.phoneNumber,
+    gateNotes: gateNotes ?? this.gateNotes,
+    confirmedAt: confirmedAt ?? this.confirmedAt,
+    recordedBy: recordedBy ?? this.recordedBy,
+    provenance: provenance ?? this.provenance,
+    consentStatus: consentStatus ?? this.consentStatus,
+    reviewAfter: reviewAfter ?? this.reviewAfter,
+    createdAt: createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+
+  Map<String, Object?> toJson() => {
+    'id': id,
+    'geometry': geometry.toJson(),
+    'outcome': outcome.name,
+    'firstName': ?firstName,
+    'contactRole': ?contactRole,
+    'phoneNumber': ?phoneNumber,
+    'gateNotes': gateNotes,
+    'confirmedAt': confirmedAt.toUtc().toIso8601String(),
+    'recordedBy': recordedBy,
+    'provenance': provenance.name,
+    'consentStatus': consentStatus.name,
+    'reviewAfter': reviewAfter.toUtc().toIso8601String(),
+    'createdAt': createdAt.toUtc().toIso8601String(),
+    'updatedAt': updatedAt.toUtc().toIso8601String(),
+  };
+
+  factory LandAccessNote.fromJson(Map<String, Object?> json) => LandAccessNote(
+    id: json['id']! as String,
+    geometry: LandAccessGeometry.fromJson(
+      Map<String, Object?>.from(json['geometry']! as Map),
+    ),
+    outcome: LandAccessOutcome.values.byName(json['outcome']! as String),
+    firstName: json['firstName'] as String?,
+    contactRole: json['contactRole'] as String?,
+    phoneNumber: json['phoneNumber'] as String?,
+    gateNotes: json['gateNotes'] as String? ?? '',
+    confirmedAt: DateTime.parse(json['confirmedAt']! as String).toUtc(),
+    recordedBy: json['recordedBy']! as String,
+    provenance: LandAccessProvenance.values.byName(
+      json['provenance']! as String,
+    ),
+    consentStatus: LandAccessConsentStatus.values.byName(
+      json['consentStatus']! as String,
+    ),
+    reviewAfter: DateTime.parse(json['reviewAfter']! as String).toUtc(),
+    createdAt: DateTime.parse(json['createdAt']! as String).toUtc(),
+    updatedAt: DateTime.parse(json['updatedAt']! as String).toUtc(),
+  );
+
+  static void _checkLength(String? value, int maximum, String label) {
+    if ((value?.length ?? 0) > maximum) {
+      throw FormatException('$label is too long.');
+    }
+  }
+}
+
+class LandAccessExportMetadata {
+  LandAccessExportMetadata({
+    required this.exportId,
+    required List<String> noteIds,
+    required this.createdAt,
+  }) : noteIds = List.unmodifiable(noteIds) {
+    if (exportId.trim().isEmpty || noteIds.isEmpty) {
+      throw const FormatException('Land access export metadata is invalid.');
+    }
+  }
+
+  final String exportId;
+  final List<String> noteIds;
+  final DateTime createdAt;
+
+  Map<String, Object?> toJson() => {
+    'exportId': exportId,
+    'noteIds': noteIds,
+    'createdAt': createdAt.toUtc().toIso8601String(),
+  };
+
+  factory LandAccessExportMetadata.fromJson(Map<String, Object?> json) =>
+      LandAccessExportMetadata(
+        exportId: json['exportId']! as String,
+        noteIds: (json['noteIds']! as List).cast<String>(),
+        createdAt: DateTime.parse(json['createdAt']! as String).toUtc(),
+      );
+}

--- a/apps/mobile/lib/domain/land_access_note_store.dart
+++ b/apps/mobile/lib/domain/land_access_note_store.dart
@@ -1,0 +1,14 @@
+import 'land_access_note.dart';
+
+abstract interface class LandAccessNoteStore {
+  Future<List<LandAccessNote>> loadNotes();
+
+  Future<void> upsert(LandAccessNote note);
+
+  /// Removes the note and every local export-metadata reference to it.
+  Future<void> delete(String noteId);
+
+  Future<List<LandAccessExportMetadata>> loadExportMetadata();
+
+  Future<void> recordExport(LandAccessExportMetadata metadata);
+}

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -10,6 +10,7 @@ import '../../controllers/chase_vehicle_controller.dart';
 import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/completed_rides_controller.dart';
 import '../../controllers/map_style_mode_controller.dart';
+import '../../controllers/land_access_note_controller.dart';
 import '../../controllers/ride_code_preference_controller.dart';
 import '../../controllers/ride_controller.dart';
 import '../../controllers/route_progress_display_controller.dart';
@@ -68,6 +69,7 @@ class HomeScreen extends StatefulWidget {
     this.testControl,
     this.spokenGuidance,
     this.rideDiagnostics,
+    this.landAccessNotes,
     this.restoringRideCode,
     this.restorationError,
     this.onRetryRestoration,
@@ -102,6 +104,7 @@ class HomeScreen extends StatefulWidget {
   /// *here* offers the recorder too — wiring only the ride shell's sheet is
   /// what hid it from a tester who had never started a ride (#419).
   final RideDiagnosticsController? rideDiagnostics;
+  final LandAccessNoteController? landAccessNotes;
 
   final String? restoringRideCode;
   final Object? restorationError;
@@ -502,6 +505,13 @@ class _HomeScreenState extends State<HomeScreen> {
                           testControl: widget.testControl,
                           spokenGuidance: widget.spokenGuidance,
                           rideDiagnostics: widget.rideDiagnostics,
+                          landAccessNotes: widget.landAccessNotes,
+                          currentPosition: _position.value == null
+                              ? null
+                              : awareness_geo.GeoPoint(
+                                  latitude: _position.value!.latitude,
+                                  longitude: _position.value!.longitude,
+                                ),
                         ),
                         icon: const Icon(Icons.settings_outlined),
                       ),

--- a/apps/mobile/lib/features/map/land_access_note_map_projection.dart
+++ b/apps/mobile/lib/features/map/land_access_note_map_projection.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/imported_route.dart' as route_domain;
+import '../../domain/land_access_note.dart';
+import '../../services/rider_trail_recorder.dart';
+import 'ride_map_feature.dart';
+
+class LandAccessNoteMapProjection {
+  const LandAccessNoteMapProjection({
+    this.markers = const [],
+    this.traces = const [],
+  });
+
+  final List<MapOverlayMarker> markers;
+  final List<MapOverlayTrace> traces;
+}
+
+/// Converts private notes to deliberately sparse map content.
+///
+/// Contact names, phone numbers, recorder identity and free-text notes never
+/// reach marker labels. The management screen is the explicit place to reveal
+/// those values; a recovery map may be visible to anyone in the vehicle.
+LandAccessNoteMapProjection projectLandAccessNotes(
+  Iterable<LandAccessNote> notes, {
+  required DateTime now,
+}) {
+  final active = notes
+      .where((note) => !note.isExpiredAt(now))
+      .toList(growable: false);
+  return LandAccessNoteMapProjection(
+    markers: List.unmodifiable([
+      for (final note in active)
+        MapOverlayMarker(
+          id: 'private-land-access-${note.id}',
+          point: route_domain.GeoPoint(
+            latitude: note.geometry.anchor.latitude,
+            longitude: note.geometry.anchor.longitude,
+          ),
+          label: 'Private access · ${landAccessOutcomeLabel(note.outcome)}',
+          icon: note.geometry.kind == LandAccessGeometryKind.point
+              ? Icons.place_outlined
+              : Icons.polyline_outlined,
+          color: landAccessOutcomeColor(note.outcome),
+        ),
+    ]),
+    traces: List.unmodifiable([
+      for (final note in active)
+        if (note.geometry.kind == LandAccessGeometryKind.polygon)
+          MapOverlayTrace(
+            id: 'private-land-access-outline-${note.id}',
+            label: 'Private indicative access outline',
+            kind: RiderTrailKind.operationalBoundary,
+            color: landAccessOutcomeColor(note.outcome),
+            points: [
+              for (final point in note.geometry.points)
+                route_domain.GeoPoint(
+                  latitude: point.latitude,
+                  longitude: point.longitude,
+                ),
+              route_domain.GeoPoint(
+                latitude: note.geometry.points.first.latitude,
+                longitude: note.geometry.points.first.longitude,
+              ),
+            ],
+          ),
+    ]),
+  );
+}
+
+String landAccessOutcomeLabel(LandAccessOutcome outcome) => switch (outcome) {
+  LandAccessOutcome.unknown => 'no access outcome recorded',
+  LandAccessOutcome.askFirst => 'ask before vehicle access',
+  LandAccessOutcome.permissionConfirmed => 'permission was confirmed',
+  LandAccessOutcome.accessDeclined => 'vehicle access was declined',
+};
+
+Color landAccessOutcomeColor(LandAccessOutcome outcome) => switch (outcome) {
+  LandAccessOutcome.unknown => const Color(0xFF9EABB9),
+  LandAccessOutcome.askFirst => const Color(0xFFFFC857),
+  LandAccessOutcome.permissionConfirmed => const Color(0xFF72D5A4),
+  LandAccessOutcome.accessDeclined => const Color(0xFFFF8A80),
+};

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -12,6 +12,7 @@ import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/foreground_location_controller.dart';
 import '../../controllers/internet_relay_controller.dart';
 import '../../controllers/map_style_mode_controller.dart';
+import '../../controllers/land_access_note_controller.dart';
 import '../../controllers/nearby_relay_controller.dart';
 import '../../controllers/observer_access_controller.dart';
 import '../../controllers/pre_start_presence_controller.dart';
@@ -103,6 +104,7 @@ import '../../services/road_routing.dart';
 import '../../services/ride_connectivity_summary.dart';
 import '../../services/trail_display_simplifier.dart';
 import '../map/hazard_map_symbol.dart';
+import '../map/land_access_note_map_projection.dart';
 import '../map/maneuver_diagnostics.dart';
 import '../map/maneuver_list_screen.dart';
 import '../map/craft_icon.dart';
@@ -307,6 +309,7 @@ class ActiveRideShell extends StatefulWidget {
     this.testControlRegistry,
     this.spokenGuidance,
     this.rideDiagnostics,
+    this.landAccessNotes,
     this.onJoinGroupRequested,
   });
 
@@ -326,6 +329,7 @@ class ActiveRideShell extends StatefulWidget {
   /// Records what the app said beside what the bike did (#419). Null, or off,
   /// in every ordinary build.
   final RideDiagnosticsController? rideDiagnostics;
+  final LandAccessNoteController? landAccessNotes;
 
   /// Returns an unstarted solo rider to the established group-join sheet.
   /// The shell owns leaving because it must stop its ride-scoped services first;
@@ -1545,6 +1549,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     // menu, the door closest to hand while riding — showed it on and recorded
     // nothing (#457).
     widget.rideDiagnostics?.addListener(_onRideDiagnosticsChanged);
+    widget.landAccessNotes?.addListener(_onLandAccessNotesChanged);
+    if (widget.landAccessNotes?.loaded == false) {
+      unawaited(widget.landAccessNotes!.load());
+    }
     if (widget.enableNativeServices && widget.spokenGuidance != null) {
       _spokenGuidance = SpokenGuidanceSpeaker(
         widget.spokenGuidance!.createEngine(onOutput: _recordSpeechOutput),
@@ -2878,6 +2886,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       now: now,
     );
     final overlays = <MapOverlayMarker>[
+      ..._landAccessMapMarkers(now),
       for (final judgement in hazardJudgements)
         if (judgement.isVisible) _hazardOverlayMarker(judgement.report, now),
       if (widget.rideController.flightLanding.landing case final landing?)
@@ -3687,7 +3696,29 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       ..._originalLandingEnvelopeTraces,
       ..._liveProjectionTraces,
       ..._operationalBoundaryTraces,
+      ..._landAccessMapTraces,
     ]);
+  }
+
+  void _onLandAccessNotesChanged() {
+    if (!mounted) return;
+    _updateMapOverlays(updateDerivedState: false);
+    _pushRiderTrails();
+  }
+
+  List<MapOverlayMarker> _landAccessMapMarkers(DateTime now) {
+    final controller = widget.landAccessNotes;
+    if (controller == null || !controller.showOnMap) return const [];
+    return projectLandAccessNotes(controller.notes, now: now).markers;
+  }
+
+  List<MapOverlayTrace> get _landAccessMapTraces {
+    final controller = widget.landAccessNotes;
+    if (controller == null || !controller.showOnMap) return const [];
+    return projectLandAccessNotes(
+      controller.notes,
+      now: DateTime.now().toUtc(),
+    ).traces;
   }
 
   List<MapOverlayTrace> get _sharedForecastTraces {
@@ -7186,6 +7217,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       testControl: widget.testControl,
       spokenGuidance: widget.spokenGuidance,
       rideDiagnostics: widget.rideDiagnostics,
+      landAccessNotes: widget.landAccessNotes,
+      currentPosition: _mapPosition.value == null
+          ? null
+          : awareness_geo.GeoPoint(
+              latitude: _mapPosition.value!.latitude,
+              longitude: _mapPosition.value!.longitude,
+            ),
       embedded: true,
     ),
   );
@@ -7315,6 +7353,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     // copy of the log that was ever in memory (#456).
     unawaited(_diagnosticsWriter?.flush());
     widget.rideDiagnostics?.removeListener(_onRideDiagnosticsChanged);
+    widget.landAccessNotes?.removeListener(_onLandAccessNotesChanged);
     widget.spokenGuidance?.removeListener(_onSpokenGuidanceChanged);
     unawaited(_screenAwakeCoordinator.stop());
     widget.rideController.removeListener(_onRideControllerChanged);

--- a/apps/mobile/lib/features/settings/land_access_notes_screen.dart
+++ b/apps/mobile/lib/features/settings/land_access_notes_screen.dart
@@ -1,0 +1,912 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../controllers/land_access_note_controller.dart';
+import '../../domain/geo_point.dart' as awareness;
+import '../../domain/imported_route.dart' as route_domain;
+import '../../domain/land_access_note.dart';
+import '../../services/rider_trail_recorder.dart';
+import '../map/ride_map_feature.dart';
+
+class LandAccessNotesScreen extends StatefulWidget {
+  const LandAccessNotesScreen({
+    super.key,
+    required this.controller,
+    required this.recordedBy,
+    this.initialPoint,
+    this.enableNativeMap = true,
+  });
+
+  final LandAccessNoteController controller;
+  final String recordedBy;
+  final awareness.GeoPoint? initialPoint;
+  final bool enableNativeMap;
+
+  static Future<void> show(
+    BuildContext context, {
+    required LandAccessNoteController controller,
+    required String recordedBy,
+    awareness.GeoPoint? initialPoint,
+  }) => Navigator.of(context, rootNavigator: true).push(
+    MaterialPageRoute<void>(
+      builder: (_) => LandAccessNotesScreen(
+        controller: controller,
+        recordedBy: recordedBy,
+        initialPoint: initialPoint,
+      ),
+    ),
+  );
+
+  @override
+  State<LandAccessNotesScreen> createState() => _LandAccessNotesScreenState();
+}
+
+class _LandAccessNotesScreenState extends State<LandAccessNotesScreen> {
+  bool _showExpired = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!widget.controller.loaded) unawaited(widget.controller.load());
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    appBar: AppBar(title: const Text('Private land access')),
+    body: AnimatedBuilder(
+      animation: widget.controller,
+      builder: (context, _) {
+        final now = DateTime.now().toUtc();
+        final notes = widget.controller.notes
+            .where((note) => _showExpired || !note.isExpiredAt(now))
+            .toList(growable: false);
+        return ListView(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 120),
+          children: [
+            const _PrivacyBoundaryCard(),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                FilledButton.icon(
+                  key: const Key('add-land-access-note'),
+                  onPressed: widget.controller.busy
+                      ? null
+                      : () => _editNote(context),
+                  icon: const Icon(Icons.add_location_alt_outlined),
+                  label: const Text('Add place'),
+                ),
+                OutlinedButton.icon(
+                  key: const Key('import-land-access-notes'),
+                  onPressed: widget.controller.busy ? null : _import,
+                  icon: const Icon(Icons.lock_open_outlined),
+                  label: const Text('Import encrypted'),
+                ),
+                OutlinedButton.icon(
+                  key: const Key('export-land-access-notes'),
+                  onPressed:
+                      widget.controller.busy || widget.controller.notes.isEmpty
+                      ? null
+                      : _exportAll,
+                  icon: const Icon(Icons.lock_outlined),
+                  label: const Text('Export encrypted'),
+                ),
+              ],
+            ),
+            SwitchListTile(
+              key: const Key('show-land-access-notes-on-map'),
+              contentPadding: EdgeInsets.zero,
+              value: widget.controller.showOnMap,
+              title: const Text('Show active notes on recovery map'),
+              subtitle: const Text(
+                'Private points and outlines stay on this phone and hide at their review date.',
+              ),
+              onChanged: widget.controller.setShowOnMap,
+            ),
+            SwitchListTile(
+              key: const Key('show-expired-land-access-notes'),
+              contentPadding: EdgeInsets.zero,
+              value: _showExpired,
+              title: const Text('Show notes due for review'),
+              subtitle: const Text(
+                'Expired notes are hidden from the map by default.',
+              ),
+              onChanged: (value) => setState(() => _showExpired = value),
+            ),
+            if (widget.controller.errorMessage case final error?)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Text(
+                  error,
+                  style: const TextStyle(color: Color(0xFFFF9AAB)),
+                ),
+              ),
+            if (!widget.controller.loaded && widget.controller.busy)
+              const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(24),
+                  child: CircularProgressIndicator(),
+                ),
+              )
+            else if (notes.isEmpty)
+              const _EmptyLandAccessNotes()
+            else
+              for (final note in notes)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 10),
+                  child: _LandAccessNoteCard(
+                    note: note,
+                    onEdit: () => _editNote(context, note: note),
+                    onDelete: () => _delete(note),
+                  ),
+                ),
+          ],
+        );
+      },
+    ),
+  );
+
+  Future<void> _editNote(BuildContext context, {LandAccessNote? note}) async {
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => LandAccessNoteEditor(
+          controller: widget.controller,
+          recordedBy: widget.recordedBy,
+          note: note,
+          initialPoint: widget.initialPoint,
+          enableNativeMap: widget.enableNativeMap,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _delete(LandAccessNote note) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete this private note?'),
+        content: const Text(
+          'This removes the note and its export history from this phone. '
+          'It cannot erase copies you deliberately sent; ask every recipient '
+          'to delete those copies as well.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Keep'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) await widget.controller.delete(note.id);
+  }
+
+  Future<void> _exportAll() async {
+    final passphrase = await _askForPassphrase(
+      title: 'Encrypt private notes',
+      explanation:
+          'Choose at least 12 characters and send the passphrase separately. It is not saved.',
+      confirmation: true,
+    );
+    if (passphrase == null) return;
+    final exported = await widget.controller.export(
+      noteIds: widget.controller.notes.map((note) => note.id),
+      passphrase: passphrase,
+    );
+    if (exported == null || !mounted) return;
+    final date = exported.createdAt.toIso8601String().split('T').first;
+    await SharePlus.instance.share(
+      ShareParams(
+        subject: 'Encrypted Balloon Crumbs land access notes',
+        text:
+            'Private encrypted land access notes. Send the passphrase separately and delete the file when no longer needed.',
+        files: [
+          XFile.fromData(
+            exported.contents,
+            mimeType: 'application/vnd.balloon-crumbs.land-access+json',
+            name: 'balloon-crumbs-land-access-$date.bcland',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _import() async {
+    const type = XTypeGroup(
+      label: 'Balloon Crumbs private notes',
+      extensions: ['bcland'],
+    );
+    final file = await openFile(acceptedTypeGroups: const [type]);
+    if (file == null || !mounted) return;
+    final passphrase = await _askForPassphrase(
+      title: 'Open encrypted notes',
+      explanation:
+          'Enter the passphrase supplied by the exporting crew member. It is not saved.',
+    );
+    if (passphrase == null) return;
+    final imported = await widget.controller.import(
+      Uint8List.fromList(await file.readAsBytes()),
+      passphrase,
+    );
+    if (!mounted || widget.controller.errorMessage != null) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          '$imported private note${imported == 1 ? '' : 's'} imported.',
+        ),
+      ),
+    );
+  }
+
+  Future<String?> _askForPassphrase({
+    required String title,
+    required String explanation,
+    bool confirmation = false,
+  }) async {
+    final first = TextEditingController();
+    final second = TextEditingController();
+    String? error;
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: Text(title),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(explanation),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('land-access-passphrase'),
+                controller: first,
+                obscureText: true,
+                autocorrect: false,
+                enableSuggestions: false,
+                decoration: const InputDecoration(labelText: 'Passphrase'),
+              ),
+              if (confirmation) ...[
+                const SizedBox(height: 8),
+                TextField(
+                  key: const Key('land-access-passphrase-confirmation'),
+                  controller: second,
+                  obscureText: true,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  decoration: const InputDecoration(
+                    labelText: 'Confirm passphrase',
+                  ),
+                ),
+              ],
+              if (error case final message?) ...[
+                const SizedBox(height: 8),
+                Text(message, style: const TextStyle(color: Color(0xFFFF9AAB))),
+              ],
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final value = first.text;
+                if (value.runes.length < 12) {
+                  setDialogState(() => error = 'Use at least 12 characters.');
+                  return;
+                }
+                if (confirmation && value != second.text) {
+                  setDialogState(() => error = 'The passphrases do not match.');
+                  return;
+                }
+                Navigator.pop(context, value);
+              },
+              child: Text(confirmation ? 'Encrypt' : 'Open'),
+            ),
+          ],
+        ),
+      ),
+    );
+    first.dispose();
+    second.dispose();
+    return result;
+  }
+}
+
+class LandAccessNoteEditor extends StatefulWidget {
+  const LandAccessNoteEditor({
+    super.key,
+    required this.controller,
+    required this.recordedBy,
+    this.note,
+    this.initialPoint,
+    this.enableNativeMap = true,
+  });
+
+  final LandAccessNoteController controller;
+  final String recordedBy;
+  final LandAccessNote? note;
+  final awareness.GeoPoint? initialPoint;
+  final bool enableNativeMap;
+
+  @override
+  State<LandAccessNoteEditor> createState() => _LandAccessNoteEditorState();
+}
+
+class _LandAccessNoteEditorState extends State<LandAccessNoteEditor> {
+  late LandAccessGeometryKind _kind;
+  late List<awareness.GeoPoint> _points;
+  late LandAccessOutcome _outcome;
+  late LandAccessProvenance _provenance;
+  late LandAccessConsentStatus _consentStatus;
+  late DateTime _confirmedAt;
+  late DateTime _reviewAfter;
+  late final TextEditingController _firstName;
+  late final TextEditingController _contactRole;
+  late final TextEditingController _phone;
+  late final TextEditingController _gateNotes;
+  late final ValueNotifier<route_domain.GeoPoint?> _mapAnchor;
+  final _markers = ValueNotifier<List<MapOverlayMarker>>(const []);
+  final _traces = ValueNotifier<List<MapOverlayTrace>>(const []);
+  bool _privacyAcknowledged = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final note = widget.note;
+    _kind = note?.geometry.kind ?? LandAccessGeometryKind.point;
+    _points = [...?note?.geometry.points];
+    _outcome = note?.outcome ?? LandAccessOutcome.unknown;
+    _provenance = note?.provenance ?? LandAccessProvenance.crewObservation;
+    _consentStatus = note?.consentStatus ?? LandAccessConsentStatus.notRecorded;
+    _confirmedAt = note?.confirmedAt ?? DateTime.now().toUtc();
+    _reviewAfter =
+        note?.reviewAfter ?? _confirmedAt.add(const Duration(days: 365));
+    _firstName = TextEditingController(text: note?.firstName);
+    _contactRole = TextEditingController(text: note?.contactRole);
+    _phone = TextEditingController(text: note?.phoneNumber);
+    _gateNotes = TextEditingController(text: note?.gateNotes);
+    final anchor = _points.firstOrNull ?? widget.initialPoint;
+    _mapAnchor = ValueNotifier(
+      anchor == null
+          ? null
+          : route_domain.GeoPoint(
+              latitude: anchor.latitude,
+              longitude: anchor.longitude,
+            ),
+    );
+    _refreshGeometryOverlay();
+  }
+
+  @override
+  void dispose() {
+    _firstName.dispose();
+    _contactRole.dispose();
+    _phone.dispose();
+    _gateNotes.dispose();
+    _mapAnchor.dispose();
+    _markers.dispose();
+    _traces.dispose();
+    super.dispose();
+  }
+
+  bool get _geometryValid => switch (_kind) {
+    LandAccessGeometryKind.point => _points.length == 1,
+    LandAccessGeometryKind.polygon => _points.length >= 3,
+  };
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    appBar: AppBar(
+      title: Text(
+        widget.note == null
+            ? 'Add private access note'
+            : 'Edit private access note',
+      ),
+    ),
+    body: ListView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 28),
+      children: [
+        const Text(
+          'Tap the map to place an access point, or add at least three corners '
+          'for a field boundary. Boundaries are indicative and never identify '
+          'an owner or grant access.',
+          style: TextStyle(color: Color(0xFFB8C2CF)),
+        ),
+        const SizedBox(height: 12),
+        SegmentedButton<LandAccessGeometryKind>(
+          key: const Key('land-access-geometry-kind'),
+          segments: const [
+            ButtonSegment(
+              value: LandAccessGeometryKind.point,
+              icon: Icon(Icons.place_outlined),
+              label: Text('Point'),
+            ),
+            ButtonSegment(
+              value: LandAccessGeometryKind.polygon,
+              icon: Icon(Icons.polyline_outlined),
+              label: Text('Field outline'),
+            ),
+          ],
+          selected: {_kind},
+          onSelectionChanged: (values) {
+            setState(() {
+              _kind = values.single;
+              if (_kind == LandAccessGeometryKind.point && _points.length > 1) {
+                _points = [_points.last];
+              }
+              _refreshGeometryOverlay();
+            });
+          },
+        ),
+        const SizedBox(height: 10),
+        SizedBox(
+          height: 330,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: widget.enableNativeMap
+                ? RideMapFeature.fromEnvironment(
+                    key: const Key('land-access-map-editor'),
+                    currentPosition: _mapAnchor,
+                    overlayMarkers: _markers,
+                    riderTrails: _traces,
+                    showRouteProgress: false,
+                    canEditRoute: false,
+                    onMapTap: _addPoint,
+                  )
+                : ColoredBox(
+                    key: const Key('land-access-map-editor-placeholder'),
+                    color: const Color(0xFF111820),
+                    child: Center(
+                      child: Text(
+                        '${_points.length} map point${_points.length == 1 ? '' : 's'} selected',
+                      ),
+                    ),
+                  ),
+          ),
+        ),
+        Row(
+          children: [
+            Text('${_points.length} point${_points.length == 1 ? '' : 's'}'),
+            const Spacer(),
+            TextButton.icon(
+              key: const Key('undo-land-access-point'),
+              onPressed: _points.isEmpty ? null : _undoPoint,
+              icon: const Icon(Icons.undo),
+              label: const Text('Undo'),
+            ),
+            TextButton(
+              key: const Key('clear-land-access-points'),
+              onPressed: _points.isEmpty ? null : _clearPoints,
+              child: const Text('Clear'),
+            ),
+          ],
+        ),
+        DropdownButtonFormField<LandAccessOutcome>(
+          key: const Key('land-access-outcome'),
+          initialValue: _outcome,
+          decoration: const InputDecoration(labelText: 'Access outcome'),
+          items: LandAccessOutcome.values
+              .map(
+                (value) => DropdownMenuItem(
+                  value: value,
+                  child: Text(_outcomeLabel(value)),
+                ),
+              )
+              .toList(growable: false),
+          onChanged: (value) {
+            setState(() {
+              _outcome = value ?? _outcome;
+              _refreshGeometryOverlay();
+            });
+          },
+        ),
+        const SizedBox(height: 10),
+        TextField(
+          key: const Key('land-access-gate-notes'),
+          controller: _gateNotes,
+          maxLength: 1000,
+          maxLines: 3,
+          decoration: const InputDecoration(
+            labelText: 'Gate or access notes',
+            hintText: 'Which gate, where to park, who to ask',
+          ),
+        ),
+        const SizedBox(height: 4),
+        TextField(
+          key: const Key('land-access-first-name'),
+          controller: _firstName,
+          maxLength: 80,
+          decoration: const InputDecoration(labelText: 'First name (optional)'),
+        ),
+        TextField(
+          key: const Key('land-access-contact-role'),
+          controller: _contactRole,
+          maxLength: 80,
+          decoration: const InputDecoration(
+            labelText: 'Role (optional)',
+            hintText: 'Owner, occupier, farm manager',
+          ),
+        ),
+        TextField(
+          key: const Key('land-access-phone'),
+          controller: _phone,
+          maxLength: 40,
+          keyboardType: TextInputType.phone,
+          decoration: const InputDecoration(
+            labelText: 'Phone number (optional)',
+          ),
+        ),
+        const SizedBox(height: 4),
+        DropdownButtonFormField<LandAccessProvenance>(
+          key: const Key('land-access-provenance'),
+          initialValue: _provenance,
+          decoration: const InputDecoration(
+            labelText: 'How was this confirmed?',
+          ),
+          items: LandAccessProvenance.values
+              .map(
+                (value) => DropdownMenuItem(
+                  value: value,
+                  child: Text(_provenanceLabel(value)),
+                ),
+              )
+              .toList(growable: false),
+          onChanged: (value) =>
+              setState(() => _provenance = value ?? _provenance),
+        ),
+        const SizedBox(height: 10),
+        DropdownButtonFormField<LandAccessConsentStatus>(
+          key: const Key('land-access-consent'),
+          initialValue: _consentStatus,
+          decoration: const InputDecoration(labelText: 'Contact-data consent'),
+          items: LandAccessConsentStatus.values
+              .map(
+                (value) => DropdownMenuItem(
+                  value: value,
+                  child: Text(_consentLabel(value)),
+                ),
+              )
+              .toList(growable: false),
+          onChanged: (value) =>
+              setState(() => _consentStatus = value ?? _consentStatus),
+        ),
+        const SizedBox(height: 12),
+        ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: const Icon(Icons.event_outlined),
+          title: Text('Confirmed ${_formatDate(_confirmedAt)}'),
+          subtitle: Text('Review or delete by ${_formatDate(_reviewAfter)}'),
+          trailing: const Icon(Icons.edit_calendar_outlined),
+          onTap: _pickDates,
+        ),
+        Card(
+          color: const Color(0xFF1D2A35),
+          child: CheckboxListTile(
+            key: const Key('land-access-privacy-acknowledgement'),
+            value: _privacyAcknowledged,
+            onChanged: (value) =>
+                setState(() => _privacyAcknowledged = value ?? false),
+            title: const Text('Save privately on this phone'),
+            subtitle: const Text(
+              'Purpose: recovery access. Audience: this phone unless I make an '
+              'encrypted export. Retention: hidden at the review date until I '
+              'correct, renew or delete it. I have recorded only what is necessary.',
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.icon(
+          key: const Key('save-land-access-note'),
+          onPressed:
+              !_privacyAcknowledged || !_geometryValid || widget.controller.busy
+              ? null
+              : _save,
+          icon: const Icon(Icons.lock_outline),
+          label: const Text('Save private note'),
+        ),
+      ],
+    ),
+  );
+
+  void _addPoint(route_domain.GeoPoint point) {
+    setState(() {
+      final converted = awareness.GeoPoint(
+        latitude: point.latitude,
+        longitude: point.longitude,
+      );
+      if (_kind == LandAccessGeometryKind.point) {
+        _points = [converted];
+      } else if (_points.length < 200) {
+        _points = [..._points, converted];
+      }
+      _refreshGeometryOverlay();
+    });
+  }
+
+  void _undoPoint() {
+    setState(() {
+      _points = _points.sublist(0, _points.length - 1);
+      _refreshGeometryOverlay();
+    });
+  }
+
+  void _clearPoints() {
+    setState(() {
+      _points = [];
+      _refreshGeometryOverlay();
+    });
+  }
+
+  void _refreshGeometryOverlay() {
+    final color = _outcomeColor(_outcome);
+    _markers.value = [
+      for (var index = 0; index < _points.length; index += 1)
+        MapOverlayMarker(
+          id: 'land-access-editor-point-$index',
+          point: route_domain.GeoPoint(
+            latitude: _points[index].latitude,
+            longitude: _points[index].longitude,
+          ),
+          label: _kind == LandAccessGeometryKind.point
+              ? 'Access point'
+              : 'Field corner ${index + 1}',
+          icon: _kind == LandAccessGeometryKind.point
+              ? Icons.place_outlined
+              : Icons.circle,
+          color: color,
+        ),
+    ];
+    _traces.value =
+        _kind == LandAccessGeometryKind.polygon && _points.length >= 2
+        ? [
+            MapOverlayTrace(
+              id: 'land-access-editor-outline',
+              label: 'Private indicative field outline',
+              kind: RiderTrailKind.operationalBoundary,
+              color: color,
+              points: [
+                for (final point in _points)
+                  route_domain.GeoPoint(
+                    latitude: point.latitude,
+                    longitude: point.longitude,
+                  ),
+                if (_points.length >= 3)
+                  route_domain.GeoPoint(
+                    latitude: _points.first.latitude,
+                    longitude: _points.first.longitude,
+                  ),
+              ],
+            ),
+          ]
+        : const [];
+  }
+
+  Future<void> _pickDates() async {
+    final confirmed = await showDatePicker(
+      context: context,
+      firstDate: DateTime.utc(2020),
+      lastDate: DateTime.now().toUtc().add(const Duration(days: 1)),
+      initialDate: _confirmedAt,
+      helpText: 'When was this information confirmed?',
+    );
+    if (confirmed == null || !mounted) return;
+    final review = await showDatePicker(
+      context: context,
+      firstDate: confirmed,
+      lastDate: confirmed.add(const Duration(days: 730)),
+      initialDate: _reviewAfter.isBefore(confirmed) ? confirmed : _reviewAfter,
+      helpText: 'When should the crew review or delete it?',
+    );
+    if (review == null) return;
+    setState(() {
+      _confirmedAt = DateTime.utc(
+        confirmed.year,
+        confirmed.month,
+        confirmed.day,
+      );
+      _reviewAfter = DateTime.utc(review.year, review.month, review.day);
+    });
+  }
+
+  Future<void> _save() async {
+    final existing = widget.note;
+    final now = DateTime.now().toUtc();
+    await widget.controller.save(
+      LandAccessNote(
+        id: existing?.id ?? widget.controller.newId(),
+        geometry: LandAccessGeometry(kind: _kind, points: _points),
+        outcome: _outcome,
+        firstName: _optional(_firstName.text),
+        contactRole: _optional(_contactRole.text),
+        phoneNumber: _optional(_phone.text),
+        gateNotes: _gateNotes.text.trim(),
+        confirmedAt: _confirmedAt,
+        recordedBy: widget.recordedBy.trim().isEmpty
+            ? 'This device'
+            : widget.recordedBy.trim(),
+        provenance: _provenance,
+        consentStatus: _consentStatus,
+        reviewAfter: _reviewAfter,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      ),
+    );
+    if (mounted && widget.controller.errorMessage == null) {
+      Navigator.pop(context);
+    }
+  }
+}
+
+class _PrivacyBoundaryCard extends StatelessWidget {
+  const _PrivacyBoundaryCard();
+
+  @override
+  Widget build(BuildContext context) => const Card(
+    color: Color(0xFF1D2A35),
+    child: Padding(
+      padding: EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Private recovery memory',
+            style: TextStyle(fontWeight: FontWeight.w800),
+          ),
+          SizedBox(height: 6),
+          Text(
+            'These notes are encrypted on this device. They are never uploaded, '
+            'relayed, scored publicly or treated as permission. Sharing requires '
+            'an explicit encrypted export with a separate passphrase.',
+          ),
+          SizedBox(height: 6),
+          Text(
+            'If a named person asks for correction or removal, edit or delete the '
+            'record here and ask anyone who received an export to delete it too.',
+            style: TextStyle(color: Color(0xFFB8C2CF)),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _EmptyLandAccessNotes extends StatelessWidget {
+  const _EmptyLandAccessNotes();
+
+  @override
+  Widget build(BuildContext context) => const Padding(
+    padding: EdgeInsets.symmetric(vertical: 32),
+    child: Column(
+      children: [
+        Icon(Icons.place_outlined, size: 44, color: Color(0xFF8D98A7)),
+        SizedBox(height: 10),
+        Text(
+          'No private access notes on this phone',
+          style: TextStyle(fontWeight: FontWeight.w700),
+        ),
+        SizedBox(height: 4),
+        Text(
+          'Add only details the recovery crew genuinely needs.',
+          textAlign: TextAlign.center,
+        ),
+      ],
+    ),
+  );
+}
+
+class _LandAccessNoteCard extends StatelessWidget {
+  const _LandAccessNoteCard({
+    required this.note,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final LandAccessNote note;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final contact = [
+      ?_optional(note.firstName),
+      ?_optional(note.contactRole),
+    ].join(' · ');
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  note.geometry.kind == LandAccessGeometryKind.point
+                      ? Icons.place_outlined
+                      : Icons.polyline_outlined,
+                  color: _outcomeColor(note.outcome),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    _outcomeLabel(note.outcome),
+                    style: const TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Edit private note',
+                  onPressed: onEdit,
+                  icon: const Icon(Icons.edit_outlined),
+                ),
+                IconButton(
+                  tooltip: 'Delete private note',
+                  onPressed: onDelete,
+                  icon: const Icon(Icons.delete_outline),
+                ),
+              ],
+            ),
+            if (note.gateNotes.trim().isNotEmpty) Text(note.gateNotes),
+            if (contact.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Text(contact),
+            ],
+            if ((note.phoneNumber ?? '').trim().isNotEmpty)
+              Text(note.phoneNumber!),
+            const SizedBox(height: 8),
+            Text(
+              'Confirmed ${_formatDate(note.confirmedAt)} · review by ${_formatDate(note.reviewAfter)} · ${_provenanceLabel(note.provenance)}',
+              style: const TextStyle(color: Color(0xFF9EABB9), fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _outcomeLabel(LandAccessOutcome outcome) => switch (outcome) {
+  LandAccessOutcome.unknown => 'No access outcome recorded',
+  LandAccessOutcome.askFirst => 'Ask before vehicle access',
+  LandAccessOutcome.permissionConfirmed => 'Permission was confirmed',
+  LandAccessOutcome.accessDeclined => 'Vehicle access was declined',
+};
+
+Color _outcomeColor(LandAccessOutcome outcome) => switch (outcome) {
+  LandAccessOutcome.unknown => const Color(0xFF9EABB9),
+  LandAccessOutcome.askFirst => const Color(0xFFFFC857),
+  LandAccessOutcome.permissionConfirmed => const Color(0xFF72D5A4),
+  LandAccessOutcome.accessDeclined => const Color(0xFFFF8A80),
+};
+
+String _provenanceLabel(LandAccessProvenance provenance) =>
+    switch (provenance) {
+      LandAccessProvenance.crewObservation => 'Crew observation',
+      LandAccessProvenance.landContact => 'Land contact',
+      LandAccessProvenance.publicReference => 'Public reference',
+    };
+
+String _consentLabel(LandAccessConsentStatus consent) => switch (consent) {
+  LandAccessConsentStatus.notRecorded => 'No contact-data consent recorded',
+  LandAccessConsentStatus.verbal => 'Verbal consent recorded',
+  LandAccessConsentStatus.written => 'Written consent recorded',
+  LandAccessConsentStatus.contactRequestedRemoval =>
+    'Contact requested removal',
+};
+
+String _formatDate(DateTime value) =>
+    '${value.day.toString().padLeft(2, '0')}/${value.month.toString().padLeft(2, '0')}/${value.year}';
+
+String? _optional(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}

--- a/apps/mobile/lib/features/settings/unit_settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/unit_settings_sheet.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../controllers/chase_vehicle_controller.dart';
 import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/map_style_mode_controller.dart';
+import '../../controllers/land_access_note_controller.dart';
 import '../../controllers/rider_profile_controller.dart';
 import '../../controllers/route_progress_display_controller.dart';
 import '../../controllers/speed_limit_display_controller.dart';
@@ -14,6 +15,7 @@ import '../../controllers/spoken_guidance_controller.dart';
 import '../../controllers/test_control_controller.dart';
 import '../../domain/app_links.dart';
 import '../../domain/distance_unit.dart';
+import '../../domain/geo_point.dart';
 import '../../domain/map_style_mode.dart';
 import '../../domain/rider_color.dart';
 import '../../services/basemap_configuration.dart';
@@ -22,6 +24,7 @@ import '../../services/natural_voice_pack.dart';
 import '../../services/spoken_guidance.dart';
 import 'about_build_sheet.dart';
 import 'chase_vehicle_sheet.dart';
+import 'land_access_notes_screen.dart';
 import 'rider_profile_sheet.dart';
 import 'ride_diagnostics_section.dart';
 import 'test_control_section.dart';
@@ -41,6 +44,8 @@ class UnitSettingsSheet extends StatelessWidget {
     this.testControl,
     this.spokenGuidance,
     this.rideDiagnostics,
+    this.landAccessNotes,
+    this.currentPosition,
     this.embedded = false,
   });
 
@@ -67,6 +72,8 @@ class UnitSettingsSheet extends StatelessWidget {
 
   /// Off, and absent from an ordinary build (#419).
   final RideDiagnosticsController? rideDiagnostics;
+  final LandAccessNoteController? landAccessNotes;
+  final GeoPoint? currentPosition;
 
   /// Present only in a build carrying the test-control define. Null everywhere
   /// else, and [TestControlSection] renders nothing when the define is absent,
@@ -95,6 +102,8 @@ class UnitSettingsSheet extends StatelessWidget {
     TestControlController? testControl,
     SpokenGuidanceController? spokenGuidance,
     RideDiagnosticsController? rideDiagnostics,
+    LandAccessNoteController? landAccessNotes,
+    GeoPoint? currentPosition,
   }) => showModalBottomSheet<void>(
     context: context,
     showDragHandle: true,
@@ -112,6 +121,8 @@ class UnitSettingsSheet extends StatelessWidget {
       testControl: testControl,
       spokenGuidance: spokenGuidance,
       rideDiagnostics: rideDiagnostics,
+      landAccessNotes: landAccessNotes,
+      currentPosition: currentPosition,
     ),
   );
 
@@ -198,6 +209,42 @@ class UnitSettingsSheet extends StatelessWidget {
                 if (!embedded) Navigator.of(context).pop();
                 unawaited(
                   ChaseVehicleSheet.show(appContext, controller: chaseVehicle),
+                );
+              },
+            ),
+          ],
+          if (landAccessNotes case final landAccessNotes?) ...[
+            const SizedBox(height: 16),
+            Text(
+              'PRIVATE LAND ACCESS',
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: const Color(0xFF8D98A7),
+                letterSpacing: 1.1,
+              ),
+            ),
+            const SizedBox(height: 6),
+            ListTile(
+              key: const Key('open-land-access-notes'),
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.place_outlined),
+              title: const Text('Recovery access notes'),
+              subtitle: const Text(
+                'Encrypted on this phone; never a public permission score.',
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () {
+                final appContext = Navigator.of(
+                  context,
+                  rootNavigator: true,
+                ).context;
+                if (!embedded) Navigator.of(context).pop();
+                unawaited(
+                  LandAccessNotesScreen.show(
+                    appContext,
+                    controller: landAccessNotes,
+                    recordedBy: riderProfile.displayName,
+                    initialPoint: currentPosition,
+                  ),
                 );
               },
             ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:maplibre_gl/maplibre_gl.dart';
 
 import 'app/balloon_crumbs_app.dart';
 import 'controllers/distance_unit_controller.dart';
+import 'controllers/land_access_note_controller.dart';
 import 'controllers/completed_rides_controller.dart';
 import 'controllers/map_style_mode_controller.dart';
 import 'controllers/ride_code_preference_controller.dart';
@@ -20,6 +21,7 @@ import 'controllers/spoken_guidance_controller.dart';
 import 'controllers/test_control_controller.dart';
 import 'data/json_file_recorded_route_store.dart';
 import 'data/json_file_completed_ride_store.dart';
+import 'data/secure_land_access_note_store.dart';
 import 'data/shared_preferences_session_store.dart';
 import 'data/secure_crew_room_store.dart';
 import 'data/sqlite_event_store.dart';
@@ -102,6 +104,9 @@ Future<void> main() async {
     completedRideStore: completedRides,
     crewRoomStore: const SecureCrewRoomStore(),
   );
+  final landAccessNotes = LandAccessNoteController(
+    const SecureLandAccessNoteStore(),
+  );
 
   // The registry is created unconditionally - it is one nullable field - but the
   // server only binds a port when the define is present and the in-app switch is
@@ -136,6 +141,7 @@ Future<void> main() async {
       testControlRegistry: testControlRegistry,
       spokenGuidance: spokenGuidance,
       rideDiagnostics: rideDiagnostics,
+      landAccessNotes: landAccessNotes,
       initializeController: controller.initialize,
     ),
   );

--- a/apps/mobile/lib/services/land_access_note_export.dart
+++ b/apps/mobile/lib/services/land_access_note_export.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+
+import '../domain/land_access_note.dart';
+
+class LandAccessNoteExport {
+  const LandAccessNoteExport({
+    required this.exportId,
+    required this.createdAt,
+    required this.contents,
+    required this.noteIds,
+  });
+
+  final String exportId;
+  final DateTime createdAt;
+  final Uint8List contents;
+  final List<String> noteIds;
+}
+
+/// Password-encrypted, authenticated export format for deliberate crew sharing.
+class LandAccessNoteExportCodec {
+  LandAccessNoteExportCodec({
+    this.iterations = 210000,
+    Random? random,
+    AesGcm? cipher,
+  }) : _random = random ?? Random.secure(),
+       _cipher = cipher ?? AesGcm.with256bits() {
+    if (iterations < 10000 || iterations > 2000000) {
+      throw ArgumentError.value(iterations, 'iterations');
+    }
+  }
+
+  static const _associatedData = 'balloon-crumbs-land-access-notes-v1';
+  final int iterations;
+  final Random _random;
+  final AesGcm _cipher;
+
+  Future<LandAccessNoteExport> encrypt({
+    required List<LandAccessNote> notes,
+    required String passphrase,
+    required DateTime createdAt,
+    required String exportId,
+  }) async {
+    if (notes.isEmpty) throw const FormatException('Select at least one note.');
+    if (passphrase.runes.length < 12) {
+      throw const FormatException(
+        'Use an export passphrase of at least 12 characters.',
+      );
+    }
+    final salt = _randomBytes(16);
+    final nonce = _randomBytes(12);
+    final key = await _deriveKey(passphrase, salt, iterations);
+    final clearText = utf8.encode(
+      jsonEncode({
+        'schemaVersion': 1,
+        'exportId': exportId,
+        'createdAt': createdAt.toUtc().toIso8601String(),
+        'notes': notes.map((note) => note.toJson()).toList(growable: false),
+      }),
+    );
+    final box = await _cipher.encrypt(
+      clearText,
+      secretKey: key,
+      nonce: nonce,
+      aad: utf8.encode(_associatedData),
+    );
+    final envelope = {
+      'format': _associatedData,
+      'schemaVersion': 1,
+      'kdf': {
+        'name': 'PBKDF2-HMAC-SHA256',
+        'iterations': iterations,
+        'salt': base64Encode(salt),
+      },
+      'cipher': {
+        'name': 'AES-256-GCM',
+        'nonce': base64Encode(box.nonce),
+        'mac': base64Encode(box.mac.bytes),
+        'cipherText': base64Encode(box.cipherText),
+      },
+    };
+    return LandAccessNoteExport(
+      exportId: exportId,
+      createdAt: createdAt.toUtc(),
+      contents: Uint8List.fromList(utf8.encode(jsonEncode(envelope))),
+      noteIds: List.unmodifiable(notes.map((note) => note.id)),
+    );
+  }
+
+  Future<List<LandAccessNote>> decrypt(
+    Uint8List contents,
+    String passphrase,
+  ) async {
+    if (passphrase.runes.length < 12) {
+      throw const FormatException('The export passphrase is too short.');
+    }
+    try {
+      final envelope = Map<String, Object?>.from(
+        jsonDecode(utf8.decode(contents, allowMalformed: false)) as Map,
+      );
+      if (envelope['format'] != _associatedData ||
+          envelope['schemaVersion'] != 1) {
+        throw const FormatException(
+          'This is not a Balloon Crumbs land access export.',
+        );
+      }
+      final kdf = Map<String, Object?>.from(envelope['kdf']! as Map);
+      final cipher = Map<String, Object?>.from(envelope['cipher']! as Map);
+      final exportIterations = kdf['iterations']! as int;
+      if (kdf['name'] != 'PBKDF2-HMAC-SHA256' ||
+          cipher['name'] != 'AES-256-GCM' ||
+          exportIterations < 10000 ||
+          exportIterations > 2000000) {
+        throw const FormatException(
+          'The encrypted export settings are unsupported.',
+        );
+      }
+      final salt = base64Decode(kdf['salt']! as String);
+      final nonce = base64Decode(cipher['nonce']! as String);
+      final mac = base64Decode(cipher['mac']! as String);
+      final cipherText = base64Decode(cipher['cipherText']! as String);
+      if (salt.length != 16 || nonce.length != 12 || mac.length != 16) {
+        throw const FormatException('The encrypted export is malformed.');
+      }
+      final key = await _deriveKey(passphrase, salt, exportIterations);
+      final clearText = await _cipher.decrypt(
+        SecretBox(cipherText, nonce: nonce, mac: Mac(mac)),
+        secretKey: key,
+        aad: utf8.encode(_associatedData),
+      );
+      final payload = Map<String, Object?>.from(
+        jsonDecode(utf8.decode(clearText, allowMalformed: false)) as Map,
+      );
+      if (payload['schemaVersion'] != 1 || payload['notes'] is! List) {
+        throw const FormatException('The decrypted export is invalid.');
+      }
+      final notes = (payload['notes']! as List)
+          .map(
+            (item) =>
+                LandAccessNote.fromJson(Map<String, Object?>.from(item as Map)),
+          )
+          .toList(growable: false);
+      if (notes.isEmpty ||
+          notes.length > 500 ||
+          notes.map((note) => note.id).toSet().length != notes.length) {
+        throw const FormatException('The decrypted export is invalid.');
+      }
+      return List.unmodifiable(notes);
+    } on SecretBoxAuthenticationError {
+      throw const FormatException(
+        'The passphrase is wrong or the export was changed.',
+      );
+    } on FormatException {
+      rethrow;
+    } on Object {
+      throw const FormatException('The encrypted export could not be opened.');
+    }
+  }
+
+  Future<SecretKey> _deriveKey(String passphrase, List<int> salt, int rounds) =>
+      Pbkdf2(
+        macAlgorithm: Hmac.sha256(),
+        iterations: rounds,
+        bits: 256,
+      ).deriveKey(secretKey: SecretKey(utf8.encode(passphrase)), nonce: salt);
+
+  Uint8List _randomBytes(int length) => Uint8List.fromList(
+    List<int>.generate(length, (_) => _random.nextInt(256), growable: false),
+  );
+}

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -137,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   archive: ^4.0.9
   audioplayers: ^6.8.1
   crypto: ^3.0.7
+  cryptography: ^2.9.0
   file_selector: ^1.1.0
   flutter_map: ^8.3.1
   flutter_secure_storage: ^10.3.1

--- a/apps/mobile/test/contracts/land_access_notes_local_only_test.dart
+++ b/apps/mobile/test/contracts/land_access_notes_local_only_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'land access contacts have no relay or diagnostics serialization path',
+    () {
+      final forbiddenRoots = [
+        Directory('../server/src'),
+        Directory('lib/internet'),
+        Directory('lib/relay'),
+        Directory('lib/services'),
+      ];
+      const forbiddenWireFields = [
+        'landAccessNote',
+        'landAccessNotes',
+        'landContact',
+        'contactPhoneNumber',
+      ];
+
+      for (final root in forbiddenRoots) {
+        for (final entity in root.listSync(recursive: true).whereType<File>()) {
+          if (!entity.path.endsWith('.dart') && !entity.path.endsWith('.py')) {
+            continue;
+          }
+          if (entity.path.endsWith('land_access_note_export.dart')) continue;
+          final source = entity.readAsStringSync();
+          for (final field in forbiddenWireFields) {
+            expect(
+              source,
+              isNot(contains("'$field'")),
+              reason: '${entity.path} must not serialize $field',
+            );
+          }
+        }
+      }
+    },
+  );
+}

--- a/apps/mobile/test/data/secure_land_access_note_store_test.dart
+++ b/apps/mobile/test/data/secure_land_access_note_store_test.dart
@@ -1,0 +1,85 @@
+import 'package:balloon_crumbs/data/secure_land_access_note_store.dart';
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/land_access_note.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  test('notes and export metadata remain in secure storage', () async {
+    const store = SecureLandAccessNoteStore();
+    final note = _note('field-a');
+
+    await store.upsert(note);
+    await store.recordExport(
+      LandAccessExportMetadata(
+        exportId: 'export-a',
+        noteIds: [note.id],
+        createdAt: DateTime.utc(2026, 8, 24),
+      ),
+    );
+
+    expect(await store.loadNotes(), hasLength(1));
+    expect(await store.loadExportMetadata(), hasLength(1));
+  });
+
+  test('deleting a note removes its local export metadata', () async {
+    const store = SecureLandAccessNoteStore();
+    final first = _note('field-a');
+    final second = _note('field-b');
+    await store.upsert(first);
+    await store.upsert(second);
+    await store.recordExport(
+      LandAccessExportMetadata(
+        exportId: 'export-a',
+        noteIds: [first.id, second.id],
+        createdAt: DateTime.utc(2026, 8, 24),
+      ),
+    );
+
+    await store.delete(first.id);
+    var metadata = await store.loadExportMetadata();
+    expect(metadata.single.noteIds, [second.id]);
+
+    await store.delete(second.id);
+    metadata = await store.loadExportMetadata();
+    expect(metadata, isEmpty);
+    expect(await store.loadNotes(), isEmpty);
+  });
+
+  test('malformed storage is deleted rather than partly disclosed', () async {
+    await const FlutterSecureStorage().write(
+      key: 'balloon_crumbs_land_access_notes_v1',
+      value: '{"schemaVersion":1,"notes":"private","exports":[]}',
+    );
+
+    expect(await const SecureLandAccessNoteStore().loadNotes(), isEmpty);
+    expect(
+      await const FlutterSecureStorage().read(
+        key: 'balloon_crumbs_land_access_notes_v1',
+      ),
+      isNull,
+    );
+  });
+}
+
+LandAccessNote _note(String id) => LandAccessNote(
+  id: id,
+  geometry: LandAccessGeometry(
+    kind: LandAccessGeometryKind.point,
+    points: const [GeoPoint(latitude: 51.1, longitude: -2.1)],
+  ),
+  outcome: LandAccessOutcome.unknown,
+  confirmedAt: DateTime.utc(2026, 8, 24),
+  recordedBy: 'Synthetic tester',
+  provenance: LandAccessProvenance.crewObservation,
+  consentStatus: LandAccessConsentStatus.notRecorded,
+  reviewAfter: DateTime.utc(2027, 8, 24),
+  createdAt: DateTime.utc(2026, 8, 24),
+  updatedAt: DateTime.utc(2026, 8, 24),
+);

--- a/apps/mobile/test/domain/land_access_note_test.dart
+++ b/apps/mobile/test/domain/land_access_note_test.dart
@@ -1,0 +1,76 @@
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/land_access_note.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('land access note preserves privacy governance fields', () {
+    final note = _note();
+
+    final restored = LandAccessNote.fromJson(note.toJson());
+
+    expect(restored.id, note.id);
+    expect(restored.geometry.kind, LandAccessGeometryKind.polygon);
+    expect(restored.geometry.points, hasLength(3));
+    expect(restored.outcome, LandAccessOutcome.askFirst);
+    expect(restored.firstName, 'Pat');
+    expect(restored.contactRole, 'Occupier');
+    expect(restored.phoneNumber, '07000 000000');
+    expect(restored.provenance, LandAccessProvenance.landContact);
+    expect(restored.consentStatus, LandAccessConsentStatus.verbal);
+    expect(restored.reviewAfter, DateTime.utc(2027, 8, 24));
+  });
+
+  test('point and polygon geometry reject ambiguous shapes', () {
+    expect(
+      () => LandAccessGeometry(
+        kind: LandAccessGeometryKind.point,
+        points: const [
+          GeoPoint(latitude: 51, longitude: -2),
+          GeoPoint(latitude: 52, longitude: -2),
+        ],
+      ),
+      throwsFormatException,
+    );
+    expect(
+      () => LandAccessGeometry(
+        kind: LandAccessGeometryKind.polygon,
+        points: const [
+          GeoPoint(latitude: 51, longitude: -2),
+          GeoPoint(latitude: 52, longitude: -2),
+        ],
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('review date cannot predate the confirmation', () {
+    expect(
+      () => _note(reviewAfter: DateTime.utc(2026, 8, 23)),
+      throwsFormatException,
+    );
+  });
+}
+
+LandAccessNote _note({DateTime? reviewAfter}) => LandAccessNote(
+  id: 'field-1',
+  geometry: LandAccessGeometry(
+    kind: LandAccessGeometryKind.polygon,
+    points: const [
+      GeoPoint(latitude: 51.1, longitude: -2.1),
+      GeoPoint(latitude: 51.2, longitude: -2.1),
+      GeoPoint(latitude: 51.2, longitude: -2.2),
+    ],
+  ),
+  outcome: LandAccessOutcome.askFirst,
+  firstName: 'Pat',
+  contactRole: 'Occupier',
+  phoneNumber: '07000 000000',
+  gateNotes: 'Use the eastern gate after asking.',
+  confirmedAt: DateTime.utc(2026, 8, 24),
+  recordedBy: 'Synthetic tester',
+  provenance: LandAccessProvenance.landContact,
+  consentStatus: LandAccessConsentStatus.verbal,
+  reviewAfter: reviewAfter ?? DateTime.utc(2027, 8, 24),
+  createdAt: DateTime.utc(2026, 8, 24),
+  updatedAt: DateTime.utc(2026, 8, 24),
+);

--- a/apps/mobile/test/features/map/land_access_note_map_projection_test.dart
+++ b/apps/mobile/test/features/map/land_access_note_map_projection_test.dart
@@ -1,0 +1,56 @@
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/land_access_note.dart';
+import 'package:balloon_crumbs/features/map/land_access_note_map_projection.dart';
+import 'package:balloon_crumbs/services/rider_trail_recorder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('projection hides expired notes and private contact values', () {
+    final active = _note('active', reviewAfter: DateTime.utc(2027));
+    final expired = _note('expired', reviewAfter: DateTime.utc(2025));
+
+    final projection = projectLandAccessNotes([
+      active,
+      expired,
+    ], now: DateTime.utc(2026, 8, 24));
+
+    expect(projection.markers, hasLength(1));
+    expect(projection.traces, hasLength(1));
+    expect(projection.markers.single.id, contains('active'));
+    expect(projection.markers.single.label, contains('ask before'));
+    expect(projection.markers.single.label, isNot(contains('Pat')));
+    expect(projection.markers.single.label, isNot(contains('07000')));
+    expect(projection.traces.single.kind, RiderTrailKind.operationalBoundary);
+    expect(
+      projection.traces.single.points.first.latitude,
+      projection.traces.single.points.last.latitude,
+    );
+    expect(
+      projection.traces.single.points.first.longitude,
+      projection.traces.single.points.last.longitude,
+    );
+  });
+}
+
+LandAccessNote _note(String id, {required DateTime reviewAfter}) =>
+    LandAccessNote(
+      id: id,
+      geometry: LandAccessGeometry(
+        kind: LandAccessGeometryKind.polygon,
+        points: const [
+          GeoPoint(latitude: 51.1, longitude: -2.1),
+          GeoPoint(latitude: 51.2, longitude: -2.1),
+          GeoPoint(latitude: 51.2, longitude: -2.2),
+        ],
+      ),
+      outcome: LandAccessOutcome.askFirst,
+      firstName: 'Pat',
+      phoneNumber: '07000 000000',
+      confirmedAt: DateTime.utc(2024),
+      recordedBy: 'Synthetic tester',
+      provenance: LandAccessProvenance.landContact,
+      consentStatus: LandAccessConsentStatus.verbal,
+      reviewAfter: reviewAfter,
+      createdAt: DateTime.utc(2024),
+      updatedAt: DateTime.utc(2024),
+    );

--- a/apps/mobile/test/features/settings/land_access_notes_screen_test.dart
+++ b/apps/mobile/test/features/settings/land_access_notes_screen_test.dart
@@ -1,0 +1,145 @@
+import 'dart:math';
+
+import 'package:balloon_crumbs/controllers/land_access_note_controller.dart';
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/land_access_note.dart';
+import 'package:balloon_crumbs/domain/land_access_note_store.dart';
+import 'package:balloon_crumbs/features/settings/land_access_notes_screen.dart';
+import 'package:balloon_crumbs/services/land_access_note_export.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('manager explains the local privacy boundary and map toggle', (
+    tester,
+  ) async {
+    final controller = LandAccessNoteController(
+      _MemoryStore([_note()]),
+      exportCodec: LandAccessNoteExportCodec(
+        iterations: 10000,
+        random: Random(1),
+      ),
+    );
+    await controller.load();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: LandAccessNotesScreen(
+          controller: controller,
+          recordedBy: 'Synthetic tester',
+          enableNativeMap: false,
+        ),
+      ),
+    );
+
+    expect(find.text('Private recovery memory'), findsOneWidget);
+    expect(find.textContaining('never uploaded'), findsOneWidget);
+    expect(
+      find.textContaining('never a public permission score'),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('show-land-access-notes-on-map')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('show-land-access-notes-on-map')));
+    await tester.pump();
+    expect(controller.showOnMap, isTrue);
+  });
+
+  testWidgets(
+    'editor requires purpose audience and retention acknowledgement',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(945, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final store = _MemoryStore([_note()]);
+      final controller = LandAccessNoteController(store);
+      await controller.load();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: LandAccessNoteEditor(
+            controller: controller,
+            recordedBy: 'Synthetic tester',
+            note: _note(),
+            enableNativeMap: false,
+          ),
+        ),
+      );
+
+      final acknowledgement = find.byKey(
+        const Key('land-access-privacy-acknowledgement'),
+      );
+      expect(find.textContaining('Purpose: recovery access'), findsOneWidget);
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.byKey(const Key('save-land-access-note')),
+            )
+            .onPressed,
+        isNull,
+      );
+
+      await tester.tap(acknowledgement);
+      await tester.pump();
+      expect(
+        tester
+            .widget<FilledButton>(
+              find.byKey(const Key('save-land-access-note')),
+            )
+            .onPressed,
+        isNotNull,
+      );
+    },
+  );
+}
+
+LandAccessNote _note() => LandAccessNote(
+  id: 'field-a',
+  geometry: LandAccessGeometry(
+    kind: LandAccessGeometryKind.point,
+    points: const [GeoPoint(latitude: 51.1, longitude: -2.1)],
+  ),
+  outcome: LandAccessOutcome.askFirst,
+  gateNotes: 'Ask before opening the gate.',
+  confirmedAt: DateTime.utc(2026, 8, 24),
+  recordedBy: 'Synthetic tester',
+  provenance: LandAccessProvenance.crewObservation,
+  consentStatus: LandAccessConsentStatus.notRecorded,
+  reviewAfter: DateTime.utc(2027, 8, 24),
+  createdAt: DateTime.utc(2026, 8, 24),
+  updatedAt: DateTime.utc(2026, 8, 24),
+);
+
+class _MemoryStore implements LandAccessNoteStore {
+  _MemoryStore(List<LandAccessNote> notes) : _notes = [...notes];
+
+  List<LandAccessNote> _notes;
+  final List<LandAccessExportMetadata> _exports = [];
+
+  @override
+  Future<void> delete(String noteId) async {
+    _notes.removeWhere((note) => note.id == noteId);
+    _exports.removeWhere((item) => item.noteIds.contains(noteId));
+  }
+
+  @override
+  Future<List<LandAccessExportMetadata>> loadExportMetadata() async =>
+      List.unmodifiable(_exports);
+
+  @override
+  Future<List<LandAccessNote>> loadNotes() async => List.unmodifiable(_notes);
+
+  @override
+  Future<void> recordExport(LandAccessExportMetadata metadata) async {
+    _exports.add(metadata);
+  }
+
+  @override
+  Future<void> upsert(LandAccessNote note) async {
+    _notes = [..._notes.where((item) => item.id != note.id), note];
+  }
+}

--- a/apps/mobile/test/services/land_access_note_export_test.dart
+++ b/apps/mobile/test/services/land_access_note_export_test.dart
@@ -1,0 +1,92 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/land_access_note.dart';
+import 'package:balloon_crumbs/services/land_access_note_export.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late LandAccessNoteExportCodec codec;
+
+  setUp(() {
+    codec = LandAccessNoteExportCodec(iterations: 10000, random: Random(42));
+  });
+
+  test(
+    'authenticated encrypted export round trips governance fields',
+    () async {
+      final note = _note();
+      final encrypted = await codec.encrypt(
+        notes: [note],
+        passphrase: 'correct horse battery staple',
+        createdAt: DateTime.utc(2026, 8, 24),
+        exportId: 'export-1',
+      );
+
+      final text = String.fromCharCodes(encrypted.contents);
+      expect(text, isNot(contains('Pat')));
+      expect(text, isNot(contains('07000')));
+      expect(text, contains('AES-256-GCM'));
+
+      final restored = await codec.decrypt(
+        encrypted.contents,
+        'correct horse battery staple',
+      );
+      expect(restored.single.toJson(), note.toJson());
+    },
+  );
+
+  test('wrong passphrase and tampering fail authentication', () async {
+    final encrypted = await codec.encrypt(
+      notes: [_note()],
+      passphrase: 'correct horse battery staple',
+      createdAt: DateTime.utc(2026, 8, 24),
+      exportId: 'export-1',
+    );
+
+    await expectLater(
+      codec.decrypt(encrypted.contents, 'this passphrase is wrong'),
+      throwsFormatException,
+    );
+
+    final tampered = Uint8List.fromList(encrypted.contents);
+    final index = tampered.lastIndexWhere((byte) => byte != 0x7D);
+    tampered[index] = tampered[index] == 0x41 ? 0x42 : 0x41;
+    await expectLater(
+      codec.decrypt(tampered, 'correct horse battery staple'),
+      throwsFormatException,
+    );
+  });
+
+  test('exports require a deliberate non-trivial passphrase', () async {
+    await expectLater(
+      codec.encrypt(
+        notes: [_note()],
+        passphrase: 'short',
+        createdAt: DateTime.utc(2026, 8, 24),
+        exportId: 'export-1',
+      ),
+      throwsFormatException,
+    );
+  });
+}
+
+LandAccessNote _note() => LandAccessNote(
+  id: 'field-a',
+  geometry: LandAccessGeometry(
+    kind: LandAccessGeometryKind.point,
+    points: const [GeoPoint(latitude: 51.1, longitude: -2.1)],
+  ),
+  outcome: LandAccessOutcome.permissionConfirmed,
+  firstName: 'Pat',
+  phoneNumber: '07000 000000',
+  gateNotes: 'Phone before using the gate.',
+  confirmedAt: DateTime.utc(2026, 8, 24),
+  recordedBy: 'Synthetic tester',
+  provenance: LandAccessProvenance.landContact,
+  consentStatus: LandAccessConsentStatus.verbal,
+  reviewAfter: DateTime.utc(2027, 8, 24),
+  createdAt: DateTime.utc(2026, 8, 24),
+  updatedAt: DateTime.utc(2026, 8, 24),
+);

--- a/docs/land-access-notes-privacy.md
+++ b/docs/land-access-notes-privacy.md
@@ -1,0 +1,92 @@
+# Private land-access notes: privacy and abuse boundary
+
+Status: implemented as a device-local v1. This is an engineering record, not
+legal advice. A club or commercial operator must document its own controller,
+lawful basis and retention decision before deploying the feature to its crew.
+
+## Purpose and data flow
+
+The sole purpose is helping a recovery crew remember where to seek permission
+and how to approach a field after a landing. A record can contain an indicative
+point or polygon, gate/access notes, a factual access outcome, an optional first
+name/role/phone number, confirmation and review dates, recorder, provenance and
+contact-data consent state.
+
+V1 is deliberately bounded:
+
+- the record is held in the iOS Keychain or Android encrypted-storage boundary
+  through `FlutterSecureStorage`;
+- it is not an event, analytics property, diagnostic item, notification,
+  server request, relay payload or automatic backup;
+- the ordinary recovery map can render a local point/outline only after the
+  user switches the private layer on, and hides records due for review;
+- sharing is an explicit file export encrypted and authenticated with AES-256
+  GCM; PBKDF2-HMAC-SHA256 derives the key from a passphrase that is never saved;
+- the exporting user must send the passphrase separately and choose the
+  recipient. Import is equally deliberate.
+
+An encrypted export is still personal data in the hands of its sender and
+recipient. Deleting the local record removes its local export metadata, but
+cannot remotely erase a file already sent. The UI tells the user to ask every
+recipient to delete such copies.
+
+## Controller, lawful basis and consent
+
+Balloon Crumbs has no account or central land-contact service and does not
+receive this data. The person or organisation deciding why the record exists
+and who receives it is the controller for that copy. A club/operator should
+record the controller name and contact route in its own member notice.
+
+Do not assume that participation in a flight is consent to store a land
+contact's details. An operator considering legitimate interests should complete
+and retain its own purpose/necessity/balancing assessment. Where consent is the
+chosen basis, it must be specific, informed and withdrawable. The app records
+whether verbal/written consent was obtained, no consent was recorded, or the
+contact requested removal; it does not turn that label into legal validity.
+
+Record the minimum needed. Name, role and phone are optional. Never use free
+text for gossip, allegations or sensitive personal information.
+
+## Retention, correction and removal
+
+New records default to a review date 12 months after confirmation; the user may
+choose an earlier date. On that date the record disappears from the recovery
+map and the active list until it is corrected, renewed or deleted. Operational
+policy should prefer deletion when the crew cannot reconfirm the information.
+
+A contact subject can ask the crew member or club that recorded/shared the data
+to view, correct or remove it. That user can edit or delete the record on the
+device and must notify known export recipients. There is no central Balloon
+Crumbs database to search or erase in v1.
+
+## Neutral presentation and limitations
+
+Outcomes are restricted to:
+
+- no outcome recorded;
+- ask before vehicle access;
+- permission was confirmed;
+- vehicle access was declined.
+
+They describe one dated interaction. There is no cooperation rating, public
+leaderboard or automatic sharing. A point, drawn outline, HMLR reference or
+previous permission never identifies the current owner/occupier, grants access,
+or establishes a safe landing area.
+
+## Abuse threat model
+
+| Threat | V1 control | Residual action |
+| --- | --- | --- |
+| Public landowner directory or reputation score | No server/relay API; local layer off by default; fixed neutral outcomes | Do not screenshot or republish the layer |
+| Phone/name leaked through logs or notifications | Domain/store are outside diagnostics, notifications, events and internet clients; contract test scans those boundaries | Report any new serialization path as a release blocker |
+| Lost or inspected phone | Keychain/keystore-backed storage; app exposes only the local user's records | Device passcode, OS updates and remote device controls remain the user's responsibility |
+| Export intercepted | AES-256-GCM authenticated encryption; separate unsaved 12+ character passphrase | Use a distinct passphrase and separate channel; delete after import |
+| Weak or malicious import | Authenticated envelope, bounded KDF settings, schema/size/geometry limits, newest-update conflict rule | Import only from a known crew member |
+| Stale permission treated as current | Confirmation/provenance/review visible; expired records hidden from active map | Reconfirm locally before access every time |
+| Contact cannot withdraw | Edit/delete and explicit recipient-deletion instructions | Clubs must publish their own controller contact route |
+| Free-text harassment or sensitive claims | Purpose copy and 1,000-character bound; no public sharing path | Crew policy and device owner remain responsible for appropriate content |
+
+Any future relay sync, club directory, moderation or remote deletion service is
+a new privacy product. It requires a separate notice, access controls, audit
+trail, correction/erasure workflow, abuse response and legal review before code
+or API activation.


### PR DESCRIPTION
Closes #76

## What changed
- adds device-local keychain/keystore-backed land-access point and polygon notes
- requires purpose, audience and retention acknowledgement before saving optional contact data
- adds dated provenance, consent state, neutral outcomes, correction/deletion and an optional private recovery-map layer
- adds deliberate AES-256-GCM encrypted export/import with an unsaved passphrase and local export-metadata cleanup
- documents controller/lawful-basis, retention, removal and abuse boundaries
- proves that land-access contact fields have no relay/server/diagnostic serialization path

## Verification
- `flutter analyze lib test`
- `flutter test` (1,828 passed; 24 intentional skips)
- focused crypto, secure-store, projection, contract and widget suites