### PR TITLE
feat: close role-specific recovery viewpoints

### DIFF
--- a/apps/mobile/lib/features/map/ride_map.dart
+++ b/apps/mobile/lib/features/map/ride_map.dart
@@ -6,18 +6,21 @@ export 'ride_map_feature.dart'
         GroupMiniMapRenderer,
         MapOverlayMarker,
         MapOverlayTrace,
+        RecoveryMapViewpoint,
         RideMapPerspective,
         RideMapFeature,
         RideMapScreen,
         describeQuickMessageOrigin,
         groupMiniMapBackgroundColor,
         groupMiniMapGridColor,
+        groupMiniMapCraftMarkers,
         groupMiniMapRenderer,
         landscapeGuidancePanelWidth,
         portraitRideMenuTopOffset,
         portraitBottomChromeKey,
         rideMapPrimaryPanelFill,
         rideMapShowsForecastContext,
+        recoveryMapViewpointPoints,
         quickMessageIcon;
 export 'route_trail_style.dart'
     show RouteLineStyle, RouteTrailStyle, contrastRatio, relativeLuminance;

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -116,6 +116,50 @@ enum _ImportedTrackChoice { cancel, followOriginal, generateNavigable }
 /// aviation presentation.
 enum RideMapPerspective { chase, balloon }
 
+enum RecoveryMapViewpoint {
+  ownCraft('My craft', Icons.my_location),
+  balloon('Balloon', Icons.air_outlined),
+  wholeCrew('Whole crew', Icons.groups_outlined);
+
+  const RecoveryMapViewpoint(this.label, this.icon);
+
+  final String label;
+  final IconData icon;
+}
+
+@visibleForTesting
+List<GeoPoint> recoveryMapViewpointPoints({
+  required RecoveryMapViewpoint viewpoint,
+  required GeoPoint? currentPosition,
+  required CraftIconStyle localCraftStyle,
+  required Iterable<MapOverlayMarker> markers,
+}) {
+  final craftMarkers = markers.where((marker) => marker.craftStyle != null);
+  return switch (viewpoint) {
+    RecoveryMapViewpoint.ownCraft => [?currentPosition],
+    RecoveryMapViewpoint.balloon => [
+      if (localCraftStyle == CraftIconStyle.balloon) ?currentPosition,
+      ...craftMarkers
+          .where((marker) => marker.craftStyle == CraftIconStyle.balloon)
+          .map((marker) => marker.point),
+    ],
+    RecoveryMapViewpoint.wholeCrew => [
+      ?currentPosition,
+      ...craftMarkers.map((marker) => marker.point),
+    ],
+  };
+}
+
+@visibleForTesting
+List<MapOverlayMarker> groupMiniMapCraftMarkers(
+  Iterable<MapOverlayMarker> markers,
+) => markers
+    .where(
+      (marker) =>
+          marker.id.startsWith('craft-') || marker.id.startsWith('rider-'),
+    )
+    .toList(growable: false);
+
 @visibleForTesting
 bool rideMapShowsForecastContext({
   required RideMapPerspective perspective,
@@ -1108,6 +1152,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
   bool _routing = false;
   bool _routingToStart = false;
   bool _navigationMode = false;
+  RecoveryMapViewpoint? _recoveryMapViewpoint;
+  DateTime? _lastBalloonViewpointUpdateAt;
   bool _navigationCanvasActive = false;
   bool _autoFollowSuppressed = false;
   bool _cameraFramingRefreshScheduled = false;
@@ -2295,13 +2341,63 @@ class _RideMapScreenState extends State<RideMapScreen> {
               ),
               label: Text(widget.mapOrientation.label),
             );
-      final cameraControls = orientation == null && followMe == null
+      final selectedViewpoint =
+          _recoveryMapViewpoint ??
+          (_navigationMode ? RecoveryMapViewpoint.ownCraft : null);
+      final viewpoint = widget.groupRiderCount == null
+          ? null
+          : Material(
+              color: const Color(0xE6252E39),
+              borderRadius: BorderRadius.circular(24),
+              child: PopupMenuButton<RecoveryMapViewpoint>(
+                key: const Key('recovery-map-viewpoint'),
+                tooltip: 'Choose map viewpoint',
+                onSelected: (choice) =>
+                    unawaited(_focusRecoveryMapViewpoint(choice)),
+                itemBuilder: (context) => [
+                  for (final choice in RecoveryMapViewpoint.values)
+                    PopupMenuItem(
+                      value: choice,
+                      child: Row(
+                        children: [
+                          Icon(
+                            choice == selectedViewpoint
+                                ? Icons.check_circle
+                                : choice.icon,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 10),
+                          Text(choice.label),
+                        ],
+                      ),
+                    ),
+                ],
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 10,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.center_focus_strong, size: 20),
+                      const SizedBox(width: 8),
+                      const Text('View'),
+                      const SizedBox(width: 4),
+                      const Icon(Icons.arrow_drop_down, size: 20),
+                    ],
+                  ),
+                ),
+              ),
+            );
+      final cameraControls =
+          orientation == null && followMe == null && viewpoint == null
           ? null
           : Wrap(
               spacing: 8,
               runSpacing: 8,
               crossAxisAlignment: WrapCrossAlignment.center,
-              children: [?orientation, ?followMe],
+              children: [?viewpoint, ?orientation, ?followMe],
             );
 
       if (landscape) {
@@ -2585,9 +2681,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     required double width,
     required double height,
   }) {
-    final groupRiders = overlays
-        .where((marker) => marker.id.startsWith('rider-'))
-        .toList(growable: false);
+    final groupRiders = groupMiniMapCraftMarkers(overlays);
     final inferredGroupSize =
         groupRiders.length + (_effectivePosition == null ? 0 : 1);
     // The participant count is a snapshot supplied by the ride shell, while
@@ -3496,6 +3590,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
         if (activateNavigationCanvas) _navigationCanvasActive = true;
         if (autoFollow) {
           _navigationMode = true;
+          _recoveryMapViewpoint = RecoveryMapViewpoint.ownCraft;
           _navigationCanvasActive = true;
         }
       });
