### PR TITLE
Complete weather and wind context

### DIFF
--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -4265,36 +4265,43 @@ class _RideMapScreenState extends State<RideMapScreen> {
       Marker(
         point: LatLng(sample.position.latitude, sample.position.longitude),
         width: 52,
-        height: 48,
+        height: 56,
         child: Semantics(
           label:
-              'Forecast wind from ${sample.vector.fromDegrees.round()} degrees '
-              'at ${sample.vector.speedKmh.round()} kilometres per hour',
+              '${_windForecastSemanticPrefix()} from '
+              '${sample.vector.fromDegrees.round()} degrees at '
+              '${sample.vector.speedKmh.round()} kilometres per hour'
+              '${sample.surfaceGustKmh == null ? '' : ', with a 10 metre above ground gust of ${sample.surfaceGustKmh!.round()} kilometres per hour'}',
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               Transform.rotate(
                 angle: sample.vector.towardDegrees * math.pi / 180,
-                child: const Icon(
+                child: Icon(
                   Icons.navigation_rounded,
-                  color: Color(0xFF64D8FF),
+                  color: _windForecastColor(),
                   size: 25,
-                  shadows: [Shadow(color: Color(0xFF07131C), blurRadius: 5)],
+                  shadows: const [
+                    Shadow(color: Color(0xFF07131C), blurRadius: 5),
+                  ],
                 ),
               ),
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 3, vertical: 1),
                 decoration: BoxDecoration(
-                  color: const Color(0xD907131C),
+                  color: _windForecastColor().withValues(alpha: 0.88),
                   borderRadius: BorderRadius.circular(4),
                 ),
                 child: Text(
-                  '${sample.vector.speedKmh.round()}',
+                  '${sample.vector.speedKmh.round()}'
+                  '${sample.surfaceGustKmh == null ? '' : ' G${sample.surfaceGustKmh!.round()}'}',
                   style: const TextStyle(
                     color: Colors.white,
                     fontSize: 9,
                     fontWeight: FontWeight.w800,
                   ),
+                  maxLines: 1,
+                  softWrap: false,
                 ),
               ),
             ],
@@ -4302,6 +4309,31 @@ class _RideMapScreenState extends State<RideMapScreen> {
         ),
       ),
   ];
