### PR TITLE
feat: close balloon telemetry integrity

### DIFF
--- a/apps/mobile/lib/controllers/distance_unit_controller.dart
+++ b/apps/mobile/lib/controllers/distance_unit_controller.dart
@@ -3,20 +3,29 @@ import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../domain/distance_unit.dart';
+import '../domain/altitude_unit.dart';
 
 class DistanceUnitController extends ChangeNotifier
     implements ValueListenable<DistanceUnit> {
   DistanceUnitController.forLocale(this.locale)
     : _preferences = null,
-      _override = null;
+      _override = null,
+      _altitudeUnit = AltitudeUnit.metres;
 
-  DistanceUnitController._(this._preferences, this.locale, this._override);
+  DistanceUnitController._(
+    this._preferences,
+    this.locale,
+    this._override,
+    this._altitudeUnit,
+  );
 
   static const preferenceKey = 'distance_unit_override';
+  static const altitudePreferenceKey = 'altitude_unit';
 
   final SharedPreferences? _preferences;
   final Locale locale;
   DistanceUnit? _override;
+  AltitudeUnit _altitudeUnit;
 
   static Future<DistanceUnitController> load({required Locale locale}) async {
     final preferences = await SharedPreferences.getInstance();
@@ -24,7 +33,16 @@ class DistanceUnitController extends ChangeNotifier
     final override = DistanceUnit.values
         .where((unit) => unit.name == stored)
         .firstOrNull;
-    return DistanceUnitController._(preferences, locale, override);
+    final storedAltitude = preferences.getString(altitudePreferenceKey);
+    final altitudeUnit = AltitudeUnit.values
+        .where((unit) => unit.name == storedAltitude)
+        .firstOrNull;
+    return DistanceUnitController._(
+      preferences,
+      locale,
+      override,
+      altitudeUnit ?? AltitudeUnit.metres,
+    );
   }
 
   static DistanceUnit defaultForLocale(Locale locale) {
@@ -37,6 +55,10 @@ class DistanceUnitController extends ChangeNotifier
   DistanceUnit get localeDefault => defaultForLocale(locale);
 
   bool get followsLocale => _override == null;
+
+  /// Altitude is metric by default on every locale. Road-distance locale rules
+  /// must not silently turn the aircraft display into feet.
+  AltitudeUnit get altitudeUnit => _altitudeUnit;
 
   @override
   DistanceUnit get value => _override ?? localeDefault;
@@ -52,6 +74,13 @@ class DistanceUnitController extends ChangeNotifier
     if (_override == null) return;
     _override = null;
     await _preferences?.remove(preferenceKey);
+    notifyListeners();
+  }
+
+  Future<void> setAltitudeUnit(AltitudeUnit unit) async {
+    if (_altitudeUnit == unit) return;
+    _altitudeUnit = unit;
+    await _preferences?.setString(altitudePreferenceKey, unit.name);
     notifyListeners();
   }
 }

--- a/apps/mobile/lib/domain/altitude_unit.dart
+++ b/apps/mobile/lib/domain/altitude_unit.dart
@@ -1,0 +1,27 @@
+enum AltitudeUnit { metres, feet }
+
+extension AltitudeUnitLabel on AltitudeUnit {
+  String get label => switch (this) {
+    AltitudeUnit.metres => 'Metres',
+    AltitudeUnit.feet => 'Feet',
+  };
+
+  String get symbol => switch (this) {
+    AltitudeUnit.metres => 'm',
+    AltitudeUnit.feet => 'ft',
+  };
+
+  double fromMetres(double metres) => switch (this) {
+    AltitudeUnit.metres => metres,
+    AltitudeUnit.feet => metres * 3.280839895,
+  };
+
+  String altitude(double metres) => '${fromMetres(metres).round()} $symbol';
+
+  String accuracy(double metres) => '±${fromMetres(metres).round()} $symbol';
+
+  String verticalRate(double metresPerSecond) => switch (this) {
+    AltitudeUnit.metres => '${metresPerSecond.toStringAsFixed(1)} m/s',
+    AltitudeUnit.feet => '${(metresPerSecond * 196.8503937).round()} ft/min',
+  };
+}

--- a/apps/mobile/lib/features/map/balloon_altitude_style.dart
+++ b/apps/mobile/lib/features/map/balloon_altitude_style.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import '../../domain/imported_route.dart';
+import '../../domain/altitude_unit.dart';
 
 /// One colour band in the balloon ground-track legend.
 class BalloonAltitudeBand {
@@ -25,11 +26,16 @@ class BalloonAltitudeSegment {
     required this.points,
     required this.color,
     required this.altitudeMeters,
+    required this.widthFactor,
   });
 
   final List<GeoPoint> points;
   final Color color;
   final double? altitudeMeters;
+
+  /// A non-colour cue shared by every renderer: higher bands are progressively
+  /// thicker, while an unknown-altitude leg is the thinnest.
+  final double widthFactor;
 
   bool get hasAltitude => altitudeMeters != null;
 }
