### PR TITLE
feat: close safe moving rendezvous

### DIFF
--- a/apps/mobile/lib/controllers/ride_simulation_controller.dart
+++ b/apps/mobile/lib/controllers/ride_simulation_controller.dart
@@ -130,6 +130,7 @@ class RideSimulationController extends ChangeNotifier {
   Duration _simulatedElapsed = Duration.zero;
   double _timeScale = 8;
   double _baseSpeedMetersPerSecond = 13.4;
+  double? _routedRoadSpeedMetersPerSecond;
   bool _backRiderDelayed = false;
   bool _emitting = false;
   bool _disposed = false;
@@ -476,10 +477,16 @@ class RideSimulationController extends ChangeNotifier {
 
   /// Replaces only the road journey. Balloon time, altitude, position and both
   /// travelled trails continue uninterrupted.
-  void replaceChaseRoute(List<GeoPoint> route) {
+  void replaceChaseRoute(List<GeoPoint> route, {Duration? plannedDuration}) {
     if (route.length < 2) return;
     final next = _RouteSampler(route);
+    final durationSeconds = plannedDuration == null
+        ? 0.0
+        : plannedDuration.inMicroseconds / Duration.microsecondsPerSecond;
     _routeSampler = next;
+    _routedRoadSpeedMetersPerSecond = durationSeconds > 0
+        ? next.totalDistanceMeters / durationSeconds
+        : null;
     for (final agent in _agents.where((agent) => agent.role != RideRole.lead)) {
       agent.progressMeters = 0;
     }
@@ -845,7 +852,15 @@ class RideSimulationController extends ChangeNotifier {
       return 0;
     }
     if (agent.id == backRiderId && _backRiderDelayed) {
-      return _baseSpeedMetersPerSecond * 0.45;
+      return (_routedRoadSpeedMetersPerSecond ?? _baseSpeedMetersPerSecond) *
+          0.45;
+    }
+    final routedRoadSpeed = _routedRoadSpeedMetersPerSecond;
+    if (routedRoadSpeed != null) {
+      // OSRM/Valhalla journey duration already reflects the mapped road class,
+      // legal restrictions and profile speeds. Preserve that timing instead of
+      // replaying provider geometry at the demo's old fixed 30 mph speed.
+      return routedRoadSpeed * agent.speedFactor;
     }
     final elapsedSeconds =
         _simulatedElapsed.inMicroseconds / Duration.microsecondsPerSecond;

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -7,7 +7,6 @@ import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../controllers/chase_vehicle_controller.dart';
-import '../../domain/chase_vehicle.dart';
 import '../../controllers/distance_unit_controller.dart';
 import '../../controllers/foreground_location_controller.dart';
 import '../../controllers/internet_relay_controller.dart';
@@ -50,6 +49,7 @@ import '../../domain/ride_role.dart';
 import '../../domain/ride_session.dart';
 import '../../domain/rider_location.dart';
 import '../../domain/rider_color.dart';
+import '../../domain/route_preferences.dart';
 import '../../domain/route_store.dart';
 import '../../internet/internet_relay_client.dart';
 import '../../internet/internet_relay_worker.dart';
@@ -62,6 +62,7 @@ import '../../relay/relay_engine.dart';
 import '../../relay/sqlite_relay_queue.dart';
 import '../../services/carplay_bridge.dart';
 import '../../services/chase_guidance_target.dart';
+import '../../services/chase_rendezvous_planner.dart';
 import '../../services/craft_roster.dart';
 import '../../services/craft_track_reducer.dart';
 import '../../services/fiesta_flight_loader.dart';
@@ -1461,7 +1462,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   String? _carPlayMapStyleJson;
   late final http.Client _carPlayRoutingClient;
   late final http.Client _windForecastClient;
-  late final RoadRoutingService _simulationRoutingService;
+  late final RoadRoutingService _roadRoutingService;
+  late final ChaseRendezvousPlanner _chaseRendezvousPlanner;
   late final DestinationRoutePlanner _carPlayDestinationPlanner;
   ForegroundLocationController? _locationController;
   NearbyRelayController? _relayController;
@@ -1491,6 +1493,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   String? _observedLandingGuidanceRevision;
   String? _observedFlightLandingEventId;
   bool _chaseGuidanceRouting = false;
+  bool _chaseGuidanceHadUsableTarget = false;
+  String? _chaseGuidanceStatus;
+  ChaseRendezvousSelection? _activeChaseRendezvous;
+  ChaseGuidanceTarget? _lastChaseGuidanceKind;
   DateTime? _lastChaseGuidanceRouteAt;
   awareness_geo.GeoPoint? _lastChaseGuidanceTarget;
   int _chaseGuidanceRouteSequence = 0;
@@ -1626,7 +1632,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final carPlayRouting = RoutingConfiguration.fromEnvironment();
     _carPlayRoutingClient = http.Client();
     _windForecastClient = http.Client();
-    _simulationRoutingService = PreferenceAwareRoadRoutingService(
+    _roadRoutingService = PreferenceAwareRoadRoutingService(
       osrm: OsrmRoadRoutingService(
         client: _carPlayRoutingClient,
         baseUrl: carPlayRouting.routingBaseUrl,
@@ -1636,12 +1642,19 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         routeUrl: carPlayRouting.valhallaRoutingUrl,
       ),
     );
+    _chaseRendezvousPlanner = ChaseRendezvousPlanner(
+      routingService: _roadRoutingService,
+      // The bundled OSRM and Valhalla endpoints are public fair-use services.
+      // Candidate requests stay below their documented one-request-per-second
+      // limit; a configured private endpoint safely receives the same bound.
+      requestSpacing: const Duration(milliseconds: 1100),
+    );
     _carPlayDestinationPlanner = DestinationRoutePlanner(
       searchService: NominatimDestinationSearchService(
         client: _carPlayRoutingClient,
         baseUrl: carPlayRouting.geocodingBaseUrl,
       ),
-      routingService: _simulationRoutingService,
+      routingService: _roadRoutingService,
     );
     widget.rideController.addListener(_onRideControllerChanged);
     _syncSharedLandingZone();
@@ -2625,23 +2638,38 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     _lastSimulationRerouteElapsed = simulation.simulatedElapsed;
     _lastSimulationRerouteLanding = landing;
     try {
-      final result = await _simulationRoutingService.routeThrough([
-        route_domain.GeoPoint(
+      final destination = _chaseGuidanceResolver.resolve(
+        target: ChaseGuidanceTarget.landingArea,
+        now: DateTime.now(),
+        landingZone: LandingZoneTarget(
+          center: landing,
+          radiusMeters: 300,
+          label: 'Forecast landing area',
+          updatedAt: DateTime.now(),
+        ),
+      )!;
+      final rendezvous = await _chaseRendezvousPlanner.plan(
+        origin: route_domain.GeoPoint(
           latitude: chase.position.latitude,
           longitude: chase.position.longitude,
         ),
-        route_domain.GeoPoint(
-          latitude: landing.latitude,
-          longitude: landing.longitude,
+        destination: destination,
+        preferences: RoutePreferences(
+          vehicle: widget.chaseVehicle?.vehicle ?? ChaseVehicle.unspecified,
         ),
-      ], originBearingDegrees: chase.headingDegrees);
+        previousEndpoint: _routeDestination(_simulationChaseRoute),
+        originBearingDegrees: chase.headingDegrees,
+      );
       if (!mounted || _simulationController != simulation) return;
+      final result = rendezvous.routeResult;
       final route = route_domain.ImportedRoute(
         id: 'live-chase-route-${_simulationRerouteSequence++}',
         name: 'Live chase route to forecast landing area',
         description:
-            'Recalculated from the Land Rover position to a road-accessible '
-            'point serving the forecast landing area.',
+            'Recalculated from the Land Rover position to the best of '
+            '${rendezvous.candidatesAccepted} provider-routed road candidates '
+            'serving the forecast landing area. '
+            '${rendezvous.accessConfidence.limitation}',
         importedAt: DateTime.now(),
         sourceFileName: 'live-open-meteo-chase-route',
         paths: [
@@ -2650,8 +2678,17 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             points: result.points,
           ),
         ],
-        waypoints: const [],
+        waypoints: [
+          route_domain.RouteWaypoint(
+            point: rendezvous.roadEndpoint,
+            name: 'Road rendezvous',
+            description:
+                'Forecast-area endpoint; mapped access only. Verify permission and safe stopping.',
+            symbol: 'Flag, Red',
+          ),
+        ],
         maneuvers: result.maneuvers,
+        plannedDuration: result.duration,
       );
       await _simulationRouteStore?.saveActiveRoute(route);
       if (!mounted || _simulationController != simulation) return;
@@ -2665,6 +2702,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               ),
             )
             .toList(growable: false),
+        plannedDuration: result.duration,
       );
       setState(() {});
     } on Object catch (error) {
@@ -5189,6 +5227,23 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     );
   }
 
+  String? get _chaseGuidanceDisplayLabel {
+    final target = _chaseGuidanceTarget;
+    if (_chaseGuidanceRouting) return 'Calculating road rendezvous candidates…';
+    if (target == null) return null;
+    final destination = _currentChaseGuidanceDestination();
+    final evidenceLabel = destination == null
+        ? target.label
+        : '${destination.label} · candidate area ±${MeasurementFormatter(widget.distanceUnits.value).distance(destination.uncertaintyRadiusMeters)}';
+    return [evidenceLabel, ?_chaseGuidanceStatus].join(' · ');
+  }
+
+  void _setChaseGuidanceStatus(String status) {
+    if (_chaseGuidanceStatus == status) return;
+    _chaseGuidanceStatus = status;
+    if (mounted) setState(() {});
+  }
+
   Future<void> _chooseChaseGuidanceTarget() async {
     final role = widget.rideController.session?.flightRole;
     if (role == null ||
@@ -5295,6 +5350,16 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final destination = _currentChaseGuidanceDestination();
     final origin = _mapPosition.value;
     if (selected == null || destination == null || origin == null) {
+      if (destination == null) _chaseGuidanceHadUsableTarget = false;
+      _setChaseGuidanceStatus(
+        selected == null
+            ? 'choose a chase target'
+            : origin == null
+            ? 'last route held · this vehicle fix unavailable'
+            : selected == ChaseGuidanceTarget.balloon
+            ? 'last route held · fresh balloon fix unavailable'
+            : 'last route held · intended area unavailable',
+      );
       if (force && mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -5309,12 +5374,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return;
     }
     final now = DateTime.now();
+    final recoveredUsableTarget = !_chaseGuidanceHadUsableTarget;
+    _chaseGuidanceHadUsableTarget = true;
     if (!_chaseGuidanceReroutePolicy.shouldReroute(
       now: now,
       target: destination.point,
       lastRoutedAt: _lastChaseGuidanceRouteAt,
       lastTarget: _lastChaseGuidanceTarget,
-      force: force,
+      force: force || recoveredUsableTarget,
     )) {
       return;
     }
@@ -5322,36 +5389,32 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     _chaseGuidanceRouting = true;
     if (mounted) setState(() {});
     try {
-      final result = await _simulationRoutingService.routeThrough([
-        origin,
-        route_domain.GeoPoint(
-          latitude: destination.point.latitude,
-          longitude: destination.point.longitude,
+      final rendezvous = await _chaseRendezvousPlanner.plan(
+        origin: origin,
+        destination: destination,
+        preferences: RoutePreferences(
+          vehicle: widget.chaseVehicle?.vehicle ?? ChaseVehicle.unspecified,
         ),
-      ], originBearingDegrees: _mapNavigationPosition.value?.headingDegrees);
+        previousEndpoint: _lastChaseGuidanceKind == destination.kind
+            ? _activeChaseRendezvous?.roadEndpoint
+            : null,
+        originBearingDegrees: _mapNavigationPosition.value?.headingDegrees,
+      );
       if (!mounted) return;
-      final roadEndpoint = awareness_geo.GeoPoint(
-        latitude: result.points.last.latitude,
-        longitude: result.points.last.longitude,
-      );
-      if (!destination.acceptsRoadEndpoint(roadEndpoint)) {
-        _warnings.add(
-          'No sufficiently close road rendezvous was found for ${selected.label.toLowerCase()}. The previous route is still in use.',
-        );
-        setState(() {});
-        return;
-      }
-      final separation = GeoCalculations.distanceMeters(
-        roadEndpoint,
-        destination.point,
-      );
+      final result = rendezvous.routeResult;
+      final separation = rendezvous.targetSeparationMeters;
       final route = route_domain.ImportedRoute(
         id: 'personal-chase-${_chaseGuidanceRouteSequence++}',
         name: selected.label,
         description:
-            'Road guidance for this chase vehicle. The road endpoint is '
+            'Provider-routed guidance for this chase vehicle. The selected '
+            'road endpoint is '
             '${MeasurementFormatter(widget.distanceUnits.value).distance(separation)} '
-            'from ${selected == ChaseGuidanceTarget.balloon ? 'the latest balloon fix' : 'the centre of the intended area'}. Access and stopping suitability remain unverified.',
+            'from ${selected == ChaseGuidanceTarget.balloon ? 'the bounded balloon motion estimate' : 'the centre of the intended area'}. '
+            '${destination.limitations} '
+            '${rendezvous.accessConfidence.limitation} '
+            '${rendezvous.candidatesAccepted} of ${rendezvous.candidatesAttempted} candidates were usable; '
+            '${rendezvous.retainedPreviousEndpoint ? 'the previous endpoint was retained by the 90-second stability threshold' : 'the lowest fresh provider travel-time score was selected'}.',
         importedAt: now,
         sourceFileName: 'balloon-crumbs-personal-chase-route',
         paths: [
@@ -5368,10 +5431,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             symbol: 'Flag, Blue',
           ),
           route_domain.RouteWaypoint(
-            point: result.points.last,
-            name: selected.label,
+            point: rendezvous.roadEndpoint,
+            name: 'Road rendezvous',
             description:
-                'Road-accessible routing endpoint; target remains approximate.',
+                '${selected.label}; mapped access only. Check local signs, permission and safe stopping.',
             symbol: 'Flag, Red',
           ),
         ],
@@ -5379,13 +5442,19 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         plannedDuration: result.duration,
       );
       _liveRoutes = _liveRoutes.withVehicleRoadRoute(route);
+      _activeChaseRendezvous = rendezvous;
+      _lastChaseGuidanceKind = destination.kind;
       _lastChaseGuidanceRouteAt = now;
       _lastChaseGuidanceTarget = destination.point;
+      _chaseGuidanceStatus = rendezvous.retainedPreviousEndpoint
+          ? 'stable road endpoint retained · mapped access only'
+          : 'road endpoint updated · mapped access only';
       await _rideRouteStore?.saveActiveRoute(route);
       await _replaceAwarenessController(route);
       if (mounted) setState(() {});
     } on Object catch (error) {
       if (mounted) {
+        _chaseGuidanceStatus = 'last route held · no validated road candidate';
         _warnings.add(
           'Personal chase guidance is unavailable; the previous road route is still in use. $error',
         );
@@ -6258,11 +6327,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           navigation: _mapNavigationPosition.value,
           now: DateTime.now(),
         ),
-    chaseGuidanceLabel: _chaseGuidanceRouting
-        ? 'Calculating a road rendezvous…'
-        : _chaseGuidanceTarget == null
+    chaseGuidanceLabel: _chaseGuidanceDisplayLabel == null
         ? null
-        : '${_chaseGuidanceTarget!.label} · shared in this vehicle',
+        : '${_chaseGuidanceDisplayLabel!} · shared in this vehicle',
     onChooseChaseGuidance: () => unawaited(_chooseChaseGuidanceTarget()),
     maneuverCount: const NavigationGuidancePlanner()
         .instructions(_activeRoute)
@@ -7136,14 +7203,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       navigationPosition: _mapNavigationPosition,
       windForecast: _windForecastController,
       liveFlightProjection: _liveFlightProjection,
-      chaseGuidanceLabel: _chaseGuidanceRouting
-          ? 'Calculating a road rendezvous…'
-          : role == FlightRole.chaseDriver && !canChangeChaseTarget
-          ? [
-              if (_chaseGuidanceTarget != null) _chaseGuidanceTarget!.label,
-              'stop to change target',
-            ].join(' · ')
-          : _chaseGuidanceTarget?.label,
+      chaseGuidanceLabel:
+          role == FlightRole.chaseDriver && !canChangeChaseTarget
+          ? [?_chaseGuidanceDisplayLabel, 'stop to change target'].join(' · ')
+          : _chaseGuidanceDisplayLabel,
       onUpdateFlightPlan: _requestRouteChange,
       onUpdateLandingArea: () => unawaited(_chooseLandingZoneOnMap()),
       onChooseChaseGuidance: canChangeChaseTarget

--- a/apps/mobile/lib/services/chase_guidance_target.dart
+++ b/apps/mobile/lib/services/chase_guidance_target.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import '../domain/craft.dart';
 import '../domain/flight_landing.dart';
 import '../domain/geo_point.dart';
@@ -127,16 +129,27 @@ class ChaseGuidanceDestination {
   const ChaseGuidanceDestination({
     required this.kind,
     required this.point,
+    required this.evidencePoint,
     required this.label,
     required this.maximumRoadSeparationMeters,
+    required this.uncertaintyRadiusMeters,
     required this.observedAt,
+    required this.limitations,
+    this.preferredBearingDegrees,
   });
 
   final ChaseGuidanceTarget kind;
+
+  /// Bounded motion estimate or intended-area centre used to place candidate
+  /// road endpoints. This point is never sent directly as a driving endpoint.
   final GeoPoint point;
+  final GeoPoint evidencePoint;
   final String label;
   final double maximumRoadSeparationMeters;
+  final double uncertaintyRadiusMeters;
   final DateTime observedAt;
+  final String limitations;
+  final double? preferredBearingDegrees;
 
   bool acceptsRoadEndpoint(GeoPoint endpoint) =>
       GeoCalculations.distanceMeters(endpoint, point) <=
@@ -149,11 +162,13 @@ class ChaseGuidanceTargetResolver {
     this.maximumBalloonFixAge = const Duration(seconds: 45),
     this.maximumBalloonRoadSeparationMeters = 1200,
     this.landingAreaRoadMarginMeters = 500,
+    this.balloonMotionLookahead = const Duration(seconds: 60),
   });
 
   final Duration maximumBalloonFixAge;
   final double maximumBalloonRoadSeparationMeters;
   final double landingAreaRoadMarginMeters;
+  final Duration balloonMotionLookahead;
 
   ChaseGuidanceDestination? resolve({
     required ChaseGuidanceTarget target,
@@ -171,10 +186,14 @@ class ChaseGuidanceTargetResolver {
     return ChaseGuidanceDestination(
       kind: ChaseGuidanceTarget.landingArea,
       point: target.center,
+      evidencePoint: target.center,
       label: target.label,
       maximumRoadSeparationMeters:
           target.radiusMeters + landingAreaRoadMarginMeters,
+      uncertaintyRadiusMeters: target.radiusMeters,
       observedAt: target.updatedAt,
+      limitations:
+          'Pilot intent only; landing suitability, field permission, road access and safe stopping are unverified.',
     );
   }
 
@@ -187,21 +206,87 @@ class ChaseGuidanceTargetResolver {
       return ChaseGuidanceDestination(
         kind: ChaseGuidanceTarget.balloon,
         point: landedFix.position,
+        evidencePoint: landedFix.position,
         label:
             '${landing!.locationConfidence?.label ?? 'Best-known landing'} · LANDED',
         maximumRoadSeparationMeters: landing.hasConfirmedLocation
             ? 800
             : maximumBalloonRoadSeparationMeters,
+        uncertaintyRadiusMeters: math.max(
+          landedFix.accuracyMeters,
+          landing.hasConfirmedLocation ? 100 : 300,
+        ),
         observedAt: landing.declaredAt,
+        limitations:
+            'Landing evidence is preserved, but road access, field permission and safe stopping remain unverified.',
       );
     }
     if (fix == null || fix.ageAt(now) > maximumBalloonFixAge) return null;
+    final speed = fix.speedMetersPerSecond;
+    final heading = fix.headingDegrees;
+    final hasMotion =
+        speed != null &&
+        speed.isFinite &&
+        speed >= 0.5 &&
+        heading != null &&
+        heading.isFinite;
+    final projectedDistance = hasMotion
+        ? math.min(
+            speed * balloonMotionLookahead.inMilliseconds / 1000,
+            maximumBalloonRoadSeparationMeters * 0.75,
+          )
+        : 0.0;
+    final projected = hasMotion
+        ? _offset(
+            fix.position,
+            bearingDegrees: heading,
+            distanceMeters: projectedDistance,
+          )
+        : fix.position;
+    final fixAge = fix.ageAt(now);
     return ChaseGuidanceDestination(
       kind: ChaseGuidanceTarget.balloon,
-      point: fix.position,
-      label: 'Balloon · fix ${fix.ageAt(now).inSeconds}s ago',
+      point: projected,
+      evidencePoint: fix.position,
+      label: hasMotion
+          ? 'Balloon motion estimate · fix ${fixAge.inSeconds}s ago'
+          : 'Balloon vicinity · fix ${fixAge.inSeconds}s ago',
       maximumRoadSeparationMeters: maximumBalloonRoadSeparationMeters,
+      uncertaintyRadiusMeters: math.max(
+        150,
+        fix.accuracyMeters + (speed ?? 0) * (fixAge.inSeconds + 20),
+      ),
       observedAt: fix.recordedAt,
+      preferredBearingDegrees: hasMotion ? heading : null,
+      limitations: hasMotion
+          ? '${balloonMotionLookahead.inSeconds}s constant-motion estimate from a measured fix; wind, altitude changes, private access and safe stopping remain unverified.'
+          : 'No usable direction and speed; candidates surround the measured fix. Private access and safe stopping remain unverified.',
+    );
+  }
+
+  static GeoPoint _offset(
+    GeoPoint point, {
+    required double bearingDegrees,
+    required double distanceMeters,
+  }) {
+    final angularDistance = distanceMeters / GeoCalculations.earthRadiusMeters;
+    final bearing = bearingDegrees * math.pi / 180;
+    final latitude = point.latitude * math.pi / 180;
+    final longitude = point.longitude * math.pi / 180;
+    final destinationLatitude = math.asin(
+      math.sin(latitude) * math.cos(angularDistance) +
+          math.cos(latitude) * math.sin(angularDistance) * math.cos(bearing),
+    );
+    final destinationLongitude =
+        longitude +
+        math.atan2(
+          math.sin(bearing) * math.sin(angularDistance) * math.cos(latitude),
+          math.cos(angularDistance) -
+              math.sin(latitude) * math.sin(destinationLatitude),
+        );
+    return GeoPoint(
+      latitude: destinationLatitude * 180 / math.pi,
+      longitude: ((destinationLongitude * 180 / math.pi + 540) % 360) - 180,
     );
   }
 }
@@ -211,10 +296,12 @@ class ChaseGuidanceReroutePolicy {
   const ChaseGuidanceReroutePolicy({
     this.minimumInterval = const Duration(minutes: 2),
     this.minimumTargetMovementMeters = 300,
+    this.maximumRouteAge = const Duration(minutes: 10),
   });
 
   final Duration minimumInterval;
   final double minimumTargetMovementMeters;
+  final Duration maximumRouteAge;
 
   bool shouldReroute({
     required DateTime now,
@@ -224,7 +311,9 @@ class ChaseGuidanceReroutePolicy {
     bool force = false,
   }) {
     if (force || lastRoutedAt == null || lastTarget == null) return true;
-    if (now.difference(lastRoutedAt) < minimumInterval) return false;
+    final age = now.difference(lastRoutedAt);
+    if (age < minimumInterval) return false;
+    if (age >= maximumRouteAge) return true;
     return GeoCalculations.distanceMeters(lastTarget, target) >=
         minimumTargetMovementMeters;
   }

--- a/apps/mobile/lib/services/chase_rendezvous_planner.dart
+++ b/apps/mobile/lib/services/chase_rendezvous_planner.dart
@@ -1,0 +1,295 @@
+import 'dart:math' as math;
+
+import '../domain/geo_point.dart' as awareness;
+import '../domain/imported_route.dart' as route;
+import '../domain/route_preferences.dart';
+import 'chase_guidance_target.dart';
+import 'geo_calculations.dart';
+import 'road_routing.dart';
+
+enum RendezvousAccessConfidence {
+  mappedRoadProfile(
+    'The routing provider applied its mapped vehicle and access restrictions. '
+    'Private access, field entry and safe stopping remain unverified.',
+  );
+
+  const RendezvousAccessConfidence(this.limitation);
+
+  final String limitation;
+}
+
+class ChaseRendezvousSelection {
+  const ChaseRendezvousSelection({
+    required this.routeResult,
+    required this.requestedCandidate,
+    required this.roadEndpoint,
+    required this.targetSeparationMeters,
+    required this.scoreSeconds,
+    required this.accessConfidence,
+    required this.retainedPreviousEndpoint,
+    required this.candidatesAttempted,
+    required this.candidatesAccepted,
+  });
+
+  final RoadRouteResult routeResult;
+  final route.GeoPoint requestedCandidate;
+  final route.GeoPoint roadEndpoint;
+  final double targetSeparationMeters;
+  final double scoreSeconds;
+  final RendezvousAccessConfidence accessConfidence;
+  final bool retainedPreviousEndpoint;
+  final int candidatesAttempted;
+  final int candidatesAccepted;
+}
+
+class ChaseRendezvousPlanningException implements Exception {
+  const ChaseRendezvousPlanningException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Chooses a stable provider-routed endpoint around flight evidence.
+///
+/// The evidence coordinate is deliberately never submitted as the driving
+/// destination. Four bounded points around its uncertainty area are routed in
+/// a deterministic order. The provider's returned endpoint must remain close
+/// enough to the evidence, and the previous endpoint is retained unless a new
+/// candidate improves the fresh travel-time score materially.
+class ChaseRendezvousPlanner {
+  ChaseRendezvousPlanner({
+    required this.routingService,
+    this.requestSpacing = Duration.zero,
+    this.minimumScoreImprovement = const Duration(seconds: 90),
+    this.minimumCandidateRadiusMeters = 250,
+    this.maximumCandidateRadiusMeters = 750,
+    Future<void> Function(Duration)? delay,
+  }) : _delay = delay ?? Future<void>.delayed;
+
+  final RoadRoutingService routingService;
+  final Duration requestSpacing;
+  final Duration minimumScoreImprovement;
+  final double minimumCandidateRadiusMeters;
+  final double maximumCandidateRadiusMeters;
+  final Future<void> Function(Duration) _delay;
+
+  Future<ChaseRendezvousSelection> plan({
+    required route.GeoPoint origin,
+    required ChaseGuidanceDestination destination,
+    RoutePreferences preferences = RoutePreferences.defaults,
+    route.GeoPoint? previousEndpoint,
+    double? originBearingDegrees,
+  }) async {
+    final requests = _candidateRequests(
+      destination: destination,
+      previousEndpoint: previousEndpoint,
+    );
+    final accepted = <_ScoredCandidate>[];
+    var attempted = 0;
+    for (final request in requests) {
+      if (attempted > 0 && requestSpacing > Duration.zero) {
+        await _delay(requestSpacing);
+      }
+      attempted += 1;
+      try {
+        final result = await routingService.routeThrough(
+          [origin, request.point],
+          preferences: preferences,
+          originBearingDegrees: originBearingDegrees,
+        );
+        if (result.points.length < 2) continue;
+        final endpoint = result.points.last;
+        final separation = GeoCalculations.distanceMeters(
+          awareness.GeoPoint(
+            latitude: endpoint.latitude,
+            longitude: endpoint.longitude,
+          ),
+          destination.point,
+        );
+        if (!separation.isFinite ||
+            separation > destination.maximumRoadSeparationMeters) {
+          continue;
+        }
+        accepted.add(
+          _ScoredCandidate(
+            request: request,
+            result: result,
+            endpoint: endpoint,
+            separationMeters: separation,
+            // Prefer real provider travel time. The small endpoint-separation
+            // term breaks otherwise-equal routes toward the flight evidence.
+            scoreSeconds:
+                result.duration.inMilliseconds / 1000 + separation / 10,
+          ),
+        );
+      } on Object {
+        // One unreachable or provider-rejected point does not make the other
+        // bounded road candidates unsafe to try.
+      }
+    }
+    if (accepted.isEmpty) {
+      throw const ChaseRendezvousPlanningException(
+        'No provider-routed endpoint stayed within the allowed rendezvous area.',
+      );
+    }
+
+    accepted.sort((left, right) {
+      final byScore = left.scoreSeconds.compareTo(right.scoreSeconds);
+      if (byScore != 0) return byScore;
+      return left.request.order.compareTo(right.request.order);
+    });
+    var selected = accepted.first;
+    final previous = accepted
+        .where((candidate) => candidate.request.isPreviousEndpoint)
+        .firstOrNull;
+    if (previous != null &&
+        !selected.request.isPreviousEndpoint &&
+        previous.scoreSeconds - selected.scoreSeconds <
+            minimumScoreImprovement.inMilliseconds / 1000) {
+      selected = previous;
+    }
+    return ChaseRendezvousSelection(
+      routeResult: selected.result,
+      requestedCandidate: selected.request.point,
+      roadEndpoint: selected.endpoint,
+      targetSeparationMeters: selected.separationMeters,
+      scoreSeconds: selected.scoreSeconds,
+      accessConfidence: RendezvousAccessConfidence.mappedRoadProfile,
+      retainedPreviousEndpoint: selected.request.isPreviousEndpoint,
+      candidatesAttempted: attempted,
+      candidatesAccepted: accepted.length,
+    );
+  }
+
+  List<_CandidateRequest> _candidateRequests({
+    required ChaseGuidanceDestination destination,
+    required route.GeoPoint? previousEndpoint,
+  }) {
+    final requests = <_CandidateRequest>[];
+    if (previousEndpoint != null) {
+      final previousAwareness = awareness.GeoPoint(
+        latitude: previousEndpoint.latitude,
+        longitude: previousEndpoint.longitude,
+      );
+      if (GeoCalculations.distanceMeters(
+            previousAwareness,
+            destination.point,
+          ) <=
+          destination.maximumRoadSeparationMeters) {
+        requests.add(
+          _CandidateRequest(
+            point: previousEndpoint,
+            order: 0,
+            isPreviousEndpoint: true,
+          ),
+        );
+      }
+    }
+
+    final maximumRadius = math.min(
+      maximumCandidateRadiusMeters,
+      destination.maximumRoadSeparationMeters * 0.65,
+    );
+    final radius = math
+        .max(
+          minimumCandidateRadiusMeters,
+          math.min(
+            maximumRadius,
+            math.max(
+              destination.uncertaintyRadiusMeters,
+              minimumCandidateRadiusMeters,
+            ),
+          ),
+        )
+        .toDouble();
+    final firstBearing = destination.preferredBearingDegrees ?? 0;
+    for (final (index, offset) in const [0.0, 90.0, 180.0, 270.0].indexed) {
+      final point = _offset(
+        destination.point,
+        bearingDegrees: firstBearing + offset,
+        distanceMeters: radius,
+      );
+      final candidate = route.GeoPoint(
+        latitude: point.latitude,
+        longitude: point.longitude,
+      );
+      if (requests.any(
+        (existing) => _routeDistanceMeters(existing.point, candidate) < 30,
+      )) {
+        continue;
+      }
+      requests.add(
+        _CandidateRequest(
+          point: candidate,
+          order: index + 1,
+          isPreviousEndpoint: false,
+        ),
+      );
+    }
+    return List.unmodifiable(requests);
+  }
+
+  static awareness.GeoPoint _offset(
+    awareness.GeoPoint point, {
+    required double bearingDegrees,
+    required double distanceMeters,
+  }) {
+    final angularDistance = distanceMeters / GeoCalculations.earthRadiusMeters;
+    final bearing = bearingDegrees * math.pi / 180;
+    final latitude = point.latitude * math.pi / 180;
+    final longitude = point.longitude * math.pi / 180;
+    final destinationLatitude = math.asin(
+      math.sin(latitude) * math.cos(angularDistance) +
+          math.cos(latitude) * math.sin(angularDistance) * math.cos(bearing),
+    );
+    final destinationLongitude =
+        longitude +
+        math.atan2(
+          math.sin(bearing) * math.sin(angularDistance) * math.cos(latitude),
+          math.cos(angularDistance) -
+              math.sin(latitude) * math.sin(destinationLatitude),
+        );
+    return awareness.GeoPoint(
+      latitude: destinationLatitude * 180 / math.pi,
+      longitude: ((destinationLongitude * 180 / math.pi + 540) % 360) - 180,
+    );
+  }
+
+  static double _routeDistanceMeters(
+    route.GeoPoint first,
+    route.GeoPoint second,
+  ) => GeoCalculations.distanceMeters(
+    awareness.GeoPoint(latitude: first.latitude, longitude: first.longitude),
+    awareness.GeoPoint(latitude: second.latitude, longitude: second.longitude),
+  );
+}
+
+class _CandidateRequest {
+  const _CandidateRequest({
+    required this.point,
+    required this.order,
+    required this.isPreviousEndpoint,
+  });
+
+  final route.GeoPoint point;
+  final int order;
+  final bool isPreviousEndpoint;
+}
+
+class _ScoredCandidate {
+  const _ScoredCandidate({
+    required this.request,
+    required this.result,
+    required this.endpoint,
+    required this.separationMeters,
+    required this.scoreSeconds,
+  });
+
+  final _CandidateRequest request;
+  final RoadRouteResult result;
+  final route.GeoPoint endpoint;
+  final double separationMeters;
+  final double scoreSeconds;
+}

--- a/apps/mobile/lib/services/road_routing.dart
+++ b/apps/mobile/lib/services/road_routing.dart
@@ -1394,6 +1394,9 @@ bool _isRoundaboutManeuver(String type) => const {
 const _requestHeaders = {
   'Accept': 'application/json',
   'User-Agent': 'BalloonCrumbs/1.0 (https://github.com/osholt/balloon-crumbs)',
+  // Requested by the public Valhalla service for end-user applications. Other
+  // routing engines ignore this identifying header.
+  'X-Client-Id': 'balloon-crumbs',
 };
 
 String _basePath(Uri base) {

--- a/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
+++ b/apps/mobile/test/controllers/fiesta_flight_simulation_test.dart
@@ -294,6 +294,38 @@ void main() {
       reason: 'at least one chase vehicle should still be moving',
     );
   });
+
+  test('a replacement road route follows its provider journey time', () async {
+    final simulation = await build();
+    addTearDown(simulation.dispose);
+    const roadRoute = [
+      GeoPoint(latitude: 51.4459, longitude: -2.6413),
+      GeoPoint(latitude: 51.4459, longitude: -2.6313),
+    ];
+    final distance = GeoCalculations.distanceMeters(
+      roadRoute.first,
+      roadRoute.last,
+    );
+
+    simulation.replaceChaseRoute(
+      roadRoute,
+      plannedDuration: const Duration(minutes: 10),
+    );
+
+    final chase = simulation.riders.singleWhere(
+      (rider) => rider.role != RideRole.lead,
+    );
+    expect(chase.speedMetersPerSecond, closeTo(distance / 600, 0.001));
+
+    await simulation.advance(const Duration(minutes: 5));
+    final chaseHalfway = simulation.riders.singleWhere(
+      (rider) => rider.role != RideRole.lead,
+    );
+    expect(
+      GeoCalculations.distanceMeters(roadRoute.first, chaseHalfway.position),
+      closeTo(distance / 2, 2),
+    );
+  });
 }
 
 class _UnusedWindProvider implements WindForecastProvider {

--- a/apps/mobile/test/services/chase_guidance_target_test.dart
+++ b/apps/mobile/test/services/chase_guidance_target_test.dart
@@ -44,6 +44,53 @@ void main() {
     expect(target, isNull);
   });
 
+  test(
+    'fresh moving fixes produce a bounded estimate ahead of the balloon',
+    () {
+      final target = resolver.resolve(
+        target: ChaseGuidanceTarget.balloon,
+        now: now,
+        balloonFix: LocationSample(
+          position: const GeoPoint(latitude: 51.45, longitude: -2.61),
+          recordedAt: now.subtract(const Duration(seconds: 5)),
+          accuracyMeters: 6,
+          speedMetersPerSecond: 5,
+          headingDegrees: 0,
+        ),
+      );
+
+      expect(target, isNotNull);
+      expect(
+        target!.point.latitude,
+        greaterThan(target.evidencePoint.latitude),
+      );
+      expect(
+        target.point.longitude,
+        closeTo(target.evidencePoint.longitude, 1e-5),
+      );
+      expect(target.preferredBearingDegrees, 0);
+      expect(target.uncertaintyRadiusMeters, greaterThanOrEqualTo(150));
+      expect(target.limitations, contains('constant-motion'));
+    },
+  );
+
+  test('stationary fixes remain evidence without inventing a direction', () {
+    final target = resolver.resolve(
+      target: ChaseGuidanceTarget.balloon,
+      now: now,
+      balloonFix: LocationSample(
+        position: const GeoPoint(latitude: 51.45, longitude: -2.61),
+        recordedAt: now,
+        accuracyMeters: 6,
+        speedMetersPerSecond: 0,
+      ),
+    );
+
+    expect(target?.point, target?.evidencePoint);
+    expect(target?.preferredBearingDegrees, isNull);
+    expect(target?.limitations, contains('No usable direction'));
+  });
+
   test('balloon guidance rejects a road endpoint too far from the craft', () {
     final target = resolver.resolve(
       target: ChaseGuidanceTarget.balloon,
@@ -105,6 +152,16 @@ void main() {
         lastTarget: previous,
       ),
       isTrue,
+    );
+    expect(
+      policy.shouldReroute(
+        now: now,
+        target: previous,
+        lastRoutedAt: now.subtract(const Duration(minutes: 11)),
+        lastTarget: previous,
+      ),
+      isTrue,
+      reason: 'an old route is refreshed even when the target is stationary',
     );
   });
 

--- a/apps/mobile/test/services/chase_rendezvous_planner_test.dart
+++ b/apps/mobile/test/services/chase_rendezvous_planner_test.dart
@@ -1,0 +1,249 @@
+import 'package:balloon_crumbs/domain/geo_point.dart' as awareness;
+import 'package:balloon_crumbs/domain/imported_route.dart' as route;
+import 'package:balloon_crumbs/domain/rider_location.dart';
+import 'package:balloon_crumbs/domain/route_preferences.dart';
+import 'package:balloon_crumbs/services/chase_guidance_target.dart';
+import 'package:balloon_crumbs/services/chase_rendezvous_planner.dart';
+import 'package:balloon_crumbs/services/geo_calculations.dart';
+import 'package:balloon_crumbs/services/road_routing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 24, 9);
+  const origin = route.GeoPoint(latitude: 51.40, longitude: -2.60);
+
+  test(
+    'raw flight evidence is never submitted as a driving endpoint',
+    () async {
+      final routing = _FakeRoutingService();
+      final destination = const ChaseGuidanceTargetResolver().resolve(
+        target: ChaseGuidanceTarget.balloon,
+        now: now,
+        balloonFix: _fix(now, heading: 45, speed: 5),
+      )!;
+
+      final selection = await ChaseRendezvousPlanner(
+        routingService: routing,
+      ).plan(origin: origin, destination: destination);
+
+      expect(routing.requests, hasLength(4));
+      for (final request in routing.requests) {
+        final submitted = awareness.GeoPoint(
+          latitude: request.last.latitude,
+          longitude: request.last.longitude,
+        );
+        expect(
+          GeoCalculations.distanceMeters(submitted, destination.point),
+          greaterThanOrEqualTo(245),
+        );
+      }
+      expect(selection.candidatesAccepted, 4);
+      expect(selection.accessConfidence.limitation, contains('unverified'));
+    },
+  );
+
+  test('provider-rejected and unreachable candidates are excluded', () async {
+    final routing = _FakeRoutingService(
+      reject: (point) => point.latitude > 51.451,
+    );
+    final destination = _stationaryDestination(now);
+
+    final selection = await ChaseRendezvousPlanner(
+      routingService: routing,
+    ).plan(origin: origin, destination: destination);
+
+    expect(selection.candidatesAttempted, 4);
+    expect(selection.candidatesAccepted, lessThan(4));
+    expect(selection.roadEndpoint.latitude, lessThanOrEqualTo(51.451));
+  });
+
+  test(
+    'the previous endpoint survives small score gains but not large ones',
+    () async {
+      final destination = _stationaryDestination(now);
+      const previous = route.GeoPoint(latitude: 51.45225, longitude: -2.61);
+      final stableRouting = _FakeRoutingService(
+        durationFor: (point) => _near(point, previous)
+            ? const Duration(seconds: 100)
+            : const Duration(seconds: 30),
+      );
+
+      final retained =
+          await ChaseRendezvousPlanner(routingService: stableRouting).plan(
+            origin: origin,
+            destination: destination,
+            previousEndpoint: previous,
+          );
+
+      expect(retained.retainedPreviousEndpoint, isTrue);
+      expect(_near(retained.roadEndpoint, previous), isTrue);
+
+      final materialRouting = _FakeRoutingService(
+        durationFor: (point) => _near(point, previous)
+            ? const Duration(seconds: 240)
+            : const Duration(seconds: 20),
+      );
+      final changed =
+          await ChaseRendezvousPlanner(routingService: materialRouting).plan(
+            origin: origin,
+            destination: destination,
+            previousEndpoint: previous,
+          );
+
+      expect(changed.retainedPreviousEndpoint, isFalse);
+      expect(_near(changed.roadEndpoint, previous), isFalse);
+    },
+  );
+
+  test(
+    'all unreachable candidates fail without inventing an endpoint',
+    () async {
+      final planner = ChaseRendezvousPlanner(
+        routingService: _FakeRoutingService(reject: (_) => true),
+      );
+
+      await expectLater(
+        planner.plan(origin: origin, destination: _stationaryDestination(now)),
+        throwsA(isA<ChaseRendezvousPlanningException>()),
+      );
+    },
+  );
+
+  test(
+    'crossing, reversal and stationary replay stays deterministic',
+    () async {
+      final fixes = [
+        _fix(now, heading: 0, speed: 5),
+        _fix(now.add(const Duration(seconds: 5)), heading: 180, speed: 5),
+        _fix(now.add(const Duration(seconds: 10)), heading: null, speed: 0),
+      ];
+
+      Future<List<route.GeoPoint>> replay() async {
+        final selected = <route.GeoPoint>[];
+        for (final fix in fixes) {
+          final destination = const ChaseGuidanceTargetResolver().resolve(
+            target: ChaseGuidanceTarget.balloon,
+            now: fix.recordedAt,
+            balloonFix: fix,
+          )!;
+          final result = await ChaseRendezvousPlanner(
+            routingService: _FakeRoutingService(
+              durationFor: (point) => Duration(
+                seconds: ((point.latitude.abs() * 100000) % 240).round() + 30,
+              ),
+            ),
+          ).plan(origin: origin, destination: destination);
+          selected.add(result.roadEndpoint);
+        }
+        return selected;
+      }
+
+      final first = await replay();
+      final second = await replay();
+      expect(
+        first.map((point) => (point.latitude, point.longitude)),
+        second.map((point) => (point.latitude, point.longitude)),
+      );
+      expect(first, hasLength(3));
+      expect(
+        (first[0].latitude, first[0].longitude),
+        isNot((first[1].latitude, first[1].longitude)),
+        reason: 'reversal changes the candidates',
+      );
+    },
+  );
+
+  test(
+    'request spacing is applied between, never before, candidates',
+    () async {
+      final delays = <Duration>[];
+      final planner = ChaseRendezvousPlanner(
+        routingService: _FakeRoutingService(),
+        requestSpacing: const Duration(milliseconds: 1100),
+        delay: (duration) async => delays.add(duration),
+      );
+
+      await planner.plan(
+        origin: origin,
+        destination: _stationaryDestination(now),
+      );
+
+      expect(delays, const [
+        Duration(milliseconds: 1100),
+        Duration(milliseconds: 1100),
+        Duration(milliseconds: 1100),
+      ]);
+    },
+  );
+
+  test('every candidate uses the stated chase-vehicle constraints', () async {
+    final routing = _FakeRoutingService();
+    const preferences = RoutePreferences(
+      vehicle: ChaseVehicle(heightMetres: 2.8, towing: true),
+    );
+
+    await ChaseRendezvousPlanner(routingService: routing).plan(
+      origin: origin,
+      destination: _stationaryDestination(now),
+      preferences: preferences,
+    );
+
+    expect(routing.recordedPreferences, everyElement(preferences));
+    expect(preferences.requiresValhallaCosting, isTrue);
+  });
+}
+
+ChaseGuidanceDestination _stationaryDestination(DateTime now) =>
+    const ChaseGuidanceTargetResolver().resolve(
+      target: ChaseGuidanceTarget.balloon,
+      now: now,
+      balloonFix: _fix(now, heading: null, speed: 0),
+    )!;
+
+LocationSample _fix(
+  DateTime recordedAt, {
+  required double? heading,
+  required double speed,
+}) => LocationSample(
+  position: const awareness.GeoPoint(latitude: 51.45, longitude: -2.61),
+  recordedAt: recordedAt,
+  accuracyMeters: 8,
+  speedMetersPerSecond: speed,
+  headingDegrees: heading,
+);
+
+bool _near(route.GeoPoint first, route.GeoPoint second) =>
+    (first.latitude - second.latitude).abs() < 0.0001 &&
+    (first.longitude - second.longitude).abs() < 0.0001;
+
+class _FakeRoutingService implements RoadRoutingService {
+  _FakeRoutingService({this.reject, this.durationFor = _defaultDuration});
+
+  final bool Function(route.GeoPoint point)? reject;
+  final Duration Function(route.GeoPoint point) durationFor;
+  final List<List<route.GeoPoint>> requests = [];
+  final List<RoutePreferences?> recordedPreferences = [];
+
+  @override
+  Future<RoadRouteResult> routeThrough(
+    List<route.GeoPoint> waypoints, {
+    RoutePreferences? preferences,
+    double? originBearingDegrees,
+  }) async {
+    requests.add(List.unmodifiable(waypoints));
+    recordedPreferences.add(preferences);
+    final endpoint = waypoints.last;
+    if (reject?.call(endpoint) == true) {
+      throw const FormatException('provider rejected candidate');
+    }
+    return RoadRouteResult(
+      points: List.unmodifiable(waypoints),
+      distanceMeters: 1000,
+      duration: durationFor(endpoint),
+      preferences: preferences,
+    );
+  }
+
+  static Duration _defaultDuration(route.GeoPoint _) =>
+      const Duration(minutes: 5);
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -25,7 +25,7 @@ not a claim that every P0 item is small. Work packages are defined in
 | 5 | P0 | ~~Altitude-coloured ground track and telemetry card~~ **done** | WP5 | 2, 3 |
 | 6 | P0 | Pilot view, drawn landing area, and inferred landing phase | WP6 | 3, 5 |
 | 7 | P0 | ~~Multiple chase vehicles and vehicle assignment~~ **done**; rendezvous remains in 7a | WP7 | 3, 5 |
-| 7a | P0 | Chaser-selectable road guidance to the balloon or intended landing area, with safe road rendezvous and balloon-divergence checks | WP7 | 6, 7 |
+| 7a | P0 | ~~Chaser-selectable road guidance to the balloon or intended landing area, with bounded road-candidate selection, access uncertainty and reroute hysteresis~~ **done** | WP7 | 6, 7 |
 | 7b | P0 | ~~Mini-map and local viewpoint switching as the chase decision surface (balloon, track, area, vehicles)~~ **done** | WP7 | 7a |
 | 8 | P0 | Voice-first chase guidance for a moving target | WP8 | 7 |
 | 9 | P0 | Ground notes and the retrieve | WP9 | 3 |

--- a/docs/launch-recovery-acceptance.md
+++ b/docs/launch-recovery-acceptance.md
@@ -61,6 +61,25 @@ whole-crew view reuses the bounded Mercator framing used by the live mini-map.
 | Live, relayed, stale and unknown never collapse into live | `live_presence_test.dart`, `craft_roster_test.dart`, `ride_membership_live_presence_test.dart`; freshness and source remain in each inspectable marker label |
 | Small phone, landscape and large text | `role_specific_map_responsive_test.dart` renders pilot, airborne crew, chase driver, chase crew and observer at 320×568, 667×375 and 390×844 with 200% text; it also caught and closes the basemap badge overflow |
 
+## Safe moving-rendezvous closure
+
+The chase route ends at a provider-routed road candidate around flight
+evidence, never at the raw airborne coordinate. A fresh moving fix produces a
+bounded 60-second constant-motion estimate; a stationary fix produces a
+surrounding search without inventing direction; a fix over 45 seconds old
+cannot create a target. Four deterministic surrounding candidates are scored by
+fresh provider travel time and endpoint separation. The previous endpoint is
+also rescored and retained unless another saves at least 90 seconds.
+
+| Criterion | Evidence |
+| --- | --- |
+| Raw balloon coordinate is never a driving endpoint | `chase_rendezvous_planner_test.dart::raw flight evidence is never submitted as a driving endpoint` |
+| Mapped restrictions and unverified access stay distinct | Provider-rejected candidates are skipped in `chase_rendezvous_planner_test.dart`; route descriptions and the role dashboard say “mapped access only”; `docs/routing-provider-policy.md` records source terms and limitations |
+| Missing/stale evidence freezes rather than invents | `chase_guidance_target_test.dart::stale balloon fixes cannot become a live navigation target`; the live shell retains the prior route and labels why |
+| Movement, time, age and score hysteresis are explicit | `ChaseGuidanceReroutePolicy` uses 2 minutes, 300 m and a 10-minute maximum age; `ChaseRendezvousPlanner` uses a 90-second minimum score improvement |
+| Replay is deterministic and failures are bounded | `chase_rendezvous_planner_test.dart` covers crossings, reversals, stationary fixes, rejected candidates, all-unreachable candidates and identical replay results |
+| Provider use is within current terms | `docs/routing-provider-policy.md`; candidate calls are sequential at 1.1 seconds and identify Balloon Crumbs through `User-Agent` and `X-Client-Id` |
+
 ## Balloon telemetry closure
 
 Balloon Crumbs stores telemetry internally in metres and converts only at the

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -796,15 +796,15 @@ and a UI rebuild cannot change authority.
 
 ### P0.7 Per-vehicle chase guidance
 
-- [ ] Each chase vehicle independently selects intended-area or near-balloon
+- [x] Each chase vehicle independently selects intended-area or near-balloon
       road guidance.
-- [ ] A pilot landing-area update reaches every vehicle and triggers bounded
+- [x] A pilot landing-area update reaches every vehicle and triggers bounded
       route reconsideration for vehicles following that area.
-- [ ] Near-balloon mode refuses a stale balloon fix and never routes to a raw
+- [x] Near-balloon mode refuses a stale balloon fix and never routes to a raw
       airborne coordinate.
-- [ ] Reroutes use provider road geometry, speeds and vehicle constraints and
+- [x] Reroutes use provider road geometry, speeds and vehicle constraints and
       preserve the last valid route on failure.
-- [ ] Target selection, road endpoint, target age and reroute reason are visible.
+- [x] Target selection, road endpoint, target age and reroute reason are visible.
 
 ## P1 requirements
 

--- a/docs/routing-provider-policy.md
+++ b/docs/routing-provider-policy.md
@@ -1,0 +1,59 @@
+# Road routing provider policy
+
+Reviewed 24 August 2026 for the safe moving-rendezvous closure.
+
+## Configured providers
+
+The mobile client keeps every endpoint replaceable at build time:
+
+| Purpose | Default | Build-time setting |
+| --- | --- | --- |
+| ordinary car routing | OSRM public demo | `BALLOON_CRUMBS_ROUTING_URL` |
+| dimension/restriction-aware routing | Valhalla public demo | `BALLOON_CRUMBS_VALHALLA_ROUTING_URL` |
+| user-triggered place search | public Nominatim | `BALLOON_CRUMBS_GEOCODING_URL` |
+
+These defaults are suitable for the current small internal test group, not a
+capacity or uptime commitment for a public launch.
+
+## Terms and request bounds
+
+- The [OSRM demo service policy](https://map.project-osrm.org/about.html)
+  permits fair use with attribution, an identifying user agent, no scraping or
+  heavy use, and at most one request per second.
+- The [Valhalla public-demo documentation](https://valhalla.github.io/valhalla/start/introduction/)
+  applies the same fair-use policy and asks published clients to send an
+  identifying `X-Client-Id`. Balloon Crumbs sends both `User-Agent` and
+  `X-Client-Id` on road requests.
+- The [Nominatim usage policy](https://operations.osmfoundation.org/policies/nominatim/)
+  permits moderate, user-triggered app search at no more than one request per
+  second, with identification, attribution, caching and a switchable endpoint.
+  Balloon Crumbs does not use it for autocomplete, reverse-query grids or
+  moving-target routing.
+- The routing graph is principally OpenStreetMap data. Attribution and the ODbL
+  data terms remain visible through the app's map information surface; see the
+  [Valhalla data-source statement](https://valhalla.github.io/valhalla/mjolnir/data_sources/).
+
+One rendezvous decision tries at most four surrounding candidates, plus the
+previous endpoint when it is still relevant. Requests are sequential with
+1.1 seconds between them. Ordinary recalculation then requires two minutes and
+300 m of target movement; a stationary route is refreshed after ten minutes.
+This keeps the default clients below the provider request-rate limit.
+
+## What provider routing proves
+
+OSRM's car profile and Valhalla's auto/truck costing use mapped road and access
+restrictions. Vehicle dimensions entered by a crew select Valhalla truck
+costing. A returned path therefore means the provider found a traversable route
+under its profile and current OpenStreetMap graph.
+
+It does **not** prove that:
+
+- every private, destination-only, seasonal or temporary restriction is mapped;
+- a gate is open or a landowner has given permission;
+- a road shoulder, gateway or lane is safe or lawful to stop on;
+- the vehicle dimensions or source map are complete and current.
+
+The app consequently says “mapped access only”, keeps field permission and safe
+stopping unverified, and freezes the prior route if no bounded candidate is
+accepted. A raw airborne coordinate is never submitted as the driving endpoint.
+


### PR DESCRIPTION
## Summary
- route chase vehicles to bounded provider-validated road candidates rather than raw airborne coordinates
- freeze and label the last valid route for stale/unreachable evidence, with explicit movement, age, request-rate and hysteresis thresholds
- replay simulation chase routes using provider road duration and vehicle constraints
- document provider terms, access limitations and deterministic acceptance coverage

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test test/controllers/fiesta_flight_simulation_test.dart test/services/chase_guidance_target_test.dart test/services/chase_rendezvous_planner_test.dart`
- full Flutter suite before final provider-duration test: 1,792 passed, 24 expected skips

Closes #8