@@ -3588,6 +3683,23 @@ class _RideMapScreenState extends State<RideMapScreen> {
     if (!_basemap.usesMapLibre) setState(() {});
     _scheduleMapLibreSync(overlays: true);
     unawaited(_publishGroupPipSnapshot());
+    if (_recoveryMapViewpoint == RecoveryMapViewpoint.balloon) {
+      final now = DateTime.now();
+      final previous = _lastBalloonViewpointUpdateAt;
+      if (previous == null ||
+          now.difference(previous) >= const Duration(milliseconds: 750)) {
+        _lastBalloonViewpointUpdateAt = now;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted &&
+              _recoveryMapViewpoint == RecoveryMapViewpoint.balloon) {
+            _focusRecoveryMapViewpoint(
+              RecoveryMapViewpoint.balloon,
+              reportMissingFix: false,
+            );
+          }
+        });
+      }
+    }
   }
 
   void _onWindForecastChanged() {
@@ -3681,35 +3793,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _stopFollowing(suppressAutomatic: _shouldAutoFollow);
       return;
     }
-    if (_effectivePosition == null) {
-      final acquired = await widget.acquireCurrentPosition?.call();
-      if (!mounted) return;
-      if (acquired == null && _effectivePosition == null) {
-        _showMessage(
-          'Could not get your position. Check Location Services and '
-          'Balloon Crumbs location access.',
-        );
-        return;
-      }
-    }
-    setState(() {
-      _navigationMode = true;
-      _navigationCanvasActive = true;
-      _autoFollowSuppressed = false;
-      // Taking the camera is not arriving at the viewport. The control stays on
-      // screen until the map reports it got there (#141), because a rider
-      // watching the map ease across has not been given the viewport yet.
-      _releaseNavigationViewport();
-    });
-    // Going to the navigation viewport is a change of framing, not a tracking
-    // update, so it is eased rather than run at the linear rate the per-fix
-    // updates use.
-    unawaited(
-      _followNavigationCamera(
-        force: true,
-        transitionDuration: const Duration(milliseconds: 700),
-      ),
-    );
+    await _focusRecoveryMapViewpoint(RecoveryMapViewpoint.ownCraft);
   }
 
   /// Hands the camera back to the rider.