+
+  Color _windForecastColor() =>
+      switch (widget.windForecastController?.freshness) {
+        WindForecastFreshness.currentForecast => const Color(0xFF168FC2),
+        WindForecastFreshness.staleForecast => const Color(0xFFC67C00),
+        WindForecastFreshness.bundledReference => const Color(0xFF766790),
+        null => const Color(0xFF52606D),
+      };
+
+  String _windForecastColorHex() =>
+      '#${(_windForecastColor().toARGB32() & 0xFFFFFF).toRadixString(16).padLeft(6, '0').toUpperCase()}';
+
+  String _windForecastSemanticPrefix() {
+    final controller = widget.windForecastController;
+    final field = controller?.field;
+    if (controller == null || field == null) return 'Unavailable forecast wind';
+    final state = switch (controller.freshness) {
+      WindForecastFreshness.currentForecast => 'Current forecast wind',
+      WindForecastFreshness.staleForecast => 'Stale forecast wind',
+      WindForecastFreshness.bundledReference => 'Bundled reference wind',
+      null => 'Unavailable forecast wind',
+    };
+    return '$state, ${field.sourceLabel}, valid '
+        '${field.validAt.toLocal().toIso8601String()}';
+  }
 
   Widget _overlayMarkerChild(MapOverlayMarker overlay) {
     final hazard = overlay.hazardSymbol;
@@ -4449,7 +4481,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         _windForecastLayer,
         const ml.SymbolLayerProperties(
           iconImage: _windForecastImage,
-          iconColor: '#64D8FF',
+          iconColor: ['get', 'color'],
           iconHaloColor: '#07131C',
           iconHaloWidth: 2,
           iconSize: 0.17,
@@ -5160,7 +5192,12 @@ class _RideMapScreenState extends State<RideMapScreen> {
             'toward': sample.vector.towardDegrees,
             'from': sample.vector.fromDegrees,
             'speedKmh': sample.vector.speedKmh,
-            'speedLabel': '${sample.vector.speedKmh.round()}',
+            if (sample.surfaceGustKmh != null)
+              'surfaceGustKmh': sample.surfaceGustKmh,
+            'speedLabel':
+                '${sample.vector.speedKmh.round()}'
+                '${sample.surfaceGustKmh == null ? '' : ' G${sample.surfaceGustKmh!.round()}'}',
+            'color': _windForecastColorHex(),
           },
           'geometry': {
             'type': 'Point',
@@ -9057,11 +9094,25 @@ class _WindForecastChip extends StatelessWidget {
     animation: controller,
     builder: (context, _) {
       final field = controller.field;
+      final localizations = MaterialLocalizations.of(context);
+      final validAt = field?.validAt.toLocal();
+      final validLabel = validAt == null
+          ? null
+          : '${localizations.formatShortDate(validAt)} '
+                '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(validAt))}';
       final status = field == null
           ? controller.loading
                 ? 'Loading forecast…'
                 : 'Forecast unavailable'
-          : field.sourceLabel;
+          : switch (controller.freshness) {
+              WindForecastFreshness.currentForecast =>
+                'CURRENT · valid $validLabel · UKMO/Open-Meteo',
+              WindForecastFreshness.staleForecast =>
+                'STALE · valid $validLabel · UKMO/Open-Meteo',
+              WindForecastFreshness.bundledReference =>
+                'REFERENCE · $validLabel · bundled model',
+              null => 'Forecast unavailable',
+            };
       return Card(
         key: const Key('wind-forecast-chip'),
         margin: EdgeInsets.zero,
@@ -9141,13 +9192,27 @@ class _WindForecastControl extends StatelessWidget {
           ? null
           : '${localizations.formatShortDate(validAt)} '
                 '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(validAt))}';
+      final freshness = controller.freshness;
+      final fetchedAge = field?.fetchedAgeAt(DateTime.now());
+      final fetchedAgeLabel = fetchedAge == null
+          ? null
+          : fetchedAge.inMinutes < 60
+          ? '${fetchedAge.inMinutes} min old'
+          : '${fetchedAge.inHours} h old';
       final status = field == null
           ? controller.loading
                 ? 'Loading latest forecast…'
                 : 'Forecast unavailable'
-          : field.isLiveForecast
-          ? '${field.sourceLabel} · valid $validTime'
-          : '${field.sourceLabel} · reference $validTime';
+          : switch (freshness) {
+              WindForecastFreshness.currentForecast =>
+                'CURRENT FORECAST · ${field.sourceLabel} · valid $validTime · fetched $fetchedAgeLabel',
+              WindForecastFreshness.staleForecast =>
+                'STALE FORECAST · ${field.sourceLabel} · valid $validTime · fetched $fetchedAgeLabel',
+              WindForecastFreshness.bundledReference =>
+                'BUNDLED REFERENCE · ${field.sourceLabel} · reference $validTime',
+              null => 'Forecast unavailable',
+            };
+      final gustRange = field?.surfaceGustRangeKmh;
       return Card(
         key: const Key('wind-forecast-control'),
         margin: EdgeInsets.zero,
@@ -9182,8 +9247,11 @@ class _WindForecastControl extends StatelessWidget {
                           status,
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            color: Color(0xFFB7C4D1),
+                          style: TextStyle(
+                            color:
+                                freshness == WindForecastFreshness.staleForecast
+                                ? const Color(0xFFFFC857)
+                                : const Color(0xFFB7C4D1),
                             fontSize: 10,
                           ),
                         ),
@@ -9237,13 +9305,44 @@ class _WindForecastControl extends StatelessWidget {
                     SizedBox(width: 5),
                     Expanded(
                       child: Text(
-                        'Arrow points downwind · number is km/h · forecast '
-                        'model only, not an aviation briefing',
+                        'Arrow points downwind · number is km/h · G is the '
+                        'forecast gust at 10 m AGL, not at the selected MSL '
+                        'layer · model only, not an aviation briefing',
                         style: TextStyle(color: Color(0xFFB7C4D1), fontSize: 9),
                       ),
                     ),
                   ],
                 ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 5),
+                    child: Text(
+                      gustRange == null
+                          ? '10 m AGL gust unavailable for this forecast or reference fixture.'
+                          : '10 m AGL forecast gust across this grid: '
+                                '${gustRange.minimum.round()}–${gustRange.maximum.round()} km/h.',
+                      key: const Key('wind-surface-gust-summary'),
+                      style: const TextStyle(
+                        color: Color(0xFFB7C4D1),
+                        fontSize: 9,
+                      ),
+                    ),
+                  ),
+                ),
+                if (controller.error != null)
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Padding(
+                      padding: EdgeInsets.only(top: 5),
+                      child: Text(
+                        'The latest refresh failed. The labelled prior field '
+                        'remains reference-only; chase tracking is unaffected.',
+                        key: Key('wind-refresh-failed'),
+                        style: TextStyle(color: Color(0xFFFFC857), fontSize: 9),
+                      ),
+                    ),
+                  ),
                 if (field?.origin == WindForecastOrigin.openMeteoUkmo)
                   Align(
                     alignment: Alignment.centerLeft,

--- a/apps/mobile/lib/services/open_meteo_wind.dart
+++ b/apps/mobile/lib/services/open_meteo_wind.dart
@@ -28,6 +28,8 @@ const openMeteoWindAltitudeLevels = <int>[
 
 enum WindForecastOrigin { openMeteoUkmo, bundledFallback }
 
+enum WindForecastFreshness { currentForecast, staleForecast, bundledReference }
+
 class WindForecastVector {
   const WindForecastVector({
     required this.altitudeMetersMsl,
@@ -80,11 +82,17 @@ class WindForecastColumn {
     required this.position,
     required this.vectors,
     this.groundElevationMetersMsl,
+    this.surfaceGustKmh,
   });
 
   final GeoPoint position;
   final List<WindForecastVector> vectors;
   final double? groundElevationMetersMsl;
+
+  /// Maximum forecast gust at 10 m above ground for the selected model hour.
+  /// It is deliberately not attached to an MSL wind vector: Open-Meteo/UKMO
+  /// does not supply gusts for those height levels.
+  final double? surfaceGustKmh;
 
   WindForecastVector? atAltitude(double altitudeMetersMsl) {
     if (vectors.isEmpty) return null;
@@ -125,10 +133,15 @@ class WindForecastColumn {
 }
 
 class WindForecastSample {
-  const WindForecastSample({required this.position, required this.vector});
+  const WindForecastSample({
+    required this.position,
+    required this.vector,
+    this.surfaceGustKmh,
+  });
 
   final GeoPoint position;
   final WindForecastVector vector;
+  final double? surfaceGustKmh;
 }
 
 class WindForecastField {
@@ -147,6 +160,34 @@ class WindForecastField {
   final String sourceLabel;
 
   bool get isLiveForecast => origin == WindForecastOrigin.openMeteoUkmo;
+
+  static const maximumFetchedAge = Duration(hours: 2);
+  static const maximumValidTimeOffset = Duration(minutes: 90);
+
+  WindForecastFreshness freshnessAt(DateTime now) {
+    if (!isLiveForecast) return WindForecastFreshness.bundledReference;
+    final utcNow = now.toUtc();
+    if (utcNow.difference(fetchedAt.toUtc()).abs() > maximumFetchedAge ||
+        utcNow.difference(validAt.toUtc()).abs() > maximumValidTimeOffset) {
+      return WindForecastFreshness.staleForecast;
+    }
+    return WindForecastFreshness.currentForecast;
+  }
+
+  Duration fetchedAgeAt(DateTime now) {
+    final age = now.toUtc().difference(fetchedAt.toUtc());
+    return age.isNegative ? Duration.zero : age;
+  }
+
+  ({double minimum, double maximum})? get surfaceGustRangeKmh {
+    final values = columns
+        .map((column) => column.surfaceGustKmh)
+        .whereType<double>()
+        .where((value) => value.isFinite && value >= 0)
+        .toList(growable: false);
+    if (values.isEmpty) return null;
+    return (minimum: values.reduce(math.min), maximum: values.reduce(math.max));
+  }
 
   WindForecastVector? at(GeoPoint position, double altitudeMetersMsl) {
     if (columns.isEmpty) return null;
@@ -180,7 +221,11 @@ class WindForecastField {
       List.unmodifiable([
         for (final column in columns)
           if (column.atAltitude(altitudeMetersMsl) case final vector?)
-            WindForecastSample(position: column.position, vector: vector),
+            WindForecastSample(
+              position: column.position,
+              vector: vector,
+              surfaceGustKmh: column.surfaceGustKmh,
+            ),
       ]);
 }
 
@@ -224,6 +269,7 @@ class OpenMeteoWindProvider implements WindForecastProvider {
     }
     final requestedPoints = windForecastGrid(center);
     final variables = <String>[
+      'wind_gusts_10m',
       for (final altitude in openMeteoWindAltitudeLevels) ...[
         'wind_speed_${altitude}m',
         'wind_direction_${altitude}m',
@@ -285,6 +331,11 @@ class OpenMeteoWindProvider implements WindForecastProvider {
       }
       final validAt = parsedTimes[timeIndex];
       commonValidAt ??= validAt;
+      final surfaceGusts = hourly['wind_gusts_10m'];
+      final surfaceGust =
+          surfaceGusts is List && timeIndex < surfaceGusts.length
+          ? (surfaceGusts[timeIndex] as num?)?.toDouble()
+          : null;
       final vectors = <WindForecastVector>[];
       for (final altitude in openMeteoWindAltitudeLevels) {
         final speeds = hourly['wind_speed_${altitude}m'];
@@ -312,6 +363,9 @@ class OpenMeteoWindProvider implements WindForecastProvider {
             vectors: List.unmodifiable(vectors),
             groundElevationMetersMsl: groundElevation?.isFinite == true
                 ? groundElevation
+                : null,
+            surfaceGustKmh: surfaceGust?.isFinite == true && surfaceGust! >= 0
+                ? surfaceGust
                 : null,
           ),
         );
@@ -377,6 +431,7 @@ class WindForecastController extends ChangeNotifier {
   bool get loading => _loading;
   String? get error => _error;
   int get selectedAltitudeMetersMsl => _selectedAltitudeMetersMsl;
+  WindForecastFreshness? get freshness => _field?.freshnessAt(_clock().toUtc());
 
   void setEnabled(bool value) {
     if (_enabled == value) return;

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -107,6 +107,7 @@ void main() {
                   speedKmh: 30,
                 ),
               ],
+              surfaceGustKmh: 38,
             ),
           ],
           validAt: DateTime.utc(2026, 8, 21, 10),
@@ -279,6 +280,12 @@ void main() {
       expect(find.byKey(const Key('wind-forecast-control')), findsOneWidget);
       expect(find.byKey(const Key('wind-altitude-slider')), findsOneWidget);
       expect(find.textContaining('1000 M MSL'), findsOneWidget);
+      expect(find.textContaining('BUNDLED REFERENCE'), findsOneWidget);
+      expect(
+        find.byKey(const Key('wind-surface-gust-summary')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('38–38 km/h'), findsOneWidget);
       Navigator.of(
         tester.element(find.byKey(const Key('wind-forecast-control'))),
       ).pop();

--- a/apps/mobile/test/services/open_meteo_wind_test.dart
+++ b/apps/mobile/test/services/open_meteo_wind_test.dart
@@ -23,6 +23,7 @@ void main() {
                 '2026-08-21T10:00',
                 '2026-08-21T11:00',
               ],
+              'wind_gusts_10m': [30, 42, 54],
               'wind_speed_20m': [12, 18, 24],
               'wind_direction_20m': [260, 270, 280],
               'wind_speed_500m': [24, 36, 48],
@@ -68,6 +69,9 @@ void main() {
     );
     expect(vector?.speedKmh, 36);
     expect(vector?.fromDegrees, 180);
+    expect(field.columns[4].surfaceGustKmh, 42);
+    expect(field.surfaceGustRangeKmh?.minimum, 42);
+    expect(requestedUri?.queryParameters['hourly'], contains('wind_gusts_10m'));
   });
 
   test('interpolates wind components across north without bearing wrap', () {
@@ -130,7 +134,85 @@ void main() {
     controller.updateBalloonAltitude(1250);
     expect(controller.selectedAltitudeMetersMsl, 1250);
   });
+
+  test(
+    'labels live fields current, then stale after their validity expires',
+    () {
+      var now = DateTime.utc(2026, 8, 24, 8);
+      final field = _fieldAt(now);
+      final controller = WindForecastController(
+        _RecordingProvider(),
+        clock: () => now,
+        initialField: field,
+      );
+      addTearDown(controller.dispose);
+
+      expect(controller.freshness, WindForecastFreshness.currentForecast);
+      now = now.add(const Duration(hours: 3));
+      expect(controller.freshness, WindForecastFreshness.staleForecast);
+    },
+  );
+
+  test(
+    'a failed offline refresh retains but never freshens the old field',
+    () async {
+      var now = DateTime.utc(2026, 8, 24, 8);
+      final original = _fieldAt(now);
+      final controller = WindForecastController(
+        const _FailingProvider(),
+        clock: () => now,
+        initialField: original,
+      );
+      addTearDown(controller.dispose);
+
+      now = now.add(const Duration(hours: 3));
+      await controller.refresh(
+        const GeoPoint(latitude: 51.44, longitude: -2.65),
+        force: true,
+      );
+
+      expect(controller.field, same(original));
+      expect(controller.error, isNotNull);
+      expect(controller.freshness, WindForecastFreshness.staleForecast);
+    },
+  );
+
+  test('bundled simulator wind is always a dated reference, never live', () {
+    final sourceTime = DateTime.utc(2026, 8, 8, 6);
+    final field = WindForecastField(
+      columns: _fieldAt(sourceTime).columns,
+      validAt: sourceTime,
+      fetchedAt: sourceTime,
+      origin: WindForecastOrigin.bundledFallback,
+      sourceLabel: 'Bundled rehearsal wind',
+    );
+
+    expect(
+      field.freshnessAt(DateTime.utc(2026, 8, 24)),
+      WindForecastFreshness.bundledReference,
+    );
+  });
 }
+
+WindForecastField _fieldAt(DateTime at) => WindForecastField(
+  columns: [
+    WindForecastColumn(
+      position: const GeoPoint(latitude: 51.44, longitude: -2.65),
+      vectors: const [
+        WindForecastVector(
+          altitudeMetersMsl: 500,
+          fromDegrees: 270,
+          speedKmh: 20,
+        ),
+      ],
+      surfaceGustKmh: 32,
+    ),
+  ],
+  validAt: at,
+  fetchedAt: at,
+  origin: WindForecastOrigin.openMeteoUkmo,
+  sourceLabel: OpenMeteoWindProvider.sourceLabel,
+);
 
 class _RecordingProvider implements WindForecastProvider {
   int fetchCount = 0;
@@ -160,4 +242,14 @@ class _RecordingProvider implements WindForecastProvider {
       sourceLabel: OpenMeteoWindProvider.sourceLabel,
     );
   }
+}
+
+class _FailingProvider implements WindForecastProvider {
+  const _FailingProvider();
+
+  @override
+  Future<WindForecastField> fetch({
+    required GeoPoint center,
+    required DateTime at,
+  }) => throw const FormatException('offline');
 }

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -15,6 +15,7 @@ import {
   operationalBoundariesGeoJson,
   parseOpenMeteoForecast,
   planWindRouteToDestination,
+  surfaceGustAtPosition,
 } from "./planner-core.mjs";
 import { applyThemePaint, themeStyle } from "./planner-theme.mjs";
 
@@ -660,7 +661,12 @@ function updateWindMarkers() {
     arrow.style.transform = `rotate(${(vector.fromDegrees + 180) % 360}deg)`;
     const speed = document.createElement("span");
     speed.className = "speed";
-    speed.textContent = `${Math.round(vector.speedKmh)}`;
+    const gust = surfaceGustAtPosition(
+      state.field,
+      position,
+      departureOffsetSeconds,
+    );
+    speed.textContent = `${Math.round(vector.speedKmh)}${gust === null ? "" : ` G${Math.round(gust)}`}`;
     element.append(arrow, speed);
     state.windMarkers.push(
       new maplibregl.Marker({ element, anchor: "center" })
@@ -932,7 +938,7 @@ function recomputeTrack({ fit = false } = {}) {
         `${formatLocalTime(state.routePlan?.departureAt ?? new Date(
           departureSearch.dayStart.getTime() +
             departureSearch.minimumDepartureOffsetMinutes * 60_000,
-        ))} model hour (not observed).`,
+        ))} model hour · speed/direction at selected MSL layer · G is 10 m AGL forecast gust (not observed).`,
       "good",
     );
     if (fit) fitForecast();
@@ -1236,6 +1242,7 @@ function windFieldDigest(field) {
     columns: (field?.columns ?? []).map((column) => ({
       position: column.position,
       vectors: column.vectors,
+      surfaceGustKmh: column.surfaceGustKmh,
     })),
   });
   let hash = 0x811c9dc5;
@@ -1323,7 +1330,7 @@ async function generatePlanCode() {
         validFrom: forecastTimes[0] ?? state.field.validAt,
         validTo: forecastTimes.at(-1) ?? state.field.validAt,
         attribution: "Weather data by Open-Meteo",
-        licence: "CC BY 4.0",
+        licence: "CC BY-SA 4.0",
         fieldDigest: windFieldDigest(state.field),
       },
       operationalBoundaries: state.operationalBoundaries,

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -92,10 +92,13 @@ export function windForecastGrid(center) {
 export function openMeteoRequestUrl({ endpoint, center }) {
   const url = new URL(endpoint, "https://planner.invalid");
   const points = windForecastGrid(center);
-  const variables = WIND_LEVELS_METRES_MSL.flatMap((altitude) => [
-    `wind_speed_${altitude}m`,
-    `wind_direction_${altitude}m`,
-  ]);
+  const variables = [
+    "wind_gusts_10m",
+    ...WIND_LEVELS_METRES_MSL.flatMap((altitude) => [
+      `wind_speed_${altitude}m`,
+      `wind_direction_${altitude}m`,
+    ]),
+  ];
   url.searchParams.set("latitude", points.map((point) => point.latitude.toFixed(6)).join(","));
   url.searchParams.set("longitude", points.map((point) => point.longitude.toFixed(6)).join(","));
   url.searchParams.set("models", "ukmo_seamless");
@@ -145,6 +148,8 @@ export function parseOpenMeteoForecast(payload, requestedAt) {
     if (times.length === 0 || times.some((time) => time === null)) continue;
     for (let timeIndex = 0; timeIndex < times.length; timeIndex += 1) {
       const vectors = [];
+      const gusts = entry.hourly.wind_gusts_10m;
+      const surfaceGustKmh = Number(Array.isArray(gusts) ? gusts[timeIndex] : NaN);
       for (const altitudeMetresMsl of WIND_LEVELS_METRES_MSL) {
         const speeds = entry.hourly[`wind_speed_${altitudeMetresMsl}m`];
         const directions = entry.hourly[`wind_direction_${altitudeMetresMsl}m`];
@@ -160,7 +165,12 @@ export function parseOpenMeteoForecast(payload, requestedAt) {
       if (vectors.length === 0) continue;
       const epoch = times[timeIndex].getTime();
       const slice = slicesByTime.get(epoch) ?? { validAt: times[timeIndex], columns: [] };
-      slice.columns.push({ position, vectors });
+      slice.columns.push({
+        position,
+        vectors,
+        surfaceGustKmh:
+          Number.isFinite(surfaceGustKmh) && surfaceGustKmh >= 0 ? surfaceGustKmh : null,
+      });
       slicesByTime.set(epoch, slice);
     }
   }
@@ -280,6 +290,54 @@ function interpolatedVectorInColumns(columns, position, altitudeMetresMsl) {
     eastMetresPerSecond / totalWeight,
     northMetresPerSecond / totalWeight,
   );
+}
+
+function interpolatedSurfaceGustInColumns(columns, position) {
+  const candidates = columns
+    .map((column) => ({
+      distanceMetres: distanceMetres(column.position, position),
+      surfaceGustKmh: Number(column.surfaceGustKmh),
+    }))
+    .filter(
+      (candidate) =>
+        Number.isFinite(candidate.surfaceGustKmh) && candidate.surfaceGustKmh >= 0,
+    )
+    .sort((first, second) => first.distanceMetres - second.distanceMetres)
+    .slice(0, 4);
+  if (candidates.length === 0) return null;
+  if (candidates[0].distanceMetres < 1) return candidates[0].surfaceGustKmh;
+  let totalWeight = 0;
+  let weightedGust = 0;
+  for (const candidate of candidates) {
+    const weight = 1 / candidate.distanceMetres ** 2;
+    totalWeight += weight;
+    weightedGust += candidate.surfaceGustKmh * weight;
+  }
+  return weightedGust / totalWeight;
+}
+
+export function surfaceGustAtPosition(field, position, elapsedSeconds = 0) {
+  const slices = field?.timeSlices ?? [];
+  if (slices.length === 0) {
+    return interpolatedSurfaceGustInColumns(field?.columns ?? [], position);
+  }
+  const requestedAt = field.requestedAt instanceof Date ? field.requestedAt : field.validAt;
+  const targetTime = requestedAt.getTime() + finiteNumber(elapsedSeconds, "elapsed seconds") * 1000;
+  let upperIndex = slices.findIndex((slice) => slice.validAt.getTime() >= targetTime);
+  if (upperIndex < 0) upperIndex = slices.length - 1;
+  const lowerIndex = Math.max(0, upperIndex - 1);
+  const lower = slices[lowerIndex];
+  const upper = slices[upperIndex];
+  const lowerGust = interpolatedSurfaceGustInColumns(lower.columns, position);
+  const upperGust = interpolatedSurfaceGustInColumns(upper.columns, position);
+  if (lowerGust === null) return upperGust;
+  if (upperGust === null || lowerIndex === upperIndex) return lowerGust;
+  const interval = upper.validAt.getTime() - lower.validAt.getTime();
+  const fraction =
+    interval <= 0
+      ? 0
+      : Math.max(0, Math.min(1, (targetTime - lower.validAt.getTime()) / interval));
+  return lowerGust + (upperGust - lowerGust) * fraction;
 }
 
 export function interpolatedVectorAtPosition(

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -20,6 +20,7 @@ import {
   openMeteoRequestUrl,
   parseOpenMeteoForecast,
   planWindRouteToDestination,
+  surfaceGustAtPosition,
   vectorAtAltitude,
   vectorAtPosition,
   windForecastGrid,
@@ -99,7 +100,10 @@ test("structured plans retain constraints, stages, envelope and wind provenance"
 });
 
 function payload({ direction = 270, speed = 36 } = {}) {
-  const hourly = { time: ["2026-08-21T08:00", "2026-08-21T09:00"] };
+  const hourly = {
+    time: ["2026-08-21T08:00", "2026-08-21T09:00"],
+    wind_gusts_10m: [44, 52],
+  };
   for (const altitude of WIND_LEVELS_METRES_MSL) {
     hourly[`wind_speed_${altitude}m`] = [speed, speed];
     hourly[`wind_direction_${altitude}m`] = [direction, direction];
@@ -131,6 +135,7 @@ test("wind request covers a bounded wide-area UKMO grid and height levels", () =
   assert.equal(url.searchParams.get("latitude").split(",").length, 25);
   assert.match(url.searchParams.get("hourly"), /wind_speed_500m/);
   assert.match(url.searchParams.get("hourly"), /wind_direction_2000m/);
+  assert.match(url.searchParams.get("hourly"), /wind_gusts_10m/);
 });
 
 test("forecast parser chooses the hour nearest the pilot's departure", () => {
@@ -139,6 +144,22 @@ test("forecast parser chooses the hour nearest the pilot's departure", () => {
   const field = parseOpenMeteoForecast(source, new Date("2026-08-21T08:52:00Z"));
   assert.equal(field.validAt.toISOString(), "2026-08-21T09:00:00.000Z");
   assert.equal(vectorAtAltitude(field.columns[0], 500).speedKmh, 28);
+  assert.equal(field.columns[0].surfaceGustKmh, 52);
+});
+
+test("surface gust stays explicitly at 10 m AGL and interpolates in time", () => {
+  const field = parseOpenMeteoForecast(
+    payload(),
+    new Date("2026-08-21T08:00:00Z"),
+  );
+  assert.equal(
+    surfaceGustAtPosition(
+      field,
+      { latitude: 51.5, longitude: -2.5 },
+      30 * 60,
+    ),
+    48,
+  );
 });
 
 test("wind vectors interpolate between hourly forecast slices during the flight", () => {

--- a/apps/planner/planner.html
+++ b/apps/planner/planner.html
@@ -130,6 +130,7 @@
             <input type="range" id="wind-altitude" min="0" max="13" step="1" value="7" />
           </label>
           <p class="status" id="wind-status" role="status">Set a launch point to load wind.</p>
+          <p class="small muted">Arrow points downwind. Values are km/h; G is the modelled 10 m above-ground gust, not a gust at the selected MSL layer.</p>
           <div class="layer-control airspace-control">
             <div>
               <strong id="airspace-title">Aeronautical chart</strong>

--- a/docs/weather-wind-source.md
+++ b/docs/weather-wind-source.md
@@ -1,14 +1,24 @@
 # Weather and wind source
 
+Decision reviewed: 24 August 2026. Recheck the linked provider and licence
+pages before a public, paid or high-volume release.
+
 Open-Meteo is the selected advisory wind provider for tester builds. Balloon
 Crumbs requests the UK Met Office UKV forecast through Open-Meteo's keyless
-forecast API and displays a small grid of wind direction and speed values at
-selectable heights from 20 m to 2,000 m above mean sea level.
+forecast API and displays a 5 × 5 grid of wind direction and speed values at
+selectable heights from 20 m to 2,000 m above mean sea level. It also requests
+the UKMO surface gust: this is labelled `G`, in km/h, and is explicitly the
+forecast gust at 10 m above ground level (AGL), not a gust at the selected MSL
+wind layer.
 
 No API credential is stored or shipped. Slider changes reuse the complete
 vertical profile returned by the last request; they do not make another
-request. Forecast data is kept in memory only. The simulator retains its dated,
-bundled wind profile as an offline fallback.
+request. Forecast data is kept in memory only and is not an offline cache. A
+prior in-memory response may remain visible after a network failure, but it is
+labelled `STALE` after either its fetch age exceeds two hours or its valid time
+is more than 90 minutes from the current time. The simulator retains its dated,
+bundled wind profile as a visibly separate `BUNDLED REFERENCE`, never as a live
+or current forecast.
 
 The map attributes the live data to Open-Meteo and identifies UKMO as the model
 source. Open-Meteo's UKMO documentation states that UK Met Office data is
@@ -17,13 +27,48 @@ licensed under CC BY-SA 4.0:
 - <https://open-meteo.com/en/docs/ukmo-api>
 - <https://open-meteo.com/en/license>
 
+## Operational fit and provenance
+
+Open-Meteo's UKMO documentation says the seamless UK feed combines the UKMO
+Global model with the high-resolution UKV 2 km model over the UK and Ireland.
+UKV is hourly, updates every hour and supplies approximately two forecast days.
+Open-Meteo also notes an additional delay for UKMO open data. The bounded app
+request asks for the nearest three model hours; the web planner asks for three
+days so it can vary departure time.
+
+The response used here exposes forecast valid times but not a trustworthy model
+run identifier. Balloon Crumbs therefore shows the provider/model, exact valid
+time and local fetch age, and does not invent or imply a run time. The web
+planner additionally shows the selected model hour. The app does not request
+Open-Meteo's “current” variables and has no observation provider: every wind or
+gust value in this product is styled and described as forecast model output.
+
+Only the selected, bounded wind context needed for a flight replay is shared
+with that operation; it carries source, valid time, units and forecast status.
+The 25-column provider response is not stored on the relay or redistributed as
+a reusable weather dataset.
+
+Open-Meteo's public keyless endpoint is suitable for current internal testing.
+Its fair-use, rate, commercial-plan and attribution terms must be reviewed
+before launch or increased load. No response is committed to Git or placed in a
+shared offline pack.
+
 ## Limitations
 
 This is numerical forecast-model output, not a live measurement from the
 balloon and not an aviation weather briefing. The displayed valid time, height
-datum, units, source, and forecast-only warning must remain visible. Turning the
-map layer off hides the arrows but does not change the simulator's wind physics.
+datum, units, source, fetch age/freshness, surface-gust datum and forecast-only
+warning must remain visible. Turning the map layer off hides the arrows but does
+not change the simulator's wind physics.
 
-The public keyless endpoint is appropriate for the current internal-test use.
-Usage, attribution, caching, and commercial terms must be reviewed again before
-a public or paid release.
+Wind layers and telemetry use km/h for horizontal speed and metres MSL for
+height. Vertical telemetry/rates remain m/s. Surface gust is the sole AGL value
+and is labelled `10 m AGL` everywhere it is explained.
+
+Failure or expiry never blocks balloon/crew positions, tracks, landing status or
+chase guidance. Automated fixtures cover updated forecast selection, altitude
+and bearing interpolation, current-to-stale transition, failed/offline refresh,
+the dated bundled simulator reference, and 10 m gust parsing.
+
+Pilots and crews must use an appropriate official aviation forecast and briefing
+for operational decisions.


### PR DESCRIPTION
## Summary
- add explicit current, stale, and bundled-reference forecast states with source, valid time, fetch age, units, and limitations
- add UKMO 10 m AGL gusts to mobile and planner without conflating them with MSL wind layers
- keep tracking usable through refresh/offline failures and document provider fit, licensing, retention, and operational boundaries
- add deterministic parser, interpolation, freshness, offline-failure, and presentation coverage

## Verification
- Dart formatting check
- Flutter static analysis
- Flutter tests: 1,841 passed; 24 intentionally skipped
- Planner Node tests: 37 passed
- Git whitespace check

Closes #12