@@ -39,6 +45,8 @@ class BalloonAltitudeStyle {
   const BalloonAltitudeStyle._();
 
   static const unknownColor = Color(0xFFB7C4D1);
+  static const unknownWidthFactor = 0.65;
+  static const bandWidthFactors = <double>[0.8, 0.95, 1.1, 1.25, 1.4];
 
   static const bands = <BalloonAltitudeBand>[
     BalloonAltitudeBand(
@@ -77,6 +85,24 @@ class BalloonAltitudeStyle {
     return selected;
   }
 
+  static List<String> labels(AltitudeUnit unit) => [
+    for (var index = 0; index < bands.length; index += 1)
+      _labelForBand(index, unit),
+  ];
+
+  static String _labelForBand(int index, AltitudeUnit unit) {
+    final lower = bands[index].minimumMeters;
+    final upper = index + 1 < bands.length
+        ? bands[index + 1].minimumMeters
+        : null;
+    String value(double metres) => unit.fromMetres(metres).round().toString();
+    if (!lower.isFinite && upper != null) {
+      return '<${value(upper)} ${unit.symbol}';
+    }
+    if (upper == null) return '${value(lower)}+ ${unit.symbol}';
+    return '${value(lower)}–${value(upper)} ${unit.symbol}';
+  }
+
   static List<BalloonAltitudeSegment> segments(List<GeoPoint> points) => [
     for (var index = 1; index < points.length; index += 1)
       _segment(points[index - 1], points[index]),
@@ -96,6 +122,18 @@ class BalloonAltitudeStyle {
       points: [start, end],
       color: altitude == null ? unknownColor : colorForMeters(altitude),
       altitudeMeters: altitude,
+      widthFactor: altitude == null
+          ? unknownWidthFactor
+          : _widthFactorForMeters(altitude),
     );
+  }
+
+  static double _widthFactorForMeters(double meters) {
+    var selected = bandWidthFactors.first;
+    for (var index = 0; index < bands.length; index += 1) {
+      if (meters < bands[index].minimumMeters) break;
+      selected = bandWidthFactors[index];
+    }
+    return selected;
   }
 }

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -19,6 +19,7 @@ import '../../data/json_file_recorded_route_store.dart';
 import '../../data/json_file_route_store.dart';
 import '../../domain/completed_ride_store.dart';
 import '../../domain/altitude.dart';
+import '../../domain/altitude_unit.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/imported_route.dart';
 import '../../domain/map_orientation.dart';
@@ -265,6 +266,7 @@ class RideMapFeature extends StatefulWidget {
     this.mapStyleString,
     this.completedRideStore,
     this.distanceUnit = DistanceUnit.kilometres,
+    this.altitudeUnit = AltitudeUnit.metres,
     this.speedLimitDisplay,
     this.showRouteProgress = true,
     this.basemapConfiguration = const BasemapConfiguration(),
@@ -333,6 +335,7 @@ class RideMapFeature extends StatefulWidget {
     CompletedRideStore? completedRideStore,
     bool canEditRoute = true,
     DistanceUnit distanceUnit = DistanceUnit.kilometres,
+    AltitudeUnit altitudeUnit = AltitudeUnit.metres,
     SpeedLimitDisplayController? speedLimitDisplay,
     bool showRouteProgress = true,
     bool darkMapStyle = false,
@@ -396,6 +399,7 @@ class RideMapFeature extends StatefulWidget {
     completedRideStore: completedRideStore,
     canEditRoute: canEditRoute,
     distanceUnit: distanceUnit,
+    altitudeUnit: altitudeUnit,
     speedLimitDisplay: speedLimitDisplay,
     showRouteProgress: showRouteProgress,
     basemapConfiguration: BasemapConfiguration.fromEnvironment().forBrightness(
@@ -497,6 +501,7 @@ class RideMapFeature extends StatefulWidget {
   final String? mapStyleString;
   final CompletedRideStore? completedRideStore;
   final DistanceUnit distanceUnit;
+  final AltitudeUnit altitudeUnit;
   final SpeedLimitDisplayController? speedLimitDisplay;
   final bool showRouteProgress;
   final BasemapConfiguration basemapConfiguration;
@@ -662,6 +667,7 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         chaseVehicle: widget.chaseVehicle,
         navigationExportCoordinator: widget.navigationExportCoordinator,
         distanceUnit: widget.distanceUnit,
+        altitudeUnit: widget.altitudeUnit,
         speedLimitDisplay: widget.speedLimitDisplay,
         showRouteProgress: widget.showRouteProgress,
         localCraftStyle: widget.localCraftStyle,
@@ -764,6 +770,7 @@ class RideMapScreen extends StatefulWidget {
     this.completedRideStore,
     this.storedRouteLibrary,
     this.distanceUnit = DistanceUnit.kilometres,
+    this.altitudeUnit = AltitudeUnit.metres,
     this.speedLimitDisplay,
     this.showRouteProgress = true,
     this.disposeOfflineTileCache = false,
@@ -890,6 +897,7 @@ class RideMapScreen extends StatefulWidget {
   final StoredRouteLibrary? storedRouteLibrary;
 
   final DistanceUnit distanceUnit;
+  final AltitudeUnit altitudeUnit;
   final SpeedLimitDisplayController? speedLimitDisplay;
   final bool showRouteProgress;
   final bool disposeOfflineTileCache;
@@ -1754,6 +1762,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                                 builder: (context, fix, _) =>
                                     _BalloonAltitudeCard(
                                       fix: fix,
+                                      altitudeUnit: widget.altitudeUnit,
                                       onShowMapInformation:
                                           _showBalloonMapInformation,
                                     ),
@@ -1768,6 +1777,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
                               key: const Key('wind-forecast-control-position'),
                               child: _WindForecastChip(
                                 controller: controller,
+                                altitudeUnit: widget.altitudeUnit,
                                 onShowDetails: _showWindForecastDetails,
                               ),
                             ),
@@ -4462,7 +4472,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
         'balloon-crumbs-route-remaining-border',
         ml.LineLayerProperties(
           lineColor: _casingHex,
-          lineWidth: displayedRouteStyle.casingWidthPixels,
+          lineWidth: [
+            'coalesce',
+            ['get', 'casingWidth'],
+            displayedRouteStyle.casingWidthPixels,
+          ],
           lineDasharray: displayedRouteStyle.maplibreCasingDashArray,
           lineCap: 'round',
           lineJoin: 'round',
@@ -4476,7 +4490,11 @@ class _RideMapScreenState extends State<RideMapScreen> {
           lineColor: _route?.isBalloonForecast == true
               ? const ['get', 'color']
               : _hexColor(displayedRouteStyle.color),
-          lineWidth: displayedRouteStyle.widthPixels,
+          lineWidth: [
+            'coalesce',
+            ['get', 'width'],
+            displayedRouteStyle.widthPixels,
+          ],
           lineDasharray: displayedRouteStyle.maplibreDashArray,
           lineCap: 'round',
           lineJoin: 'round',
@@ -4635,7 +4653,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       'balloon-crumbs-trail-${kind.name}-casing',
       ml.LineLayerProperties(
         lineColor: _casingHex,
-        lineWidth: style.casingWidthPixels,
+        lineWidth: const ['get', 'casingWidth'],
         lineDasharray: style.maplibreCasingDashArray,
         lineCap: 'round',
         lineJoin: 'round',
@@ -4651,7 +4669,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         // segments use altitude colours; chase craft retain the identity
         // colour of their elected reporter across both map renderers.
         lineColor: const ['get', 'color'],
-        lineWidth: style.widthPixels,
+        lineWidth: const ['get', 'width'],
         lineDasharray: style.maplibreDashArray,
         lineCap: 'round',
         lineJoin: 'round',
@@ -4780,7 +4798,14 @@ class _RideMapScreenState extends State<RideMapScreen> {
           {
             'type': 'Feature',
             'id': part.id,
-            'properties': {'color': _hexColor(part.color)},
+            'properties': {
+              'color': _hexColor(part.color),
+              'width':
+                  RouteTrailStyle.forecastTrack.widthPixels * part.widthFactor,
+              'casingWidth':
+                  RouteTrailStyle.forecastTrack.casingWidthPixels *
+                  part.widthFactor,
+            },
             'geometry': {
               'type': 'LineString',
               'coordinates': [
@@ -4799,11 +4824,14 @@ class _RideMapScreenState extends State<RideMapScreen> {
       (_route?.isBalloonForecast == true
               ? RouteTrailStyle.forecastTrack
               : RouteTrailStyle.routeAhead)
-          .withColor(part.color),
+          .withColor(part.color)
+          .scaleWidth(part.widthFactor),
     ),
   );
 
-  Iterable<({String id, List<GeoPoint> points, Color color})>
+  Iterable<
+    ({String id, List<GeoPoint> points, Color color, double widthFactor})
+  >
   get _displayedRouteParts sync* {
     if (_route?.isBalloonForecast != true) {
       for (final (index, path) in _displayedRoutePaths.indexed) {
@@ -4811,6 +4839,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
           id: 'remaining-route-$index',
           points: path,
           color: RouteTrailStyle.routeAhead.color,
+          widthFactor: 1,
         );
       }
       return;
@@ -4823,6 +4852,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
           id: 'forecast-$pathIndex-altitude-$segmentIndex',
           points: segment.points,
           color: segment.color,
+          widthFactor: segment.widthFactor,
         );
       }
     }
@@ -4888,17 +4918,24 @@ class _RideMapScreenState extends State<RideMapScreen> {
             (trace) => _renderedTrailParts(trace).map(
               (part) => _routePolyline(
                 part.points,
-                trace.style.withColor(part.color),
+                trace.style.withColor(part.color).scaleWidth(part.widthFactor),
               ),
             ),
           );
 
-  Iterable<({String id, List<GeoPoint> points, Color color})>
+  Iterable<
+    ({String id, List<GeoPoint> points, Color color, double widthFactor})
+  >
   _renderedTrailParts(MapOverlayTrace trace) sync* {
     if (trace.kind != RiderTrailKind.balloonGroundTrack &&
         trace.kind != RiderTrailKind.forecastTrack &&
         trace.kind != RiderTrailKind.liveProjectionTrack) {
-      yield (id: trace.id, points: trace.points, color: trace.effectiveColor);
+      yield (
+        id: trace.id,
+        points: trace.points,
+        color: trace.effectiveColor,
+        widthFactor: 1,
+      );
       return;
     }
     for (final (index, segment) in BalloonAltitudeStyle.segments(
@@ -4908,6 +4945,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         id: '${trace.id}-altitude-$index',
         points: segment.points,
         color: segment.color,
+        widthFactor: segment.widthFactor,
       );
     }
   }
@@ -5022,6 +5060,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
               'kind': trace.kind.name,
               'label': trace.label,
               'color': _hexColor(part.color),
+              'width': trace.style.widthPixels * part.widthFactor,
+              'casingWidth': trace.style.casingWidthPixels * part.widthFactor,
             },
             'geometry': {
               'type': 'LineString',
@@ -5503,6 +5543,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       context,
       route: activeRoute,
       distanceUnit: widget.distanceUnit,
+      altitudeUnit: widget.altitudeUnit,
       distanceMeters: distanceMeters,
       duration: duration,
       warnings: confirmationWarnings,
@@ -6290,6 +6331,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       useSafeArea: true,
       builder: (context) => _BalloonMapInformationSheet(
         configuration: widget.aeronauticalChartConfiguration,
+        altitudeUnit: widget.altitudeUnit,
         now: now,
       ),
     );
@@ -6304,7 +6346,10 @@ class _RideMapScreenState extends State<RideMapScreen> {
       useSafeArea: true,
       builder: (context) => SingleChildScrollView(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-        child: _WindForecastControl(controller: controller),
+        child: _WindForecastControl(
+          controller: controller,
+          altitudeUnit: widget.altitudeUnit,
+        ),
       ),
     );
   }
@@ -8459,10 +8504,12 @@ class _MapOverlayLabel extends StatelessWidget {
 class _WindForecastChip extends StatelessWidget {
   const _WindForecastChip({
     required this.controller,
+    required this.altitudeUnit,
     required this.onShowDetails,
   });
 
   final WindForecastController controller;
+  final AltitudeUnit altitudeUnit;
   final VoidCallback onShowDetails;
 
   @override
@@ -8505,7 +8552,7 @@ class _WindForecastChip extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'WIND · ${controller.selectedAltitudeMetersMsl} M',
+                      'WIND · ${altitudeUnit.altitude(controller.selectedAltitudeMetersMsl.toDouble()).toUpperCase()}',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
@@ -8550,9 +8597,13 @@ class _WindForecastChip extends StatelessWidget {
 }
 
 class _WindForecastControl extends StatelessWidget {
-  const _WindForecastControl({required this.controller});
+  const _WindForecastControl({
+    required this.controller,
+    required this.altitudeUnit,
+  });
 
   final WindForecastController controller;
+  final AltitudeUnit altitudeUnit;
 
   @override
   Widget build(BuildContext context) => AnimatedBuilder(
@@ -8589,6 +8640,13 @@ class _WindForecastControl extends StatelessWidget {
               null => 'Forecast unavailable',
             };
       final gustRange = field?.surfaceGustRangeKmh;
+      final minimumAltitude = altitudeUnit.altitude(
+        openMeteoWindAltitudeLevels.first.toDouble(),
+      );
+      final maximumAltitude = altitudeUnit.altitude(
+        openMeteoWindAltitudeLevels.last.toDouble(),
+      );
+      final surfaceGustAltitude = altitudeUnit.altitude(10);
       return Card(
         key: const Key('wind-forecast-control'),
         margin: EdgeInsets.zero,
@@ -8612,7 +8670,7 @@ class _WindForecastControl extends StatelessWidget {
                       children: [
                         Text(
                           'FORECAST WIND · '
-                          '${controller.selectedAltitudeMetersMsl} M MSL',
+                          '${altitudeUnit.altitude(controller.selectedAltitudeMetersMsl.toDouble()).toUpperCase()} MSL',
                           style: const TextStyle(
                             fontSize: 11,
                             fontWeight: FontWeight.w800,
@@ -8657,7 +8715,7 @@ class _WindForecastControl extends StatelessWidget {
                 ),
                 Row(
                   children: [
-                    const Text('20', style: TextStyle(fontSize: 9)),
+                    Text(minimumAltitude, style: const TextStyle(fontSize: 9)),
                     Expanded(
                       child: Slider(
                         key: const Key('wind-altitude-slider'),
@@ -8666,25 +8724,29 @@ class _WindForecastControl extends StatelessWidget {
                             .toDouble(),
                         divisions: openMeteoWindAltitudeLevels.length - 1,
                         value: selectedIndex.clamp(0, 100).toDouble(),
-                        label: '${controller.selectedAltitudeMetersMsl} m MSL',
+                        label:
+                            '${altitudeUnit.altitude(controller.selectedAltitudeMetersMsl.toDouble())} MSL',
                         onChanged: (value) => controller.setSelectedAltitude(
                           openMeteoWindAltitudeLevels[value.round()].toDouble(),
                         ),
                       ),
                     ),
-                    const Text('2000 m', style: TextStyle(fontSize: 9)),
+                    Text(maximumAltitude, style: const TextStyle(fontSize: 9)),
                   ],
                 ),
-                const Row(
+                Row(
                   children: [
-                    Icon(Icons.navigation_rounded, size: 13),
-                    SizedBox(width: 5),
+                    const Icon(Icons.navigation_rounded, size: 13),
+                    const SizedBox(width: 5),
                     Expanded(
                       child: Text(
                         'Arrow points downwind · number is km/h · G is the '
-                        'forecast gust at 10 m AGL, not at the selected MSL '
+                        'forecast gust at $surfaceGustAltitude AGL, not at the selected MSL '
                         'layer · model only, not an aviation briefing',
-                        style: TextStyle(color: Color(0xFFB7C4D1), fontSize: 9),
+                        style: const TextStyle(
+                          color: Color(0xFFB7C4D1),
+                          fontSize: 9,
+                        ),
                       ),
                     ),
                   ],
@@ -8695,8 +8757,8 @@ class _WindForecastControl extends StatelessWidget {
                     padding: const EdgeInsets.only(top: 5),
                     child: Text(
                       gustRange == null
-                          ? '10 m AGL gust unavailable for this forecast or reference fixture.'
-                          : '10 m AGL forecast gust across this grid: '
+                          ? '$surfaceGustAltitude AGL gust unavailable for this forecast or reference fixture.'
+                          : '$surfaceGustAltitude AGL forecast gust across this grid: '
                                 '${gustRange.minimum.round()}–${gustRange.maximum.round()} km/h.',
                       key: const Key('wind-surface-gust-summary'),
                       style: const TextStyle(
@@ -8960,10 +9022,12 @@ class _HmlrInspireReferenceSheet extends StatelessWidget {
 class _BalloonMapInformationSheet extends StatelessWidget {
   const _BalloonMapInformationSheet({
     required this.configuration,
+    required this.altitudeUnit,
     required this.now,
   });
 
   final AeronauticalChartConfiguration configuration;
+  final AltitudeUnit altitudeUnit;
   final DateTime now;
 
   @override
@@ -9029,13 +9093,13 @@ class _BalloonMapInformationSheet extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 10),
-            const Text(
+            Text(
               'Balloon altitude and the coloured ground track are shown in '
-              'metres. GNSS altitude is not terrain clearance. Grey track '
-              'segments have no usable altitude.',
+              '${altitudeUnit.label.toLowerCase()}. GNSS altitude is not '
+              'terrain clearance. Grey track segments have no usable altitude.',
             ),
             const SizedBox(height: 14),
-            const _BalloonAltitudeLegend(),
+            _BalloonAltitudeLegend(altitudeUnit: altitudeUnit),
           ],
         ),
       ),
@@ -9198,78 +9262,106 @@ class _AeronauticalLegendRow extends StatelessWidget {
 }
 
 class _BalloonAltitudeLegend extends StatelessWidget {
-  const _BalloonAltitudeLegend();
+  const _BalloonAltitudeLegend({required this.altitudeUnit});
+
+  final AltitudeUnit altitudeUnit;
 
   @override
-  Widget build(BuildContext context) => Semantics(
-    label:
-        'Balloon track altitude in metres: ${BalloonAltitudeStyle.bands.map((band) => band.label).join(', ')}. Grey means altitude unavailable.',
-    child: Card(
-      key: const Key('balloon-altitude-legend'),
-      color: const Color(0xE6252E39),
-      margin: EdgeInsets.zero,
-      child: SizedBox(
-        width: 248,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Text(
-                'TRACK ALTITUDE · METRES',
-                style: TextStyle(
-                  color: Color(0xFFCED6DF),
-                  fontSize: 10,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0.5,
+  Widget build(BuildContext context) {
+    final labels = BalloonAltitudeStyle.labels(altitudeUnit);
+    String threshold(double metres) =>
+        altitudeUnit.fromMetres(metres).round().toString();
+    return Semantics(
+      label:
+          'Balloon track altitude in ${altitudeUnit.label.toLowerCase()}: '
+          '${labels.join(', ')}. The line grows thicker as altitude increases. '
+          'Grey and thinnest means altitude unavailable.',
+      child: Card(
+        key: const Key('balloon-altitude-legend'),
+        color: const Color(0xE6252E39),
+        margin: EdgeInsets.zero,
+        child: SizedBox(
+          width: 248,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'TRACK ALTITUDE · ${altitudeUnit.label.toUpperCase()}',
+                  style: const TextStyle(
+                    color: Color(0xFFCED6DF),
+                    fontSize: 10,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0.5,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 5),
-              ClipRRect(
-                borderRadius: BorderRadius.circular(4),
-                child: Row(
+                const SizedBox(height: 5),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: SizedBox(
+                    height: 14,
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        for (final (index, band)
+                            in BalloonAltitudeStyle.bands.indexed)
+                          Expanded(
+                            child: ColoredBox(
+                              color: band.color,
+                              child: SizedBox(
+                                height:
+                                    6 +
+                                    BalloonAltitudeStyle
+                                            .bandWidthFactors[index] *
+                                        5,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    for (final band in BalloonAltitudeStyle.bands)
-                      Expanded(
-                        child: ColoredBox(
-                          color: band.color,
-                          child: const SizedBox(height: 8),
-                        ),
-                      ),
+                    Text(
+                      '<${threshold(150)}',
+                      style: const TextStyle(fontSize: 9),
+                    ),
+                    Text(threshold(300), style: const TextStyle(fontSize: 9)),
+                    Text(threshold(600), style: const TextStyle(fontSize: 9)),
+                    Text(
+                      '${threshold(900)}+ ${altitudeUnit.symbol}',
+                      style: const TextStyle(fontSize: 9),
+                    ),
                   ],
                 ),
-              ),
-              const SizedBox(height: 3),
-              const Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text('<150', style: TextStyle(fontSize: 9)),
-                  Text('300', style: TextStyle(fontSize: 9)),
-                  Text('600', style: TextStyle(fontSize: 9)),
-                  Text('900+ m', style: TextStyle(fontSize: 9)),
-                ],
-              ),
-              const SizedBox(height: 2),
-              const Text(
-                'Grey = altitude unavailable',
-                style: TextStyle(color: Color(0xFFB7C4D1), fontSize: 9),
-              ),
-            ],
+                const SizedBox(height: 2),
+                const Text(
+                  'Thicker = higher · grey/thinnest = altitude unavailable',
+                  style: TextStyle(color: Color(0xFFB7C4D1), fontSize: 9),
+                ),
+              ],
+            ),
           ),
         ),
       ),
-    ),
-  );
+    );
+  }
 }
 
 class _BalloonAltitudeCard extends StatelessWidget {
   const _BalloonAltitudeCard({
     required this.fix,
+    required this.altitudeUnit,
     required this.onShowMapInformation,
   });
 
   final MapNavigationPosition? fix;
+  final AltitudeUnit altitudeUnit;
   final VoidCallback onShowMapInformation;
 
   @override
@@ -9283,13 +9375,13 @@ class _BalloonAltitudeCard extends StatelessWidget {
               .abs();
     final primary = altitude == null
         ? 'Altitude unavailable'
-        : '${altitude.round()} m';
+        : altitudeUnit.altitude(altitude);
     final trend = _trend(reading?.verticalSpeedMetersPerSecond);
     final accuracy = reading?.altitudeAccuracyMeters;
     final details = [
       if (reading != null && altitude != null) _source(reading.altitudeSource),
       if (reading != null && altitude != null) _datum(reading.altitudeDatum),
-      if (accuracy != null) '±${accuracy.round()} m',
+      if (accuracy != null) altitudeUnit.accuracy(accuracy),
       if (age != null) _age(age),
     ];
     return Semantics(
@@ -9408,7 +9500,7 @@ class _BalloonAltitudeCard extends StatelessWidget {
         ? '↓'
         : '→';
     final magnitude = metresPerSecond.abs();
-    return '$arrow ${magnitude.toStringAsFixed(1)} m/s';
+    return '$arrow ${altitudeUnit.verticalRate(magnitude)}';
   }
 
   static String _source(AltitudeSource source) => switch (source) {

--- a/apps/mobile/lib/features/map/route_confirmation_sheet.dart
+++ b/apps/mobile/lib/features/map/route_confirmation_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../domain/altitude_unit.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/imported_route.dart';
 import '../../services/measurement_formatter.dart';
@@ -31,6 +32,7 @@ class RouteConfirmationSheet extends StatelessWidget {
     super.key,
     required this.route,
     required this.distanceUnit,
+    this.altitudeUnit = AltitudeUnit.metres,
     this.distanceMeters,
     this.duration,
     this.warnings = const [],
@@ -39,6 +41,7 @@ class RouteConfirmationSheet extends StatelessWidget {
 
   final ImportedRoute route;
   final DistanceUnit distanceUnit;
+  final AltitudeUnit altitudeUnit;
   final double? distanceMeters;
   final Duration? duration;
   final List<String> warnings;
@@ -51,6 +54,7 @@ class RouteConfirmationSheet extends StatelessWidget {
     BuildContext context, {
     required ImportedRoute route,
     required DistanceUnit distanceUnit,
+    AltitudeUnit altitudeUnit = AltitudeUnit.metres,
     double? distanceMeters,
     Duration? duration,
     List<String> warnings = const [],
@@ -62,6 +66,7 @@ class RouteConfirmationSheet extends StatelessWidget {
       builder: (sheetContext) => RouteConfirmationSheet(
         route: route,
         distanceUnit: distanceUnit,
+        altitudeUnit: altitudeUnit,
         distanceMeters: distanceMeters,
         duration: duration,
         warnings: warnings,
@@ -124,7 +129,7 @@ class RouteConfirmationSheet extends StatelessWidget {
                   if (_maximumAltitude(route) case final altitude?)
                     _Fact(
                       icon: Icons.height,
-                      label: 'Max ${altitude.round()} m MSL',
+                      label: 'Max ${altitudeUnit.altitude(altitude)} MSL',
                     )
                   else
                     const _Fact(

--- a/apps/mobile/lib/features/map/route_trail_style.dart
+++ b/apps/mobile/lib/features/map/route_trail_style.dart
@@ -31,6 +31,13 @@ class RouteLineStyle {
     dashPixels: dashPixels,
   );
 
+  RouteLineStyle scaleWidth(double factor) => RouteLineStyle(
+    color: color,
+    widthPixels: widthPixels * factor,
+    casingWidthPixels: casingWidthPixels * factor,
+    dashPixels: dashPixels,
+  );
+
   /// MapLibre expresses `line-dasharray` in multiples of the line width, so the
   /// pixel run lengths are converted here rather than being restated per layer.
   List<double>? get maplibreDashArray => _dashArrayFor(widthPixels);

--- a/apps/mobile/lib/features/replay/flight_replay_screen.dart
+++ b/apps/mobile/lib/features/replay/flight_replay_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 import '../../controllers/flight_replay_controller.dart';
+import '../../domain/altitude_unit.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/flight_replay.dart';
 import '../../domain/geo_point.dart';
@@ -14,23 +15,27 @@ class FlightReplayScreen extends StatefulWidget {
     required this.title,
     required this.replay,
     required this.distanceUnit,
+    this.altitudeUnit = AltitudeUnit.metres,
   });
 
   final String title;
   final FlightReplay replay;
   final DistanceUnit distanceUnit;
+  final AltitudeUnit altitudeUnit;
 
   static Future<void> show(
     BuildContext context, {
     required String title,
     required FlightReplay replay,
     required DistanceUnit distanceUnit,
+    required AltitudeUnit altitudeUnit,
   }) => Navigator.of(context).push(
     MaterialPageRoute<void>(
       builder: (_) => FlightReplayScreen(
         title: title,
         replay: replay,
         distanceUnit: distanceUnit,
+        altitudeUnit: altitudeUnit,
       ),
     ),
   );
@@ -80,9 +85,10 @@ class _FlightReplayScreenState extends State<FlightReplayScreen> {
               replay: widget.replay,
               frame: frame,
               distanceUnit: widget.distanceUnit,
+              altitudeUnit: widget.altitudeUnit,
             ),
             const SizedBox(height: 12),
-            _WindCard(frame.wind),
+            _WindCard(frame.wind, altitudeUnit: widget.altitudeUnit),
             const SizedBox(height: 10),
             Text(
               widget.replay.peerTracksIncluded
@@ -161,11 +167,13 @@ class _TelemetryGrid extends StatelessWidget {
     required this.replay,
     required this.frame,
     required this.distanceUnit,
+    required this.altitudeUnit,
   });
 
   final FlightReplay replay;
   final FlightReplayFrame frame;
   final DistanceUnit distanceUnit;
+  final AltitudeUnit altitudeUnit;
 
   @override
   Widget build(BuildContext context) {
@@ -199,7 +207,7 @@ class _TelemetryGrid extends StatelessWidget {
                       Text(
                         sample.altitudeMeters == null
                             ? 'Altitude unknown'
-                            : _altitude(sample.altitudeMeters!, distanceUnit),
+                            : altitudeUnit.altitude(sample.altitudeMeters!),
                       ),
                       Text(
                         sample.headingDegrees == null
@@ -217,9 +225,10 @@ class _TelemetryGrid extends StatelessWidget {
 }
 
 class _WindCard extends StatelessWidget {
-  const _WindCard(this.wind);
+  const _WindCard(this.wind, {required this.altitudeUnit});
 
   final FlightReplayWindContext? wind;
+  final AltitudeUnit altitudeUnit;
 
   @override
   Widget build(BuildContext context) {
@@ -247,7 +256,9 @@ class _WindCard extends StatelessWidget {
           for (final vector in context.vectors)
             ListTile(
               dense: true,
-              title: Text('${vector.altitudeMetersMsl.round()} m MSL'),
+              title: Text(
+                '${altitudeUnit.altitude(vector.altitudeMetersMsl)} MSL',
+              ),
               trailing: Text(
                 '${vector.fromDegrees.round().toString().padLeft(3, '0')}° from · ${vector.speedKmh.round()} km/h',
               ),
@@ -414,7 +425,3 @@ String _duration(Duration value) {
 String _clock(DateTime value) =>
     '${value.toLocal().hour.toString().padLeft(2, '0')}:'
     '${value.toLocal().minute.toString().padLeft(2, '0')}';
-
-String _altitude(double metres, DistanceUnit unit) => unit == DistanceUnit.miles
-    ? '${(metres * 3.28084).round()} ft'
-    : '${metres.round()} m';

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -29,6 +29,7 @@ import '../../controllers/situational_awareness_controller.dart';
 import '../../data/in_memory_event_store.dart';
 import '../../data/json_file_route_store.dart';
 import '../../data/secure_observer_grant_store.dart';
+import '../../domain/altitude_unit.dart';
 import '../../domain/event_store.dart';
 import '../../domain/completed_ride_store.dart';
 import '../../domain/flight_replay.dart';
@@ -382,6 +383,10 @@ class _CraftMapLocation {
     required this.riderSymbol,
     required this.riderColor,
     required this.altitudeMeters,
+    this.positionAccuracyMeters,
+    this.altitudeSource = AltitudeSource.unknown,
+    this.altitudeDatum = AltitudeDatum.unknown,
+    this.altitudeAccuracyMeters,
     required this.speedMetersPerSecond,
     required this.headingDegrees,
     required this.point,
@@ -396,6 +401,10 @@ class _CraftMapLocation {
   final RiderSymbol riderSymbol;
   final RiderColor riderColor;
   final double? altitudeMeters;
+  final double? positionAccuracyMeters;
+  final AltitudeSource altitudeSource;
+  final AltitudeDatum altitudeDatum;
+  final double? altitudeAccuracyMeters;
   final double? speedMetersPerSecond;
   final double? headingDegrees;
   final route_domain.GeoPoint point;
@@ -416,6 +425,35 @@ String? craftGroundMotionLabel({
     final heading = headingDegrees.round() % 360;
     const compass = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
     parts.add('${compass[((heading + 22.5) ~/ 45) % 8]} $heading°');
+  }
+  return parts.isEmpty ? null : parts.join(' · ');
+}
+
+String? _balloonFixQualityLabel(
+  _CraftMapLocation location,
+  AltitudeUnit altitudeUnit,
+) {
+  final parts = <String>[
+    if (location.positionAccuracyMeters case final accuracy?)
+      'position ±${accuracy.round()} m',
+  ];
+  if (location.altitudeMeters != null) {
+    parts.add(switch (location.altitudeSource) {
+      AltitudeSource.gnss => 'GNSS altitude',
+      AltitudeSource.barometric => 'barometric altitude',
+      AltitudeSource.unknown => 'altitude source unknown',
+    });
+    parts.add(switch (location.altitudeDatum) {
+      AltitudeDatum.wgs84Geoid => 'MSL geoid',
+      AltitudeDatum.wgs84Ellipsoid => 'WGS84 ellipsoid',
+      AltitudeDatum.relativeToLaunch => 'relative to launch',
+      AltitudeDatum.unknown => 'datum unknown',
+    });
+    if (location.altitudeAccuracyMeters case final accuracy?) {
+      parts.add(altitudeUnit.accuracy(accuracy));
+    }
+  } else {
+    parts.add('altitude unavailable');
   }
   return parts.isEmpty ? null : parts.join(' · ');
 }
@@ -2671,6 +2709,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           riderSymbol: riderSymbolDefault,
           riderColor: reporter?.riderColor ?? riderColorDefault,
           altitudeMeters: sample.altitudeMeters,
+          positionAccuracyMeters: sample.accuracyMeters,
+          altitudeSource: sample.altitudeSource,
+          altitudeDatum: sample.altitudeDatum,
+          altitudeAccuracyMeters: sample.altitudeAccuracyMeters,
           speedMetersPerSecond: sample.speedMetersPerSecond,
           headingDegrees: sample.headingDegrees,
           point: route_domain.GeoPoint(
@@ -2907,6 +2949,11 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 freshnessByRider[location.freshnessDeviceId]?.freshnessLabel ??
                     freshness.label,
             };
+            final sources =
+                freshnessByRider[location.freshnessDeviceId]?.sources;
+            final sourceSuffix = sources == null || sources.isEmpty
+                ? null
+                : sources.map((source) => source.label).join(' + ');
             // Issue #151's map companion, kept deliberately minimal: the rider
             // who raised something already has a marker, so it says what they
             // raised rather than inventing a second symbol beside it.
@@ -2927,7 +2974,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 headingDegrees: location.headingDegrees,
               ),
               if (isBalloonCraft && location.altitudeMeters != null)
-                '${location.altitudeMeters!.round()} m',
+                widget.distanceUnits.altitudeUnit.altitude(
+                  location.altitudeMeters!,
+                ),
+              if (isBalloonCraft)
+                ?_balloonFixQualityLabel(
+                  location,
+                  widget.distanceUnits.altitudeUnit,
+                ),
+              ?sourceSuffix,
               ?ageSuffix,
             ].join(' · ');
             // The roster, both maps and trails share this one identity colour.
@@ -3052,7 +3107,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                   ),
                   if (session.flightRole.isAboardBalloon &&
                       navigationPosition?.altitudeMeters != null)
-                    '${navigationPosition!.altitudeMeters!.round()} m',
+                    widget.distanceUnits.altitudeUnit.altitude(
+                      navigationPosition!.altitudeMeters!,
+                    ),
                   navigationPosition == null
                       ? 'unknown'
                       : localSpeedIsAgeing
@@ -3120,7 +3177,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 headingDegrees: craft.headingDegrees,
               ),
               if (craft.role == RideRole.lead && craft.altitudeMeters != null)
-                '${craft.altitudeMeters!.round()} m',
+                widget.distanceUnits.altitudeUnit.altitude(
+                  craft.altitudeMeters!,
+                ),
               'bundled rehearsal · now',
             ].join(' · '),
             point: route_domain.GeoPoint(
@@ -3160,7 +3219,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               headingDegrees: craft.headingDegrees,
             ),
             if (craft.isBalloon && craft.altitudeMeters != null)
-              '${craft.altitudeMeters!.round()} m',
+              widget.distanceUnits.altitudeUnit.altitude(craft.altitudeMeters!),
             freshness[craft.freshnessDeviceId]?.freshnessLabel ?? 'unknown',
           ].join(' · '),
           point: craft.point,
@@ -3224,11 +3283,20 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                   id: '${trace.id}-altitude-$index',
                   points: segment.points,
                   color: segment.color,
+                  widthFactor: segment.widthFactor,
                 ),
             ]
-          : [(id: trace.id, points: trace.points, color: trace.effectiveColor)];
+          : [
+              (
+                id: trace.id,
+                points: trace.points,
+                color: trace.effectiveColor,
+                widthFactor: 1.0,
+              ),
+            ];
       for (final part in parts) {
         if (part.points.length < 2) continue;
+        final partStyle = style.scaleWidth(part.widthFactor);
         projected.add(
           CarPlayMapTrace(
             id: part.id,
@@ -3236,9 +3304,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             label: trace.label,
             points: part.points,
             colorArgb: part.color.toARGB32(),
-            width: style.widthPixels,
-            casingWidth: style.casingWidthPixels,
-            dash: style.maplibreDashArray,
+            width: partStyle.widthPixels,
+            casingWidth: partStyle.casingWidthPixels,
+            dash: partStyle.maplibreDashArray,
           ),
         );
       }
@@ -3496,6 +3564,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       widget.rideController.events,
     );
     final balloonTrack = tracks.where((track) => track.isBalloon).firstOrNull;
+    if (balloonTrack?.rejectedSamples.isNotEmpty == true) {
+      _warnings.add(
+        'An impossible balloon position jump was excluded from the measured '
+        'track. The original fix remains in the offline flight journal.',
+      );
+    }
     if (balloonTrack?.samples.firstOrNull case final reference?) {
       final previous = _balloonReferenceFix;
       if (previous == null ||
@@ -4646,6 +4720,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       routeStore: routeStore,
       canEditRoute: _isSimulation || widget.rideController.hasFlightAuthority,
       distanceUnit: widget.distanceUnits.value,
+      altitudeUnit: widget.distanceUnits.altitudeUnit,
       speedLimitDisplay: isDriverView ? widget.speedLimitDisplay : null,
       chaseVehicle: widget.chaseVehicle?.vehicle ?? ChaseVehicle.unspecified,
       showRouteProgress:
@@ -6980,6 +7055,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     return RideSimulationScreen(
       controller: controller,
       distanceUnit: widget.distanceUnits.value,
+      altitudeUnit: widget.distanceUnits.altitudeUnit,
       onRestart: _restartSimulation,
       onExit: _leaveRide,
       onRoleChanged: _setSimulationRole,

--- a/apps/mobile/lib/features/ride/previous_rides_screen.dart
+++ b/apps/mobile/lib/features/ride/previous_rides_screen.dart
@@ -333,6 +333,7 @@ class _PreviousRideDetailScreenState extends State<PreviousRideDetailScreen> {
       title: widget.ride.title,
       replay: replay,
       distanceUnit: widget.distanceUnits.value,
+      altitudeUnit: widget.distanceUnits.altitudeUnit,
     );
   }
 

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -8,6 +8,7 @@ import '../../controllers/internet_relay_controller.dart';
 import '../../controllers/ride_controller.dart';
 import '../../controllers/nearby_relay_controller.dart';
 import '../../domain/altitude.dart';
+import '../../domain/altitude_unit.dart';
 import '../../domain/flight_role.dart';
 import '../../domain/imported_route.dart';
 import '../../domain/quick_message.dart';
@@ -105,6 +106,7 @@ class RideDashboard extends StatelessWidget {
                   const SizedBox(height: 14),
                   _RoleLivePanel(
                     role: session.flightRole,
+                    altitudeUnit: distanceUnits.altitudeUnit,
                     sharedFlightPlan: sharedFlightPlan,
                     vehicleRoadRoute: vehicleRoadRoute,
                     navigationPosition: navigationPosition,
@@ -282,6 +284,7 @@ class _RideHeader extends StatelessWidget {
 class _RoleLivePanel extends StatelessWidget {
   const _RoleLivePanel({
     required this.role,
+    required this.altitudeUnit,
     required this.sharedFlightPlan,
     required this.vehicleRoadRoute,
     required this.navigationPosition,
@@ -296,6 +299,7 @@ class _RoleLivePanel extends StatelessWidget {
   });
 
   final FlightRole role;
+  final AltitudeUnit altitudeUnit;
   final ImportedRoute? sharedFlightPlan;
   final ImportedRoute? vehicleRoadRoute;
   final ValueListenable<MapNavigationPosition?>? navigationPosition;
@@ -397,13 +401,16 @@ class _RoleLivePanel extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             if (role.isAboardBalloon) ...[
-              _AirborneTelemetry(position: position),
+              _AirborneTelemetry(
+                position: position,
+                altitudeUnit: altitudeUnit,
+              ),
               const SizedBox(height: 12),
-              _WindSummary(wind: wind),
+              _WindSummary(wind: wind, altitudeUnit: altitudeUnit),
               const SizedBox(height: 12),
               _LiveProjectionSummary(assessment: liveFlightProjection),
               const SizedBox(height: 12),
-              _FlightPlanOverview(summary: summary),
+              _FlightPlanOverview(summary: summary, altitudeUnit: altitudeUnit),
               const SizedBox(height: 12),
               _LandingIntentRow(
                 label: landingAreaLabel,
@@ -437,17 +444,24 @@ class _RoleLivePanel extends StatelessWidget {
               _LiveProjectionSummary(assessment: liveFlightProjection),
               if (role == FlightRole.chaseCrew) ...[
                 const SizedBox(height: 12),
-                _FlightPlanOverview(summary: summary),
+                _FlightPlanOverview(
+                  summary: summary,
+                  altitudeUnit: altitudeUnit,
+                ),
                 const SizedBox(height: 12),
                 _LandingIntentRow(
                   label: landingAreaLabel,
                   updatedAt: landingAreaUpdatedAt,
                 ),
                 const SizedBox(height: 12),
-                _WindSummary(wind: wind),
+                _WindSummary(wind: wind, altitudeUnit: altitudeUnit),
               ],
             ] else ...[
-              _FlightPlanOverview(summary: summary, reduced: true),
+              _FlightPlanOverview(
+                summary: summary,
+                altitudeUnit: altitudeUnit,
+                reduced: true,
+              ),
               const SizedBox(height: 12),
               _LandingIntentRow(
                 label: landingAreaLabel,
@@ -462,9 +476,13 @@ class _RoleLivePanel extends StatelessWidget {
 }
 
 class _AirborneTelemetry extends StatelessWidget {
-  const _AirborneTelemetry({required this.position});
+  const _AirborneTelemetry({
+    required this.position,
+    required this.altitudeUnit,
+  });
 
   final MapNavigationPosition? position;
+  final AltitudeUnit altitudeUnit;
 
   @override
   Widget build(BuildContext context) {
@@ -486,7 +504,9 @@ class _AirborneTelemetry extends StatelessWidget {
           Expanded(
             child: _Metric(
               label: 'ALTITUDE',
-              value: altitude == null ? 'Unavailable' : '${altitude.round()} m',
+              value: altitude == null
+                  ? 'Unavailable'
+                  : altitudeUnit.altitude(altitude),
               detail: altitude == null
                   ? 'No altitude fix'
                   : '${_altitudeSourceLabel(fix!.altitudeSource)} · ${_altitudeDatumLabel(fix.altitudeDatum)}',
@@ -498,7 +518,7 @@ class _AirborneTelemetry extends StatelessWidget {
               label: 'VERTICAL RATE',
               value: verticalRate == null
                   ? 'Unavailable'
-                  : '${verticalRate >= 0 ? '+' : ''}${verticalRate.toStringAsFixed(1)} m/s',
+                  : '${verticalRate >= 0 ? '+' : '-'}${altitudeUnit.verticalRate(verticalRate.abs())}',
               detail: fixAge == null
                   ? 'No fix'
                   : 'Fix ${_compactAge(fixAge)} ago',
@@ -547,9 +567,10 @@ class _Metric extends StatelessWidget {
 }
 
 class _WindSummary extends StatelessWidget {
-  const _WindSummary({required this.wind});
+  const _WindSummary({required this.wind, required this.altitudeUnit});
 
   final WindForecastController? wind;
+  final AltitudeUnit altitudeUnit;
 
   @override
   Widget build(BuildContext context) {
@@ -561,7 +582,7 @@ class _WindSummary extends StatelessWidget {
       key: const Key('role-wind-summary'),
       icon: Icons.air,
       title: enabled && level != null
-          ? 'Forecast wind · $level m MSL'
+          ? 'Forecast wind · ${altitudeUnit.altitude(level.toDouble())} MSL'
           : 'Forecast wind off',
       detail: field == null
           ? controller?.loading == true
@@ -606,9 +627,14 @@ class _LiveProjectionSummary extends StatelessWidget {
 }
 
 class _FlightPlanOverview extends StatelessWidget {
-  const _FlightPlanOverview({required this.summary, this.reduced = false});
+  const _FlightPlanOverview({
+    required this.summary,
+    required this.altitudeUnit,
+    this.reduced = false,
+  });
 
   final FlightPlanSummary? summary;
+  final AltitudeUnit altitudeUnit;
   final bool reduced;
 
   @override
@@ -643,8 +669,8 @@ class _FlightPlanOverview extends StatelessWidget {
     final altitude = plan.altitudeCeilingMetersMsl == null
         ? plan.maximumAltitudeMetersMsl == null
               ? null
-              : 'forecast max ${plan.maximumAltitudeMetersMsl!.round()} m MSL'
-        : 'ceiling ${plan.altitudeCeilingMetersMsl!.round()} m MSL';
+              : 'forecast max ${altitudeUnit.altitude(plan.maximumAltitudeMetersMsl!)} MSL'
+        : 'ceiling ${altitudeUnit.altitude(plan.altitudeCeilingMetersMsl!)} MSL';
     final window = plan.matchingWindowStart == null
         ? null
         : plan.matchingWindowEnd == null ||
@@ -653,10 +679,10 @@ class _FlightPlanOverview extends StatelessWidget {
         : 'start window ${_formatTime(context, plan.matchingWindowStart!)}–${_formatTime(context, plan.matchingWindowEnd!)}';
     final climb = plan.maximumAscentRateMetersPerSecond == null
         ? null
-        : 'climb ${plan.maximumAscentRateMetersPerSecond!.toStringAsFixed(1)} m/s';
+        : 'climb ${altitudeUnit.verticalRate(plan.maximumAscentRateMetersPerSecond!)}';
     final descent = plan.maximumDescentRateMetersPerSecond == null
         ? null
-        : 'descent ${plan.maximumDescentRateMetersPerSecond!.toStringAsFixed(1)} m/s';
+        : 'descent ${altitudeUnit.verticalRate(plan.maximumDescentRateMetersPerSecond!)}';
     final detail = [
       times,
       duration,
@@ -713,7 +739,7 @@ class _FlightPlanOverview extends StatelessWidget {
                   trailing: Text(
                     stage.altitudeMetersMsl == null
                         ? '—'
-                        : '${stage.altitudeMetersMsl!.round()} m MSL',
+                        : '${altitudeUnit.altitude(stage.altitudeMetersMsl!)} MSL',
                     style: const TextStyle(fontWeight: FontWeight.w700),
                   ),
                 ),

--- a/apps/mobile/lib/features/settings/unit_settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/unit_settings_sheet.dart
@@ -14,6 +14,7 @@ import '../../controllers/ride_diagnostics_controller.dart';
 import '../../controllers/spoken_guidance_controller.dart';
 import '../../controllers/test_control_controller.dart';
 import '../../domain/app_links.dart';
+import '../../domain/altitude_unit.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/geo_point.dart';
 import '../../domain/map_style_mode.dart';
@@ -279,6 +280,34 @@ class UnitSettingsSheet extends StatelessWidget {
                 ? 'Using the device locale default (${controller.localeDefault.label.toLowerCase()}).'
                 : 'Overriding the device locale default (${controller.localeDefault.label.toLowerCase()}).',
             style: const TextStyle(color: Color(0xFF98A3B1)),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            'ALTITUDE UNITS',
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: const Color(0xFF8D98A7),
+              letterSpacing: 1.1,
+            ),
+          ),
+          const SizedBox(height: 10),
+          SegmentedButton<AltitudeUnit>(
+            key: const Key('altitude-unit-selector'),
+            segments: AltitudeUnit.values
+                .map(
+                  (unit) => ButtonSegment<AltitudeUnit>(
+                    value: unit,
+                    label: Text(unit.label),
+                  ),
+                )
+                .toList(growable: false),
+            selected: {controller.altitudeUnit},
+            onSelectionChanged: (selection) {
+              unawaited(controller.setAltitudeUnit(selection.single));
+            },
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Altitude defaults to metres independently of road distance.',
           ),
           if (!controller.followsLocale) ...[
             const SizedBox(height: 4),

--- a/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
+++ b/apps/mobile/lib/features/simulation/ride_simulation_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../../controllers/ride_simulation_controller.dart';
+import '../../domain/altitude_unit.dart';
 import '../../domain/distance_unit.dart';
 import '../../domain/ride_role.dart';
 import '../../services/measurement_formatter.dart';
@@ -13,6 +14,7 @@ class RideSimulationScreen extends StatelessWidget {
     super.key,
     required this.controller,
     this.distanceUnit = DistanceUnit.miles,
+    this.altitudeUnit = AltitudeUnit.metres,
     required this.onRestart,
     required this.onExit,
     required this.onRoleChanged,
@@ -21,6 +23,7 @@ class RideSimulationScreen extends StatelessWidget {
 
   final RideSimulationController controller;
   final DistanceUnit distanceUnit;
+  final AltitudeUnit altitudeUnit;
   final Future<void> Function() onRestart;
   final Future<void> Function() onExit;
   final Future<void> Function(RideRole role) onRoleChanged;
@@ -60,6 +63,7 @@ class RideSimulationScreen extends StatelessWidget {
             final fleet = _FleetCard(
               controller: controller,
               distanceUnit: distanceUnit,
+              altitudeUnit: altitudeUnit,
             );
             if (landscape) {
               return Padding(
@@ -247,10 +251,15 @@ class _SimulationControls extends StatelessWidget {
 }
 
 class _FleetCard extends StatelessWidget {
-  const _FleetCard({required this.controller, required this.distanceUnit});
+  const _FleetCard({
+    required this.controller,
+    required this.distanceUnit,
+    required this.altitudeUnit,
+  });
 
   final RideSimulationController controller;
   final DistanceUnit distanceUnit;
+  final AltitudeUnit altitudeUnit;
 
   @override
   Widget build(BuildContext context) => Card(
@@ -288,7 +297,7 @@ class _FleetCard extends StatelessWidget {
                       Text(
                         '${rider.role.label} · '
                         '${MeasurementFormatter(distanceUnit).speed(rider.speedMetersPerSecond)}'
-                        '${rider.altitudeMeters == null ? '' : ' · ${rider.altitudeMeters!.round()} m'}',
+                        '${rider.altitudeMeters == null ? '' : ' · ${altitudeUnit.altitude(rider.altitudeMeters!)}'}',
                         style: const TextStyle(
                           color: Color(0xFF8F9BAA),
                           fontSize: 12,

--- a/apps/mobile/lib/services/balloon_telemetry_plausibility.dart
+++ b/apps/mobile/lib/services/balloon_telemetry_plausibility.dart
@@ -1,0 +1,117 @@
+import 'dart:math' as math;
+
+import '../domain/rider_location.dart';
+
+enum BalloonTelemetryRejectionReason {
+  impossibleGroundSpeed,
+  impossibleVerticalSpeed,
+}
+
+class BalloonTelemetryPlausibilityDecision {
+  const BalloonTelemetryPlausibilityDecision.accepted()
+    : rejectionReason = null,
+      observedRate = null;
+
+  const BalloonTelemetryPlausibilityDecision.rejected(
+    this.rejectionReason,
+    this.observedRate,
+  );
+
+  final BalloonTelemetryRejectionReason? rejectionReason;
+  final double? observedRate;
+
+  bool get accepted => rejectionReason == null;
+}
+
+/// Rejects only physically impossible jumps from the measured balloon trail.
+///
+/// The limits are deliberately generous and are not operating limits. They are
+/// an integrity backstop for a GNSS teleport: 60 m/s across the ground and
+/// 12 m/s vertically. Reported horizontal/vertical accuracy is added to the
+/// permitted displacement, missing altitude is accepted as unknown, and a gap
+/// over two minutes starts a new honest trail segment instead of guessing what
+/// happened while fixes were absent.
+class BalloonTelemetryPlausibilityPolicy {
+  const BalloonTelemetryPlausibilityPolicy({
+    this.maximumGroundSpeedMetersPerSecond = 60,
+    this.maximumVerticalSpeedMetersPerSecond = 12,
+    this.maximumComparableGap = const Duration(minutes: 2),
+  });
+
+  final double maximumGroundSpeedMetersPerSecond;
+  final double maximumVerticalSpeedMetersPerSecond;
+  final Duration maximumComparableGap;
+
+  BalloonTelemetryPlausibilityDecision assess({
+    required LocationSample previous,
+    required LocationSample candidate,
+  }) {
+    final elapsed = candidate.recordedAt.difference(previous.recordedAt);
+    if (elapsed <= Duration.zero || elapsed > maximumComparableGap) {
+      return const BalloonTelemetryPlausibilityDecision.accepted();
+    }
+    final seconds = elapsed.inMicroseconds / Duration.microsecondsPerSecond;
+    final distance = _distanceMeters(previous, candidate);
+    final horizontalAllowance =
+        maximumGroundSpeedMetersPerSecond * seconds +
+        previous.accuracyMeters +
+        candidate.accuracyMeters;
+    if (distance > horizontalAllowance) {
+      return BalloonTelemetryPlausibilityDecision.rejected(
+        BalloonTelemetryRejectionReason.impossibleGroundSpeed,
+        distance / seconds,
+      );
+    }
+
+    final previousAltitude = previous.altitudeMeters;
+    final candidateAltitude = candidate.altitudeMeters;
+    final comparableAltitude =
+        previousAltitude != null &&
+        candidateAltitude != null &&
+        previous.altitudeDatum == candidate.altitudeDatum;
+    if (comparableAltitude) {
+      final verticalDistance = (candidateAltitude - previousAltitude).abs();
+      final verticalAllowance =
+          maximumVerticalSpeedMetersPerSecond * seconds +
+          (previous.altitudeAccuracyMeters ?? 0) +
+          (candidate.altitudeAccuracyMeters ?? 0);
+      if (verticalDistance > verticalAllowance) {
+        return BalloonTelemetryPlausibilityDecision.rejected(
+          BalloonTelemetryRejectionReason.impossibleVerticalSpeed,
+          verticalDistance / seconds,
+        );
+      }
+    }
+
+    final reportedVerticalSpeed = candidate.verticalSpeedMetersPerSecond?.abs();
+    if (reportedVerticalSpeed != null &&
+        reportedVerticalSpeed > maximumVerticalSpeedMetersPerSecond) {
+      return BalloonTelemetryPlausibilityDecision.rejected(
+        BalloonTelemetryRejectionReason.impossibleVerticalSpeed,
+        reportedVerticalSpeed,
+      );
+    }
+    return const BalloonTelemetryPlausibilityDecision.accepted();
+  }
+
+  static double _distanceMeters(LocationSample first, LocationSample second) {
+    const earthRadiusMeters = 6371008.8;
+    double radians(double degrees) => degrees * math.pi / 180;
+    final lat1 = radians(first.position.latitude);
+    final lat2 = radians(second.position.latitude);
+    final deltaLat = lat2 - lat1;
+    final deltaLon = radians(
+      second.position.longitude - first.position.longitude,
+    );
+    final a =
+        math.sin(deltaLat / 2) * math.sin(deltaLat / 2) +
+        math.cos(lat1) *
+            math.cos(lat2) *
+            math.sin(deltaLon / 2) *
+            math.sin(deltaLon / 2);
+    final bounded = a.clamp(0.0, 1.0);
+    return earthRadiusMeters *
+        2 *
+        math.atan2(math.sqrt(bounded), math.sqrt(1 - bounded));
+  }
+}

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -2,6 +2,19 @@ import '../domain/craft.dart';
 import '../domain/ride_event.dart';
 import '../domain/rider_location.dart';
 import 'craft_telemetry_election.dart';
+import 'balloon_telemetry_plausibility.dart';
+
+class RejectedCraftTrackSample {
+  const RejectedCraftTrackSample({
+    required this.sample,
+    required this.reason,
+    required this.observedRate,
+  });
+
+  final LocationSample sample;
+  final BalloonTelemetryRejectionReason reason;
+  final double observedRate;
+}
 
 class CraftTrack {
   const CraftTrack({
@@ -9,12 +22,14 @@ class CraftTrack {
     required this.label,
     required this.kind,
     required this.samples,
+    this.rejectedSamples = const [],
   });
 
   final String craftId;
   final String label;
   final CraftKind kind;
   final List<LocationSample> samples;
+  final List<RejectedCraftTrackSample> rejectedSamples;
 
   bool get isBalloon => kind == CraftKind.balloon;
 }
@@ -26,9 +41,13 @@ class CraftTrack {
 /// election used for the current craft fix is replayed through measurement
 /// time. Out-of-order and duplicate fixes cannot regress the result.
 class CraftTrackReducer {
-  const CraftTrackReducer({this.election = const CraftTelemetryElection()});
+  const CraftTrackReducer({
+    this.election = const CraftTelemetryElection(),
+    this.plausibility = const BalloonTelemetryPlausibilityPolicy(),
+  });
 
   final CraftTelemetryElection election;
+  final BalloonTelemetryPlausibilityPolicy plausibility;
 
   List<CraftTrack> fromEvents(Iterable<RideEvent> events) {
     final crafts = <String, Craft>{};
@@ -118,6 +137,7 @@ class CraftTrackReducer {
         });
       final latestByDevice = <String, _TimedCandidate>{};
       final samples = <LocationSample>[];
+      final rejectedSamples = <RejectedCraftTrackSample>[];
       String? incumbentDeviceId;
       for (final candidate in candidates) {
         final previous = latestByDevice[candidate.deviceId];
@@ -145,6 +165,22 @@ class CraftTrackReducer {
             !elected.recordedAt.isAfter(samples.last.recordedAt)) {
           continue;
         }
+        if (craft.isBalloon && samples.isNotEmpty) {
+          final decision = plausibility.assess(
+            previous: samples.last,
+            candidate: elected,
+          );
+          if (!decision.accepted) {
+            rejectedSamples.add(
+              RejectedCraftTrackSample(
+                sample: elected,
+                reason: decision.rejectionReason!,
+                observedRate: decision.observedRate!,
+              ),
+            );
+            continue;
+          }
+        }
         samples.add(elected);
       }
       tracks.add(
@@ -153,6 +189,7 @@ class CraftTrackReducer {
           label: craft.label,
           kind: craft.kind,
           samples: List.unmodifiable(samples),
+          rejectedSamples: List.unmodifiable(rejectedSamples),
         ),
       );
     }

--- a/apps/mobile/test/controllers/distance_unit_controller_test.dart
+++ b/apps/mobile/test/controllers/distance_unit_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:balloon_crumbs/controllers/distance_unit_controller.dart';
+import 'package:balloon_crumbs/domain/altitude_unit.dart';
 import 'package:balloon_crumbs/domain/distance_unit.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -45,4 +46,25 @@ void main() {
     expect(reloaded.value, DistanceUnit.miles);
     expect(reloaded.followsLocale, isTrue);
   });
+
+  test(
+    'altitude defaults to metric in every locale and persists feet',
+    () async {
+      final controller = await DistanceUnitController.load(
+        locale: const Locale('en', 'GB'),
+      );
+      addTearDown(controller.dispose);
+
+      expect(controller.value, DistanceUnit.miles);
+      expect(controller.altitudeUnit, AltitudeUnit.metres);
+
+      await controller.setAltitudeUnit(AltitudeUnit.feet);
+      final reloaded = await DistanceUnitController.load(
+        locale: const Locale('fr', 'FR'),
+      );
+      addTearDown(reloaded.dispose);
+      expect(reloaded.value, DistanceUnit.kilometres);
+      expect(reloaded.altitudeUnit, AltitudeUnit.feet);
+    },
+  );
 }

--- a/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
+++ b/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
@@ -30,8 +30,8 @@ void main() {
   ];
 
   BalloonFlight flight() {
-    // Three samples is enough to have a climb, a level and a descent, with a
-    // known height at a known moment.
+    // Four samples make the climb, level hold and descent explicit, with a
+    // known height and vertical rate at a known moment.
     return const BalloonFlight(
       name: 'test flight',
       launch: launch,
@@ -49,6 +49,11 @@ void main() {
           position: GeoPoint(latitude: 51.4300, longitude: -2.7000),
           heightMetres: 180,
           elapsed: Duration(minutes: 26),
+        ),
+        BalloonFlightSample(
+          position: GeoPoint(latitude: 51.4260, longitude: -2.7120),
+          heightMetres: 180,
+          elapsed: Duration(minutes: 30),
         ),
         BalloonFlightSample(
           position: landing,
@@ -139,20 +144,27 @@ void main() {
     );
   });
 
-  test('the balloon climbs and descends in metric altitude', () async {
-    final simulation = await build();
-    addTearDown(simulation.dispose);
+  test(
+    'the balloon climbs, holds level and descends in metric altitude',
+    () async {
+      final simulation = await build();
+      addTearDown(simulation.dispose);
 
-    double? altitude() => simulation.riders
-        .firstWhere((rider) => rider.role == RideRole.lead)
-        .altitudeMeters;
+      SimulatedRiderSnapshot balloon() =>
+          simulation.riders.firstWhere((rider) => rider.role == RideRole.lead);
 
-    expect(altitude(), 0);
-    await simulation.advance(const Duration(minutes: 26));
-    expect(altitude(), closeTo(180, 0.1));
-    await simulation.advance(const Duration(minutes: 26));
-    expect(altitude(), closeTo(0, 0.1));
-  });
+      expect(balloon().altitudeMeters, 0);
+      expect(balloon().verticalSpeedMetersPerSecond, greaterThan(0));
+      await simulation.advance(const Duration(minutes: 26));
+      expect(balloon().altitudeMeters, closeTo(180, 0.1));
+      expect(balloon().verticalSpeedMetersPerSecond, 0);
+      await simulation.advance(const Duration(minutes: 10));
+      expect(balloon().altitudeMeters, lessThan(180));
+      expect(balloon().verticalSpeedMetersPerSecond, lessThan(0));
+      await simulation.advance(const Duration(minutes: 16));
+      expect(balloon().altitudeMeters, closeTo(0, 0.1));
+    },
+  );
 
   test(
     'forecast wind drives direction while altitude stays scripted',

--- a/apps/mobile/test/domain/altitude_unit_test.dart
+++ b/apps/mobile/test/domain/altitude_unit_test.dart
@@ -1,0 +1,19 @@
+import 'package:balloon_crumbs/domain/altitude_unit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('metric altitude and vertical rate remain the default presentation', () {
+    expect(AltitudeUnit.metres.altitude(300), '300 m');
+    expect(AltitudeUnit.metres.accuracy(6), '±6 m');
+    expect(AltitudeUnit.metres.verticalRate(1.5), '1.5 m/s');
+  });
+
+  test(
+    'feet conversion updates altitude accuracy and vertical rate together',
+    () {
+      expect(AltitudeUnit.feet.altitude(300), '984 ft');
+      expect(AltitudeUnit.feet.accuracy(6), '±20 ft');
+      expect(AltitudeUnit.feet.verticalRate(1.5), '295 ft/min');
+    },
+  );
+}

--- a/apps/mobile/test/features/map/balloon_altitude_style_test.dart
+++ b/apps/mobile/test/features/map/balloon_altitude_style_test.dart
@@ -1,4 +1,5 @@
 import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/domain/altitude_unit.dart';
 import 'package:balloon_crumbs/features/map/balloon_altitude_style.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,6 +16,11 @@ void main() {
     expect(segments.first.color, BalloonAltitudeStyle.bands[1].color);
     expect(segments.last.altitudeMeters, 600);
     expect(segments.last.color, BalloonAltitudeStyle.bands[3].color);
+    expect(
+      segments.last.widthFactor,
+      greaterThan(segments.first.widthFactor),
+      reason: 'line weight is the non-colour altitude cue',
+    );
   });
 
   test('does not infer altitude when either endpoint is unknown', () {
@@ -25,5 +31,26 @@ void main() {
 
     expect(segments.single.hasAltitude, isFalse);
     expect(segments.single.color, BalloonAltitudeStyle.unknownColor);
+    expect(
+      segments.single.widthFactor,
+      BalloonAltitudeStyle.unknownWidthFactor,
+    );
+  });
+
+  test('legend labels preserve the metric thresholds when shown in feet', () {
+    expect(BalloonAltitudeStyle.labels(AltitudeUnit.metres), [
+      '<150 m',
+      '150–300 m',
+      '300–600 m',
+      '600–900 m',
+      '900+ m',
+    ]);
+    expect(BalloonAltitudeStyle.labels(AltitudeUnit.feet), [
+      '<492 ft',
+      '492–984 ft',
+      '984–1969 ft',
+      '1969–2953 ft',
+      '2953+ ft',
+    ]);
   });
 }

--- a/apps/mobile/test/features/map/balloon_map_presentation_test.dart
+++ b/apps/mobile/test/features/map/balloon_map_presentation_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:balloon_crumbs/domain/altitude.dart';
+import 'package:balloon_crumbs/domain/altitude_unit.dart';
 import 'package:balloon_crumbs/domain/imported_route.dart';
 import 'package:balloon_crumbs/domain/map_orientation.dart';
 import 'package:balloon_crumbs/domain/route_store.dart';
@@ -366,6 +367,57 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets('feet preference converts telemetry and its legend together', (
+    tester,
+  ) async {
+    final directory = Directory.systemTemp.createTempSync('balloon-feet-map');
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final navigation = ValueNotifier<MapNavigationPosition?>(
+      MapNavigationPosition(
+        point: const GeoPoint(latitude: 51.43, longitude: -2.70),
+        recordedAt: DateTime.now(),
+        accuracyMeters: 4,
+        altitudeMeters: 300,
+        altitudeSource: AltitudeSource.gnss,
+        altitudeDatum: AltitudeDatum.wgs84Geoid,
+        altitudeAccuracyMeters: 6,
+        verticalSpeedMetersPerSecond: 1.5,
+      ),
+    );
+    addTearDown(navigation.dispose);
+    final cache = OfflineTileCache(
+      rootDirectory: directory,
+      configuration: const BasemapConfiguration(),
+      httpClient: MockClient((_) async => http.Response('', 404)),
+    );
+    addTearDown(cache.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: RideMapScreen(
+          routeStore: InMemoryRouteStore(_roadRoute),
+          routeImporter: RouteImporter(source: const _NoFileSource()),
+          offlineTileCache: cache,
+          navigationPosition: navigation,
+          perspective: RideMapPerspective.balloon,
+          altitudeUnit: AltitudeUnit.feet,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('984 ft'), findsOneWidget);
+    expect(find.textContaining('↑ 295 ft/min'), findsOneWidget);
+    expect(find.textContaining('±20 ft'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('balloon-map-info-button')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('shown in feet'), findsOneWidget);
+    expect(find.text('TRACK ALTITUDE · FEET'), findsOneWidget);
+    expect(find.text('2953+ ft'), findsOneWidget);
+  });
 
   testWidgets('balloon map draws an advisory forecast without road controls', (
     tester,

--- a/apps/mobile/test/services/craft_track_reducer_test.dart
+++ b/apps/mobile/test/services/craft_track_reducer_test.dart
@@ -3,6 +3,7 @@ import 'package:balloon_crumbs/domain/geo_point.dart';
 import 'package:balloon_crumbs/domain/ride_event.dart';
 import 'package:balloon_crumbs/domain/rider_location.dart';
 import 'package:balloon_crumbs/services/craft_track_reducer.dart';
+import 'package:balloon_crumbs/services/balloon_telemetry_plausibility.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -61,22 +62,52 @@ void main() {
     },
   );
 
+  RideEvent balloonFix(
+    String device,
+    Duration at, {
+    required double latitude,
+    required double longitude,
+    double? altitudeMeters,
+    AltitudeDatum altitudeDatum = AltitudeDatum.wgs84Geoid,
+    double? verticalSpeedMetersPerSecond,
+  }) => event(
+    RideEventType.riderLocationUpdated,
+    deviceId: device,
+    at: at,
+    payload: {
+      'sample': LocationSample(
+        position: GeoPoint(latitude: latitude, longitude: longitude),
+        recordedAt: start.add(at),
+        accuracyMeters: 5,
+        altitudeMeters: altitudeMeters,
+        altitudeSource: altitudeMeters == null
+            ? AltitudeSource.unknown
+            : AltitudeSource.gnss,
+        altitudeDatum: altitudeMeters == null
+            ? AltitudeDatum.unknown
+            : altitudeDatum,
+        altitudeAccuracyMeters: altitudeMeters == null ? null : 3,
+        verticalSpeedMetersPerSecond: verticalSpeedMetersPerSecond,
+      ).toJson(),
+    },
+  );
+
   test('several basket phones reduce to one balloon track', () {
     final tracks = const CraftTrackReducer().fromEvents([
       register('Balloon', CraftKind.balloon, Duration.zero),
       attach('balloon-a', 'Balloon', const Duration(seconds: 1)),
       attach('balloon-b', 'Balloon', const Duration(seconds: 2)),
-      fix('balloon-a', const Duration(seconds: 10), -2.50),
-      fix('balloon-b', const Duration(seconds: 12), -2.49),
-      fix('balloon-a', const Duration(seconds: 20), -2.48),
-      fix('balloon-b', const Duration(seconds: 22), -2.47),
+      fix('balloon-a', const Duration(seconds: 10), -2.5000),
+      fix('balloon-b', const Duration(seconds: 12), -2.4998),
+      fix('balloon-a', const Duration(seconds: 20), -2.4995),
+      fix('balloon-b', const Duration(seconds: 22), -2.4993),
     ]);
 
     expect(tracks, hasLength(1));
     expect(tracks.single.isBalloon, isTrue);
     expect(
       tracks.single.samples.map((sample) => sample.position.longitude),
-      [-2.50, -2.48],
+      [-2.5000, -2.4995],
       reason: 'the incumbent phone produces one continuous craft path',
     );
   });
@@ -102,9 +133,9 @@ void main() {
     final tracks = const CraftTrackReducer().fromEvents([
       register('Balloon', CraftKind.balloon, Duration.zero),
       attach('balloon-a', 'Balloon', const Duration(seconds: 1)),
-      fix('balloon-a', const Duration(seconds: 20), -2.4),
-      fix('balloon-a', const Duration(seconds: 10), -2.5),
-      fix('balloon-a', const Duration(seconds: 20), -2.3),
+      fix('balloon-a', const Duration(seconds: 20), -2.4995),
+      fix('balloon-a', const Duration(seconds: 10), -2.5000),
+      fix('balloon-a', const Duration(seconds: 20), -2.4990),
     ]);
 
     expect(tracks.single.samples, hasLength(2));
@@ -112,5 +143,102 @@ void main() {
       start.add(const Duration(seconds: 10)).toLocal(),
       start.add(const Duration(seconds: 20)).toLocal(),
     ]);
+  });
+
+  test('an impossible GNSS teleport is retained as rejected evidence', () {
+    final tracks = const CraftTrackReducer().fromEvents([
+      register('Balloon', CraftKind.balloon, Duration.zero),
+      attach('balloon-a', 'Balloon', const Duration(seconds: 1)),
+      balloonFix(
+        'balloon-a',
+        const Duration(seconds: 10),
+        latitude: 51.4,
+        longitude: -2.5,
+        altitudeMeters: 300,
+      ),
+      balloonFix(
+        'balloon-a',
+        const Duration(seconds: 20),
+        latitude: 52.4,
+        longitude: -2.5,
+        altitudeMeters: 305,
+      ),
+      balloonFix(
+        'balloon-a',
+        const Duration(seconds: 30),
+        latitude: 51.4005,
+        longitude: -2.5,
+        altitudeMeters: 310,
+      ),
+    ]);
+
+    expect(tracks.single.samples, hasLength(2));
+    expect(tracks.single.samples.last.position.latitude, 51.4005);
+    expect(tracks.single.rejectedSamples, hasLength(1));
+    expect(
+      tracks.single.rejectedSamples.single.reason,
+      BalloonTelemetryRejectionReason.impossibleGroundSpeed,
+    );
+  });
+
+  test(
+    'an impossible vertical jump is excluded without hiding missing altitude',
+    () {
+      final tracks = const CraftTrackReducer().fromEvents([
+        register('Balloon', CraftKind.balloon, Duration.zero),
+        attach('balloon-a', 'Balloon', const Duration(seconds: 1)),
+        balloonFix(
+          'balloon-a',
+          const Duration(seconds: 10),
+          latitude: 51.4,
+          longitude: -2.5,
+          altitudeMeters: 300,
+        ),
+        balloonFix(
+          'balloon-a',
+          const Duration(seconds: 20),
+          latitude: 51.4001,
+          longitude: -2.5,
+          altitudeMeters: 900,
+        ),
+        balloonFix(
+          'balloon-a',
+          const Duration(seconds: 30),
+          latitude: 51.4002,
+          longitude: -2.5,
+        ),
+      ]);
+
+      expect(tracks.single.samples, hasLength(2));
+      expect(tracks.single.samples.last.altitudeMeters, isNull);
+      expect(
+        tracks.single.rejectedSamples.single.reason,
+        BalloonTelemetryRejectionReason.impossibleVerticalSpeed,
+      );
+    },
+  );
+
+  test('a reconnect after a long gap starts an honest new segment', () {
+    final tracks = const CraftTrackReducer().fromEvents([
+      register('Balloon', CraftKind.balloon, Duration.zero),
+      attach('balloon-a', 'Balloon', const Duration(seconds: 1)),
+      balloonFix(
+        'balloon-a',
+        const Duration(seconds: 10),
+        latitude: 51.4,
+        longitude: -2.5,
+        altitudeMeters: 300,
+      ),
+      balloonFix(
+        'balloon-a',
+        const Duration(minutes: 4),
+        latitude: 51.5,
+        longitude: -2.4,
+        altitudeMeters: 600,
+      ),
+    ]);
+
+    expect(tracks.single.samples, hasLength(2));
+    expect(tracks.single.rejectedSamples, isEmpty);
   });
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -13,6 +13,7 @@ import 'package:balloon_crumbs/controllers/shared_route_controller.dart';
 import 'package:balloon_crumbs/controllers/speed_limit_display_controller.dart';
 import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
+import 'package:balloon_crumbs/domain/altitude_unit.dart';
 import 'package:balloon_crumbs/domain/distance_unit.dart';
 import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/map_style_mode.dart';
@@ -486,11 +487,19 @@ void main() {
     await tester.tap(find.byTooltip('Settings'));
     await tester.pumpAndSettle();
     expect(find.text('DISTANCE UNITS'), findsOneWidget);
+    expect(find.text('ALTITUDE UNITS'), findsOneWidget);
+    expect(distanceUnits.altitudeUnit, AltitudeUnit.metres);
 
     await tester.tap(find.text('Miles'));
     await tester.pumpAndSettle();
     expect(distanceUnits.value, DistanceUnit.miles);
     expect(find.byKey(const Key('use-locale-distance-unit')), findsOneWidget);
+
+    await tester.ensureVisible(find.text('Feet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Feet'));
+    await tester.pumpAndSettle();
+    expect(distanceUnits.altitudeUnit, AltitudeUnit.feet);
 
     controller.dispose();
   });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,7 +22,7 @@ not a claim that every P0 item is small. Work packages are defined in
 | 3 | P0 | Craft model, flight roles, and pilot authority | WP3 | 2 |
 | 4 | P0 | ~~Delete the motorcycle domain and replace user-facing ride/rider copy~~ **done**; compatibility identifiers remain until after 6, 7 | WP4 | 3 |
 | 4a | P0 | Replace the 15 motorcycle map markers with craft icons (#18) | WP4 | 6, 7 |
-| 5 | P0 | Altitude-coloured ground track and telemetry card | WP5 | 2, 3 |
+| 5 | P0 | ~~Altitude-coloured ground track and telemetry card~~ **done** | WP5 | 2, 3 |
 | 6 | P0 | Pilot view, drawn landing area, and inferred landing phase | WP6 | 3, 5 |
 | 7 | P0 | Multiple chase vehicles, rendezvous, and vehicle assignment | WP7 | 3, 5 |
 | 7a | P0 | Chaser-selectable road guidance to the balloon or intended landing area, with safe road rendezvous and balloon-divergence checks | WP7 | 6, 7 |

--- a/docs/launch-recovery-acceptance.md
+++ b/docs/launch-recovery-acceptance.md
@@ -44,6 +44,31 @@ criteria without putting a pre-launch action back on the pilot:
 The bounded CI set is deliberately virtual-time driven. It does not sleep for
 45 minutes and it never publishes synthetic positions to a live relay.
 
+## Balloon telemetry closure
+
+Balloon Crumbs stores telemetry internally in metres and converts only at the
+presentation boundary. Altitude defaults to metres independently of the road
+distance locale; a separate persisted setting can select feet. The telemetry
+card, wind levels, flight-plan stages, replay, map/CarPlay labels, altitude
+thresholds and legend all consume that same setting.
+
+The measured-track integrity limits are deliberately generous corruption
+guards, not operating limits: 60 m/s ground speed and 12 m/s vertical speed,
+with both fixes' reported accuracy added to the permitted displacement. A gap
+longer than two minutes starts a new segment. Missing altitude remains a valid
+position with an unknown-height segment. A rejected fix remains in the signed
+offline event journal and in the reducer's rejected-evidence list, while never
+becoming part of the canonical drawn trail.
+
+| Criterion | Policy and evidence |
+| --- | --- |
+| Fix age, source and accuracy | Local balloon telemetry states measurement age, GNSS/barometric/unknown source, datum and available vertical accuracy; shared craft details retain position accuracy, transport source and freshness. `location_sample_altitude_test.dart`, `device_location_source_test.dart`, `balloon_map_presentation_test.dart` |
+| Documented accessible scale | Fixed metric boundaries are 150/300/600/900 m; colour and progressively thicker strokes encode the same band, while unknown altitude is the thinnest grey stroke. The textual and semantic legend converts every boundary. `balloon_altitude_style_test.dart`, `route_trail_style_test.dart`, `balloon_map_presentation_test.dart` |
+| Missing or invalid altitude | A missing reading carries unknown source/datum and draws a grey segment without deleting the position or inventing a height. `location_sample_altitude_test.dart`, `balloon_altitude_style_test.dart`, `craft_track_reducer_test.dart` |
+| Impossible jumps | Horizontal and vertical teleports are excluded from the canonical balloon trail, retained as rejected evidence and surfaced in flight warnings. `balloon_telemetry_plausibility.dart`, `craft_track_reducer_test.dart` |
+| Unit consistency | Metric is the all-locale default; feet changes altitude, accuracy, vertical rate, wind levels, plan/replay values, scale thresholds and legend together. `altitude_unit_test.dart`, `distance_unit_controller_test.dart`, `balloon_map_presentation_test.dart`, `widget_test.dart` |
+| Replay/degradation matrix | The bundled flight explicitly climbs, holds level and descends; the launch-to-recovery fixture covers GPS loss and out-of-order replay; presence suites cover clock skew and reconnect; trail tests split rather than bridge reporting gaps. `fiesta_flight_simulation_test.dart`, `launch_recovery_acceptance_fixture_test.dart`, `live_presence_clock_skew_test.dart`, `live_presence_two_device_test.dart`, `rider_trail_recorder_test.dart` |
+
 ## Physical run record
 
 Create one table per run in the field-test issue or release evidence. Do not put


### PR DESCRIPTION
## Summary
- add independently persisted metric-default altitude units across live, replay, simulation, plan and CarPlay surfaces
- reject implausible horizontal and vertical jumps from canonical trails while preserving rejected evidence and reconnect segmentation
- expose balloon fix source, age and accuracy, and encode altitude by both colour and line thickness
- document closure policy and replay evidence for climb, level flight, descent, GPS loss, clock skew and reconnects

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (1,777 passed; 24 expected skips)

Closes #6