@@ -3722,6 +3806,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
     if (!mounted) return;
     setState(() {
       _navigationMode = false;
+      _recoveryMapViewpoint = null;
       _autoFollowSuppressed = suppressAutomatic;
       _releaseNavigationViewport();
     });
@@ -3925,7 +4010,115 @@ class _RideMapScreenState extends State<RideMapScreen> {
     }
   }
 
+  Future<void> _focusRecoveryMapViewpoint(
+    RecoveryMapViewpoint viewpoint, {
+    bool reportMissingFix = true,
+  }) async {
+    if (viewpoint == RecoveryMapViewpoint.ownCraft) {
+      if (_effectivePosition == null) {
+        final acquired = await widget.acquireCurrentPosition?.call();
+        if (!mounted) return;
+        if (acquired == null && _effectivePosition == null) {
+          if (reportMissingFix) {
+            _showMessage(
+              'Could not get your position. Check Location Services and '
+              'Balloon Crumbs location access.',
+            );
+          }
+          return;
+        }
+      }
+      setState(() {
+        _recoveryMapViewpoint = viewpoint;
+        _navigationMode = true;
+        _navigationCanvasActive = true;
+        _autoFollowSuppressed = false;
+        _releaseNavigationViewport();
+      });
+      unawaited(
+        _followNavigationCamera(
+          force: true,
+          transitionDuration: const Duration(milliseconds: 700),
+        ),
+      );
+      return;
+    }
+
+    final points = recoveryMapViewpointPoints(
+      viewpoint: viewpoint,
+      currentPosition: _effectivePosition,
+      localCraftStyle: _localCraftStyle,
+      markers: widget.overlayMarkers?.value ?? const <MapOverlayMarker>[],
+    );
+    if (points.isEmpty) {
+      if (reportMissingFix) {
+        _showMessage(
+          viewpoint == RecoveryMapViewpoint.balloon
+              ? 'No balloon position is available yet.'
+              : 'No crew positions are available yet.',
+        );
+      }
+      return;
+    }
+    _stopFollowing(suppressAutomatic: _shouldAutoFollow);
+    if (!mounted) return;
+    setState(() => _recoveryMapViewpoint = viewpoint);
+    _frameRecoveryMapPoints(points);
+  }
+
+  void _frameRecoveryMapPoints(List<GeoPoint> points) {
+    if (points.isEmpty) return;
+    final framing = GroupMiniMapFraming.forPoints(
+      points,
+      width: math.max(160.0, _mapViewportWidthPixels - 84),
+      height: math.max(160.0, _mapViewportHeightPixels - 84),
+    );
+    if (!MapCameraCommand.isUsable(
+      latitude: framing.centre.latitude,
+      longitude: framing.centre.longitude,
+      zoom: framing.zoom,
+      bearing: _effectiveCameraBearingDegrees,
+    )) {
+      return;
+    }
+    _initialCameraPositioned = true;
+    if (_basemap.usesMapLibre) {
+      final controller = _mapLibreController;
+      if (controller == null) return;
+      unawaited(
+        controller.animateCamera(
+          ml.CameraUpdate.newCameraPosition(
+            ml.CameraPosition(
+              target: ml.LatLng(
+                framing.centre.latitude,
+                framing.centre.longitude,
+              ),
+              zoom: framing.zoom,
+              bearing: _effectiveCameraBearingDegrees,
+            ),
+          ),
+        ),
+      );
+      return;
+    }
+    try {
+      _mapController.moveAndRotateAnimatedRaw(
+        _latLng(framing.centre),
+        framing.zoom,
+        _effectiveCameraBearingDegrees,
+        offset: Offset.zero,
+        duration: const Duration(milliseconds: 700),
+        curve: Curves.easeInOutCubic,
+        hasGesture: false,
+        source: MapEventSource.mapController,
+      );
+    } on StateError {
+      // A viewpoint may be selected just before FlutterMap attaches.
+    }
+  }
+
   void _showWholeRoute() {
+    _recoveryMapViewpoint = null;
     _stopFollowing(suppressAutomatic: _shouldAutoFollow);
     _fitRoute();
   }
@@ -10659,7 +10852,14 @@ class _BasemapStatusBadge extends StatelessWidget {
               ),
               const SizedBox(width: 5),
             ],
