### PR TITLE
fix: close flight lifecycle publication

### DIFF
--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -21,8 +21,9 @@ class SituationalAwarenessController extends ChangeNotifier {
     List<ExternalHazardProvider> externalProviders = const [],
     SituationClock? clock,
     SituationIdFactory? idFactory,
-    this.rideStarted = true,
-    this.rideStartedAt,
+    bool rideStarted = true,
+    DateTime? rideStartedAt,
+    bool rideEnded = false,
     this.expiryPolicy = const HazardExpiryPolicy(),
     this.deduplicator = const HazardDeduplicator(),
     this.freshnessPolicy = const PresenceFreshnessPolicy(),
@@ -31,6 +32,9 @@ class SituationalAwarenessController extends ChangeNotifier {
        _externalProviders = List.unmodifiable(externalProviders),
        _clock = clock ?? DateTime.now,
        _idFactory = idFactory ?? const Uuid().v7 {
+    _rideStarted = rideStarted;
+    _rideStartedAt = rideStartedAt;
+    _rideEnded = rideEnded;
     _eventFactory = SituationEventFactory(
       session: _session,
       clock: _clock,
@@ -44,8 +48,12 @@ class SituationalAwarenessController extends ChangeNotifier {
   final List<ExternalHazardProvider> _externalProviders;
   final SituationClock _clock;
   final SituationIdFactory _idFactory;
-  final bool rideStarted;
-  final DateTime? rideStartedAt;
+  late bool _rideStarted;
+  late DateTime? _rideStartedAt;
+  late bool _rideEnded;
+  bool get rideStarted => _rideStarted;
+  DateTime? get rideStartedAt => _rideStartedAt;
+  bool get rideEnded => _rideEnded;
   final HazardExpiryPolicy expiryPolicy;
   final HazardDeduplicator deduplicator;
 
@@ -161,6 +169,21 @@ class SituationalAwarenessController extends ChangeNotifier {
     );
   }
 
+  /// Keeps the durable position journal aligned with the shared flight phase.
+  ///
+  /// The native location stream is stopped when a flight ends, but a fix may
+  /// already be queued. Gating again at the journal boundary prevents that late
+  /// callback from creating post-flight location history.
+  void updateFlightLifecycle({
+    required bool started,
+    required bool ended,
+    DateTime? startedAt,
+  }) {
+    _rideStarted = started;
+    _rideEnded = ended;
+    _rideStartedAt = startedAt;
+  }
+
   Future<void> initialize({Iterable<RideEvent>? restoredEvents}) async {
     if (_disposed) return;
     final events =
@@ -183,8 +206,10 @@ class SituationalAwarenessController extends ChangeNotifier {
   }
 
   Future<void> recordLocalLocation(LocationSample sample) async {
-    if (!rideStarted ||
-        (rideStartedAt != null && sample.recordedAt.isBefore(rideStartedAt!))) {
+    if (!_rideStarted ||
+        _rideEnded ||
+        (_rideStartedAt != null &&
+            sample.recordedAt.isBefore(_rideStartedAt!))) {
       return;
     }
     final location = RiderLocation(

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -1875,6 +1875,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       final locationController = ForegroundLocationController(
         DeviceLocationSource(),
         (sample) async {
+          if (widget.rideController.rideEnded) return;
           _latestObserverLocationSample = sample;
           _publishObserverSnapshot();
           // One decision, taken once, for both halves of reporting: distance
@@ -3935,6 +3936,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final session = widget.rideController.session;
     final rideStarted =
         widget.rideController.rideStarted && !widget.rideController.rideEnded;
+    _awarenessController?.updateFlightLifecycle(
+      started: widget.rideController.rideStarted,
+      ended: widget.rideController.rideEnded,
+      startedAt: widget.rideController.rideStartedAt,
+    );
     final rideJustStarted = rideStarted && !_observedRideStarted;
     _observedRideStarted = rideStarted;
     // The journal only accepts fixes from the start onwards, so the first fix

--- a/apps/mobile/test/controllers/situational_awareness_controller_test.dart
+++ b/apps/mobile/test/controllers/situational_awareness_controller_test.dart
@@ -236,6 +236,22 @@ void main() {
   );
 
   test(
+    'the durable journal rejects a location fix queued after flight end',
+    () async {
+      controller.updateFlightLifecycle(
+        started: true,
+        ended: true,
+        startedAt: now.subtract(const Duration(minutes: 5)),
+      );
+
+      await controller.recordLocalLocation(_sample(latitude: 51.002, at: now));
+
+      expect(controller.riderLocations, isEmpty);
+      expect(await store.eventsForRide(_session.rideId), isEmpty);
+    },
+  );
+
+  test(
     'activity replay rejects fixes recorded before the start anchor',
     () async {
       final startedAt = now.add(const Duration(minutes: 1));

--- a/docs/launch-recovery-acceptance.md
+++ b/docs/launch-recovery-acceptance.md
@@ -22,6 +22,25 @@ deterministic and contains no real flight, precise field or contact data:
 | Recovery phase | LANDED does not end the operation; chase movement and location sharing continue until recovery complete | `fiesta_flight_simulation_test.dart`, `ride_controller_test.dart` |
 | CarPlay | North-up/Direction-up and balloon/landing targets survive bridge updates and reconnect | `carplay_bridge_test.dart`, `map_orientation_preferences_test.dart`; physical checks remain below |
 
+## Membership and authority closure
+
+Issue #5's original “pilot starts” wording is superseded by the observed field
+workflow: the pilot retains flight authority, while the pilot or either chase
+role can mark balloon release and begin live tracking. Observers and balloon
+crew cannot start it. The following evidence closes the remaining lifecycle
+criteria without putting a pre-launch action back on the pilot:
+
+| Criterion | Evidence |
+| --- | --- |
+| Five devices gather before launch without duplicate membership | `test_pre_start_presence.py::test_five_devices_survive_a_45_minute_pre_launch_without_ghosts` |
+| Multiple independent chasers and role-specific viewpoints | `launch_recovery_acceptance_fixture_test.dart`, `ride_controller_craft_test.dart`, `flight_role_experience_test.dart` |
+| Restart preserves operation, role, device and craft identity | `shared_preferences_session_store_test.dart`, `live_presence_two_device_test.dart::a rider who restarts the app rejoins without re-opting in`, `ride_controller_craft_test.dart::the roster survives a journal replay` |
+| Only the current pilot can end the flight or transfer pilot authority | `ride_controller_test.dart::pilot handover is offered, accepted and applied on both devices`, `pilot_handover_test.dart` and the authority tests in `ride_controller_test.dart` |
+| Release can be marked by the pilot or chase roles, never an observer or forged balloon role | `ride_controller_test.dart::chase crew can start live tracking at balloon release` and `balloon device cannot forge a chase role to start tracking` |
+| End stops location publication and begins bounded retention | `situational_awareness_controller_test.dart::the durable journal rejects a location fix queued after flight end`, `_handleRideEnded` in `active_ride_shell.dart`, `test_sync.py::test_ride_end_shortens_retention_and_cleanup_deletes_ride` |
+| Typed-code lookup is bounded and credentials are not stored in plaintext | `test_join_codes.py::test_ride_code_lookup_is_numeric_and_rate_limited`, `test_token_less_lookups_share_a_global_budget_across_callers`, and `test_register_and_resolve_six_digit_ride_code` |
+| Offline/out-of-order authority changes converge | `pilot_handover_test.dart` and `ride_controller_test.dart::offline leader handover and duplicate starts converge deterministically` |
+
 The bounded CI set is deliberately virtual-time driven. It does not sleep for
 45 minutes and it never publishes synthetic positions to a live relay.
 


### PR DESCRIPTION
## Summary
- reject queued location fixes after a flight ends at both native and journal boundaries
- keep the awareness projection synchronized with shared flight lifecycle state
- document the issue #5 acceptance evidence and the field-tested chase-start exception

## Verification
- `flutter analyze`
- focused Flutter lifecycle, craft, presence and handover tests (105 passed)
- focused relay join-code, five-device presence and end-retention tests (17 passed)
- server Ruff format and lint

Closes #5