-            Text(status.badgeLabel, style: const TextStyle(fontSize: 10)),
+            Flexible(
+              child: Text(
+                status.badgeLabel,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(fontSize: 10),
+              ),
+            ),
           ],
         ),
       ),

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -465,6 +465,31 @@ bool roleShowsLiveRecoveryProjection(FlightRole? role) =>
     role == FlightRole.chaseDriver ||
     role == FlightRole.chaseCrew;
 
+@immutable
+class RecoveryMapRoleExperience {
+  const RecoveryMapRoleExperience({
+    required this.perspective,
+    required this.showForecastContext,
+    required this.showRoadGuidance,
+  });
+
+  factory RecoveryMapRoleExperience.forRole(FlightRole? role) =>
+      RecoveryMapRoleExperience(
+        perspective: role?.isAboardBalloon == true
+            ? RideMapPerspective.balloon
+            : RideMapPerspective.chase,
+        showForecastContext:
+            role == FlightRole.pilot ||
+            role == FlightRole.balloonCrew ||
+            role == FlightRole.chaseCrew,
+        showRoadGuidance: role == FlightRole.chaseDriver,
+      );
+
+  final RideMapPerspective perspective;
+  final bool showForecastContext;
+  final bool showRoadGuidance;
+}
+
 /// What the ride map should present of the quick messages in the journal, and
 /// the most urgent one per sender so their marker can say what they raised.
 ///
@@ -4631,8 +4656,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     }
     final session = widget.rideController.session;
     final flightRole = session?.flightRole;
-    final isBalloonView = session?.flightRole.isAboardBalloon == true;
-    final isDriverView = flightRole == FlightRole.chaseDriver;
+    final roleExperience = RecoveryMapRoleExperience.forRole(flightRole);
+    final isBalloonView =
+        roleExperience.perspective == RideMapPerspective.balloon;
+    final isDriverView = roleExperience.showRoadGuidance;
     final landingZoneUpdates = _isSimulation
         ? _simulationLandingZone
         : _sharedLandingZone;
@@ -4739,13 +4766,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           widget.rideController.session?.riderSymbol ?? riderSymbolDefault,
       localDisplayName: widget.rideController.session?.displayName ?? 'You',
       localBadgeColor: _localBadgeColor,
-      perspective: isBalloonView
-          ? RideMapPerspective.balloon
-          : RideMapPerspective.chase,
-      showForecastContext:
-          flightRole == FlightRole.pilot ||
-          flightRole == FlightRole.balloonCrew ||
-          flightRole == FlightRole.chaseCrew,
+      perspective: roleExperience.perspective,
+      showForecastContext: roleExperience.showForecastContext,
       mapOrientation: _mapOrientationMode,
       onMapOrientationChanged: (mode) => unawaited(_setMapOrientation(mode)),
     );

--- a/apps/mobile/test/features/map/ride_map_feature_test.dart
+++ b/apps/mobile/test/features/map/ride_map_feature_test.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:maplibre_gl/maplibre_gl.dart' as ml;
 import 'package:balloon_crumbs/controllers/speed_limit_display_controller.dart';
+import 'package:balloon_crumbs/domain/craft.dart';
 import 'package:balloon_crumbs/domain/distance_unit.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart' as awareness_geo;
 import 'package:balloon_crumbs/domain/hazard.dart';
@@ -34,6 +35,105 @@ import 'package:balloon_crumbs/services/road_routing.dart';
 import 'package:balloon_crumbs/services/speed_limit.dart';
 
 void main() {
+  test('recovery viewpoints frame craft without treating hazards as crew', () {
+    const local = GeoPoint(latitude: 51.45, longitude: -2.59);
+    const balloon = MapOverlayMarker(
+      id: 'balloon',
+      point: GeoPoint(latitude: 51.46, longitude: -2.58),
+      label: 'Balloon',
+      craftStyle: CraftIconStyle.balloon,
+    );
+    const rover = MapOverlayMarker(
+      id: 'rover',
+      point: GeoPoint(latitude: 51.44, longitude: -2.60),
+      label: 'Recovery 1',
+      craftStyle: CraftIconStyle.fourByFour,
+    );
+    const roverWithSameName = MapOverlayMarker(
+      id: 'rover-2',
+      point: GeoPoint(latitude: 51.42, longitude: -2.62),
+      label: 'Recovery 1',
+      craftStyle: CraftIconStyle.fourByFour,
+    );
+    const hazard = MapOverlayMarker(
+      id: 'gate',
+      point: GeoPoint(latitude: 51.43, longitude: -2.61),
+      label: 'Locked gate',
+    );
+    const markers = [balloon, rover, roverWithSameName, hazard];
+
+    expect(
+      recoveryMapViewpointPoints(
+        viewpoint: RecoveryMapViewpoint.ownCraft,
+        currentPosition: local,
+        localCraftStyle: CraftIconStyle.fourByFour,
+        markers: markers,
+      ),
+      [local],
+    );
+    expect(
+      recoveryMapViewpointPoints(
+        viewpoint: RecoveryMapViewpoint.balloon,
+        currentPosition: local,
+        localCraftStyle: CraftIconStyle.fourByFour,
+        markers: markers,
+      ),
+      [balloon.point],
+    );
+    expect(
+      recoveryMapViewpointPoints(
+        viewpoint: RecoveryMapViewpoint.wholeCrew,
+        currentPosition: local,
+        localCraftStyle: CraftIconStyle.fourByFour,
+        markers: markers,
+      ),
+      [local, balloon.point, rover.point, roverWithSameName.point],
+    );
+    expect(
+      recoveryMapViewpointPoints(
+        viewpoint: RecoveryMapViewpoint.balloon,
+        currentPosition: local,
+        localCraftStyle: CraftIconStyle.balloon,
+        markers: const [],
+      ),
+      [local],
+      reason: 'the pilot phone is itself the balloon marker',
+    );
+  });
+
+  test('the mini-map accepts production craft IDs and legacy rider IDs', () {
+    const markers = [
+      MapOverlayMarker(
+        id: 'craft-balloon',
+        point: GeoPoint(latitude: 51.46, longitude: -2.58),
+        label: 'Balloon',
+        craftStyle: CraftIconStyle.balloon,
+      ),
+      MapOverlayMarker(
+        id: 'rider-legacy-rover',
+        point: GeoPoint(latitude: 51.44, longitude: -2.60),
+        label: 'Recovery 1',
+        craftStyle: CraftIconStyle.fourByFour,
+      ),
+      MapOverlayMarker(
+        id: 'confirmed-flight-landing-event-1',
+        point: GeoPoint(latitude: 51.43, longitude: -2.61),
+        label: 'LANDED',
+        craftStyle: CraftIconStyle.balloon,
+      ),
+      MapOverlayMarker(
+        id: 'hazard-gate',
+        point: GeoPoint(latitude: 51.42, longitude: -2.62),
+        label: 'Locked gate',
+      ),
+    ];
+
+    expect(groupMiniMapCraftMarkers(markers).map((marker) => marker.id), [
+      'craft-balloon',
+      'rider-legacy-rover',
+    ]);
+  });
+
   test('a chase craft trace can retain its identity colour', () {
     const identity = Color(0xFF5AC8FA);
     const trace = MapOverlayTrace(

--- a/apps/mobile/test/features/ride/role_specific_map_responsive_test.dart
+++ b/apps/mobile/test/features/ride/role_specific_map_responsive_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:balloon_crumbs/controllers/speed_limit_display_controller.dart';
+import 'package:balloon_crumbs/domain/craft.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/domain/route_store.dart';
+import 'package:balloon_crumbs/features/map/ride_map.dart';
+import 'package:balloon_crumbs/features/ride/active_ride_shell.dart';
+import 'package:balloon_crumbs/services/basemap_configuration.dart';
+import 'package:balloon_crumbs/services/gpx_import_source.dart';
+import 'package:balloon_crumbs/services/offline_tile_cache.dart';
+import 'package:balloon_crumbs/services/route_importer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  const roles = [
+    FlightRole.pilot,
+    FlightRole.balloonCrew,
+    FlightRole.chaseDriver,
+    FlightRole.chaseCrew,
+    FlightRole.observer,
+  ];
+  const profiles = [
+    (name: 'small phone', size: Size(320, 568), textScale: 1.0),
+    (name: 'landscape', size: Size(667, 375), textScale: 1.0),
+    (name: 'large text', size: Size(390, 844), textScale: 2.0),
+  ];
+
+  test('each role has the intended recovery-map capability contract', () {
+    expect(
+      RecoveryMapRoleExperience.forRole(FlightRole.pilot),
+      isA<RecoveryMapRoleExperience>()
+          .having(
+            (value) => value.perspective,
+            'perspective',
+            RideMapPerspective.balloon,
+          )
+          .having(
+            (value) => value.showForecastContext,
+            'forecast context',
+            isTrue,
+          )
+          .having((value) => value.showRoadGuidance, 'road guidance', isFalse),
+    );
+    expect(
+      RecoveryMapRoleExperience.forRole(FlightRole.balloonCrew).perspective,
+      RideMapPerspective.balloon,
+    );
+    expect(
+      RecoveryMapRoleExperience.forRole(
+        FlightRole.chaseDriver,
+      ).showRoadGuidance,
+      isTrue,
+    );
+    expect(
+      RecoveryMapRoleExperience.forRole(
+        FlightRole.chaseDriver,
+      ).showForecastContext,
+      isFalse,
+    );
+    expect(
+      RecoveryMapRoleExperience.forRole(
+        FlightRole.chaseCrew,
+      ).showForecastContext,
+      isTrue,
+    );
+    expect(
+      RecoveryMapRoleExperience.forRole(FlightRole.observer).showRoadGuidance,
+      isFalse,
+    );
+  });
+
+  for (final profile in profiles) {
+    testWidgets('every role map fits the ${profile.name} profile', (
+      tester,
+    ) async {
+      tester.view.physicalSize = profile.size;
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final directory = Directory.systemTemp.createTempSync(
+        'balloon-role-map-',
+      );
+      final cache = OfflineTileCache(
+        rootDirectory: directory,
+        configuration: const BasemapConfiguration(),
+        httpClient: MockClient((_) async => http.Response('', 404)),
+      );
+      addTearDown(() {
+        cache.dispose();
+        directory.deleteSync(recursive: true);
+      });
+
+      for (final role in roles) {
+        final experience = RecoveryMapRoleExperience.forRole(role);
+        final speedLimitDisplay = experience.showRoadGuidance
+            ? SpeedLimitDisplayController.inMemory()
+            : null;
+        final currentPosition = ValueNotifier<GeoPoint?>(null);
+        final markers = ValueNotifier<List<MapOverlayMarker>>(const [
+          MapOverlayMarker(
+            id: 'rider-balloon',
+            point: GeoPoint(latitude: 51.46, longitude: -2.58),
+            label: 'Balloon · live',
+            craftStyle: CraftIconStyle.balloon,
+          ),
+          MapOverlayMarker(
+            id: 'rider-rover-1',
+            point: GeoPoint(latitude: 51.44, longitude: -2.60),
+            label: 'Recovery 1 · relayed',
+            craftStyle: CraftIconStyle.fourByFour,
+          ),
+          MapOverlayMarker(
+            id: 'rider-rover-2',
+            point: GeoPoint(latitude: 51.43, longitude: -2.61),
+            label: 'Recovery 2 · stale',
+            craftStyle: CraftIconStyle.fourByFour,
+          ),
+          MapOverlayMarker(
+            id: 'rider-rover-3',
+            point: GeoPoint(latitude: 51.42, longitude: -2.62),
+            label: 'Recovery 3 · unknown',
+            craftStyle: CraftIconStyle.fourByFour,
+          ),
+        ]);
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            home: Builder(
+              builder: (context) => MediaQuery(
+                data: MediaQuery.of(
+                  context,
+                ).copyWith(textScaler: TextScaler.linear(profile.textScale)),
+                child: RideMapScreen(
+                  routeStore: InMemoryRouteStore(),
+                  routeImporter: RouteImporter(source: const _NoFileSource()),
+                  offlineTileCache: cache,
+                  mapStyleString: '{}',
+                  currentPosition: currentPosition,
+                  overlayMarkers: markers,
+                  groupRiderCount: 5,
+                  perspective: experience.perspective,
+                  showForecastContext: experience.showForecastContext,
+                  speedLimitDisplay: speedLimitDisplay,
+                  showRouteProgress: experience.showRoadGuidance,
+                  rideStarted: false,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        final exception = tester.takeException();
+        expect(exception, isNull, reason: role.name);
+        expect(
+          find.byKey(const Key('recovery-map-viewpoint')),
+          findsOneWidget,
+          reason: role.name,
+        );
+        expect(
+          find.byKey(const Key('group-mini-map')),
+          experience.perspective == RideMapPerspective.balloon
+              ? findsNothing
+              : findsOneWidget,
+          reason: role.name,
+        );
+        if (profile.name == 'small phone' && role == FlightRole.pilot) {
+          await tester.tap(find.byKey(const Key('recovery-map-viewpoint')));
+          await tester.pumpAndSettle();
+          expect(find.text('My craft'), findsOneWidget);
+          expect(find.text('Balloon'), findsAtLeastNWidgets(1));
+          expect(find.text('Whole crew'), findsOneWidget);
+          final balloonChoice = find.byWidgetPredicate(
+            (widget) =>
+                widget is PopupMenuItem<RecoveryMapViewpoint> &&
+                widget.value == RecoveryMapViewpoint.balloon,
+          );
+          expect(balloonChoice, findsOneWidget);
+          await tester.tap(balloonChoice);
+          await tester.pumpAndSettle(const Duration(milliseconds: 50));
+          expect(tester.takeException(), isNull);
+        }
+
+        await tester.pumpAndSettle(const Duration(milliseconds: 50));
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        currentPosition.dispose();
+        markers.dispose();
+        speedLimitDisplay?.dispose();
+      }
+    });
+  }
+}
+
+class _NoFileSource implements GpxImportSource {
+  const _NoFileSource();
+
+  @override
+  Future<PickedGpxFile?> pickGpxFile() async => null;
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -19,14 +19,14 @@ not a claim that every P0 item is small. Work packages are defined in
 |---:|:---:|---|:---:|---|
 | 1 | P0 | ~~Isolate inherited TEC baseline and keep CI green~~ **done** | WP1 | — |
 | 2 | P0 | ~~Balloon-capable telemetry: altitude, source, datum, accuracy, vertical speed~~ **done** | WP2 | 1 |
-| 3 | P0 | Craft model, flight roles, and pilot authority | WP3 | 2 |
+| 3 | P0 | ~~Craft model, flight roles, and pilot authority~~ **done** | WP3 | 2 |
 | 4 | P0 | ~~Delete the motorcycle domain and replace user-facing ride/rider copy~~ **done**; compatibility identifiers remain until after 6, 7 | WP4 | 3 |
-| 4a | P0 | Replace the 15 motorcycle map markers with craft icons (#18) | WP4 | 6, 7 |
+| 4a | P0 | ~~Replace the 15 motorcycle map markers with craft icons (#18)~~ **done** | WP4 | 6, 7 |
 | 5 | P0 | ~~Altitude-coloured ground track and telemetry card~~ **done** | WP5 | 2, 3 |
 | 6 | P0 | Pilot view, drawn landing area, and inferred landing phase | WP6 | 3, 5 |
-| 7 | P0 | Multiple chase vehicles, rendezvous, and vehicle assignment | WP7 | 3, 5 |
+| 7 | P0 | ~~Multiple chase vehicles and vehicle assignment~~ **done**; rendezvous remains in 7a | WP7 | 3, 5 |
 | 7a | P0 | Chaser-selectable road guidance to the balloon or intended landing area, with safe road rendezvous and balloon-divergence checks | WP7 | 6, 7 |
-| 7b | P0 | Mini-map as the chase decision surface (balloon, track, area, vehicles) | WP7 | 7a |
+| 7b | P0 | ~~Mini-map and local viewpoint switching as the chase decision surface (balloon, track, area, vehicles)~~ **done** | WP7 | 7a |
 | 8 | P0 | Voice-first chase guidance for a moving target | WP8 | 7 |
 | 9 | P0 | Ground notes and the retrieve | WP9 | 3 |
 | 10 | P0 | Landing-phase basemap (OS topographic / aerial) | WP6b | 6 |

--- a/docs/launch-recovery-acceptance.md
+++ b/docs/launch-recovery-acceptance.md
@@ -33,7 +33,7 @@ criteria without putting a pre-launch action back on the pilot:
 | Criterion | Evidence |
 | --- | --- |
 | Five devices gather before launch without duplicate membership | `test_pre_start_presence.py::test_five_devices_survive_a_45_minute_pre_launch_without_ghosts` |
-| Multiple independent chasers and role-specific viewpoints | `launch_recovery_acceptance_fixture_test.dart`, `ride_controller_craft_test.dart`, `flight_role_experience_test.dart` |
+| Multiple independent chasers and role-specific viewpoints | `launch_recovery_acceptance_fixture_test.dart`, `ride_controller_craft_test.dart`, `craft_roster_test.dart`, `role_specific_map_responsive_test.dart` |
 | Restart preserves operation, role, device and craft identity | `shared_preferences_session_store_test.dart`, `live_presence_two_device_test.dart::a rider who restarts the app rejoins without re-opting in`, `ride_controller_craft_test.dart::the roster survives a journal replay` |
 | Only the current pilot can end the flight or transfer pilot authority | `ride_controller_test.dart::pilot handover is offered, accepted and applied on both devices`, `pilot_handover_test.dart` and the authority tests in `ride_controller_test.dart` |
 | Release can be marked by the pilot or chase roles, never an observer or forged balloon role | `ride_controller_test.dart::chase crew can start live tracking at balloon release` and `balloon device cannot forge a chase role to start tracking` |
@@ -43,6 +43,23 @@ criteria without putting a pre-launch action back on the pilot:
 
 The bounded CI set is deliberately virtual-time driven. It does not sleep for
 45 minutes and it never publishes synthetic positions to a live relay.
+
+## Role-specific viewpoint closure
+
+Issue #7 keeps the shared operation model independent from the camera a crew
+member chooses. The View control changes only local map framing between this
+craft, the balloon and the whole crew; it cannot publish a role, authority or
+guidance-target event. Balloon focus follows fresh craft updates, while the
+whole-crew view reuses the bounded Mercator framing used by the live mini-map.
+
+| Criterion | Evidence |
+| --- | --- |
+| At least three independently moving chase vehicles stay identifiable | `craft_roster_test.dart::four vehicles stay individually identifiable and addressable`; `ride_map_feature_test.dart::recovery viewpoints frame craft without treating hazards as crew` also keeps equal display labels separate by craft ID |
+| Balloon, current-craft and whole-crew views switch locally | `role_specific_map_responsive_test.dart` opens the View control and selects Balloon; `recoveryMapViewpointPoints` accepts no ride controller or shared-state writer |
+| Mini-map includes relevant craft with bounded framing | `group_mini_map_framing_test.dart` covers local groups, missing fixes and the 300 km outlier; `role_specific_map_responsive_test.dart` verifies every ground role retains the live overview |
+| Pilot/airborne crew suppress road UI while driver prioritises it | `RecoveryMapRoleExperience` is exercised for all five roles in `role_specific_map_responsive_test.dart`; `balloon_map_presentation_test.dart` and `active_ride_navigation_escape_test.dart` cover map controls and moving pilot chrome |
+| Live, relayed, stale and unknown never collapse into live | `live_presence_test.dart`, `craft_roster_test.dart`, `ride_membership_live_presence_test.dart`; freshness and source remain in each inspectable marker label |
+| Small phone, landscape and large text | `role_specific_map_responsive_test.dart` renders pilot, airborne crew, chase driver, chase crew and observer at 320×568, 667×375 and 390×844 with 200% text; it also caught and closes the basemap badge overflow |
 
 ## Balloon telemetry closure
 


### PR DESCRIPTION
## Summary
- give pilot, balloon crew, chase driver, chase crew, and observer explicit recovery-map capability contracts
- add local-only My craft, Balloon, and Whole crew camera viewpoints with bounded crew framing
- include production craft overlays in the live mini-map while excluding hazards and landing annotations
- make the map status badge safe at 200% text and document closure evidence

## Verification
- `flutter analyze`
- full Flutter suite: 1,782 passed, 24 expected skips
- final focused regression set after the production marker fix: 100 passed

Closes #7