### PR TITLE
feat: add voice-first chase guidance

### DIFF
--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -401,6 +401,10 @@ import UserNotifications
     carPlayChannel?.invokeMethod("toggleMapOrientation", arguments: nil)
   }
 
+  func toggleCarPlayVoiceMute() {
+    carPlayChannel?.invokeMethod("toggleVoiceMute", arguments: nil)
+  }
+
   /// Requests the final lifecycle transition for a ride already configured on
   /// the phone. Dart revalidates leadership, location readiness and lifecycle
   /// state because the native snapshot may have become stale before the tap.

--- a/apps/mobile/ios/Runner/CarPlaySceneDelegate.swift
+++ b/apps/mobile/ios/Runner/CarPlaySceneDelegate.swift
@@ -54,6 +54,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
   private var canPlanRoute = false
   private var canFreeRoam = false
   private var mapOrientation = "directionUp"
+  private var voiceMuted = true
   private var submittedSearchText = ""
   private weak var interfaceController: CPInterfaceController?
   private var sceneLifecycle = CarPlaySceneLifecycle()
@@ -428,6 +429,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     mapOrientation = snapshot["mapOrientation"] as? String == "northUp"
       ? "northUp"
       : "directionUp"
+    voiceMuted = (snapshot["voiceMuted"] as? NSNumber)?.boolValue ?? true
     guard let mapTemplate else { return }
 
     // Active-ride actions are app-owned buttons on the map canvas, matching the
@@ -437,6 +439,7 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
     var buttons: [CPMapButton] = []
     if surfaceMode == "activeRide" {
       buttons.append(mapOrientationButton())
+      buttons.append(voiceMuteButton())
     } else {
       if canPlanRoute { buttons.append(planRouteButton()) }
       if canFreeRoam { buttons.append(freeRoamButton()) }
@@ -455,6 +458,20 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
       accessibilityLabel: northUp
         ? "North-up map. Switch to direction-up"
         : "Direction-up map. Switch to north-up"
+    )
+    return button
+  }
+
+  private func voiceMuteButton() -> CPMapButton {
+    let button = CPMapButton { _ in
+      (UIApplication.shared.delegate as? AppDelegate)?.toggleCarPlayVoiceMute()
+    }
+    button.image = mapButtonImage(
+      named: voiceMuted ? "speaker.slash.fill" : "speaker.wave.2.fill",
+      color: CarPlayPalette.actionInk,
+      accessibilityLabel: voiceMuted
+        ? "Voice muted. Turn voice on"
+        : "Voice on. Mute and stop voice"
     )
     return button
   }

--- a/apps/mobile/ios/Runner/Info.plist
+++ b/apps/mobile/ios/Runner/Info.plist
@@ -95,10 +95,16 @@
 	  physical testing showed While Using did not reliably survive another
 	  navigation app taking the foreground. It still only holds a location
 	  session during an active flight and shows the blue background indicator.
+
+	  Audio is present because a chase driver may lock the phone or place CarPlay
+	  in front while the active navigation session supplies short voicePrompt TTS
+	  directions. Speech is opt-in, uses temporary ducking, and stops on mute or
+	  when the active flight ends.
 	-->
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>
+		<string>audio</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Scanning a flight invitation code lets you join a flight crew with no mobile signal. The camera is used only while that scanner is open, and no image is stored or sent anywhere.</string>

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -63,6 +63,7 @@ import '../../relay/sqlite_relay_queue.dart';
 import '../../services/carplay_bridge.dart';
 import '../../services/chase_guidance_target.dart';
 import '../../services/chase_rendezvous_planner.dart';
+import '../../services/chase_spoken_guidance.dart';
 import '../../services/craft_roster.dart';
 import '../../services/craft_track_reducer.dart';
 import '../../services/fiesta_flight_loader.dart';
@@ -1406,6 +1407,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   /// Every staged prompt already spoken, so a stage is not repeated on each fix
   /// and the early one does not suppress the ones after it (#410).
   final _spokenGuidanceKeys = <String>{};
+  static const _chaseSpokenGuidancePolicy = ChaseSpokenGuidancePolicy();
+  SpokenAudioMode? _spokenModeBeforeMute;
 
   /// The manoeuvre the rider was last being guided towards, and where it was.
   ///
@@ -1494,6 +1497,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   String? _observedFlightLandingEventId;
   bool _chaseGuidanceRouting = false;
   bool _chaseGuidanceHadUsableTarget = false;
+  bool _chaseFixLossActive = false;
+  int _chaseFixLossSequence = 0;
+  bool _chaseRoadEndpointDisclosureScheduled = false;
   String? _chaseGuidanceStatus;
   ChaseRendezvousSelection? _activeChaseRendezvous;
   ChaseGuidanceTarget? _lastChaseGuidanceKind;
@@ -1693,6 +1699,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         _updateMapOverlays(updateDerivedState: false);
       },
       onMapOrientationToggleRequested: _toggleCarPlayMapOrientation,
+      onVoiceMuteToggleRequested: _toggleSpokenGuidanceMute,
     );
   }
 
@@ -3220,6 +3227,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 confirmed: true,
               ),
         mapOrientation: _carPlayOrientationMode,
+        voiceMode: spokenAudioModeLabel(_spokenAudioMode),
+        voiceMuted: _spokenAudioMode == SpokenAudioMode.silent,
       ),
     );
   }
@@ -4055,6 +4064,29 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final flightLandingChanged =
         flightLanding?.eventId != _observedFlightLandingEventId;
     _observedFlightLandingEventId = flightLanding?.eventId;
+    final chaseSpeechReason = !_isChaserPerspective
+        ? null
+        : flightLandingChanged && flightLanding != null
+        ? ChaseSpeechCandidate.targetChanged(
+            revision: 'landed:${flightLanding.eventId}',
+            phrase:
+                'The balloon is marked landed. Recalculating the road rendezvous from the confirmed landing evidence.',
+          )
+        : chaseTargetChanged
+        ? ChaseSpeechCandidate.targetChanged(
+            revision: 'choice:${sharedTarget.name}',
+            phrase: sharedTarget == ChaseGuidanceTarget.balloon
+                ? 'Chase target changed to a road rendezvous near the balloon. Recalculating.'
+                : 'Chase target changed to the intended landing area. Recalculating.',
+          )
+        : landingTargetChanged &&
+              _chaseGuidanceTarget == ChaseGuidanceTarget.landingArea
+        ? ChaseSpeechCandidate.targetChanged(
+            revision: 'landing-area:${landingRevision ?? 'removed'}',
+            phrase:
+                'The intended landing area changed. Recalculating the road rendezvous.',
+          )
+        : null;
     _syncSharedLandingZone();
     _syncOperationalBoundaries();
     if (_isChaserPerspective && _chaseGuidanceTarget == null) {
@@ -4106,6 +4138,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               (flightLandingChanged && flightLanding != null) ||
               (landingTargetChanged &&
                   _chaseGuidanceTarget == ChaseGuidanceTarget.landingArea),
+          reasonSpeech: chaseSpeechReason,
         ),
       );
     }
@@ -5335,10 +5368,21 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return;
     }
     setState(() => _chaseGuidanceTarget = selected);
-    await _refreshChaseGuidanceIfNeeded(force: true);
+    await _refreshChaseGuidanceIfNeeded(
+      force: true,
+      reasonSpeech: ChaseSpeechCandidate.targetChanged(
+        revision: 'choice:${selected.name}',
+        phrase: selected == ChaseGuidanceTarget.balloon
+            ? 'Chase target changed to a road rendezvous near the balloon. Recalculating.'
+            : 'Chase target changed to the intended landing area. Recalculating.',
+      ),
+    );
   }
 
-  Future<void> _refreshChaseGuidanceIfNeeded({bool force = false}) async {
+  Future<void> _refreshChaseGuidanceIfNeeded({
+    bool force = false,
+    ChaseSpeechCandidate? reasonSpeech,
+  }) async {
     if (!_isChaserPerspective ||
         _isSimulation ||
         _chaseGuidanceRouting ||
@@ -5350,7 +5394,17 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final destination = _currentChaseGuidanceDestination();
     final origin = _mapPosition.value;
     if (selected == null || destination == null || origin == null) {
+      final lostUsableTarget =
+          selected == ChaseGuidanceTarget.balloon &&
+          destination == null &&
+          _chaseGuidanceHadUsableTarget;
       if (destination == null) _chaseGuidanceHadUsableTarget = false;
+      if (lostUsableTarget) {
+        _chaseFixLossActive = true;
+        _speakChaseRecoveryEvents([
+          ChaseSpeechCandidate.staleFix('loss-${_chaseFixLossSequence++}'),
+        ]);
+      }
       _setChaseGuidanceStatus(
         selected == null
             ? 'choose a chase target'
@@ -5376,6 +5430,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final now = DateTime.now();
     final recoveredUsableTarget = !_chaseGuidanceHadUsableTarget;
     _chaseGuidanceHadUsableTarget = true;
+    if (recoveredUsableTarget && _chaseFixLossActive) {
+      _chaseFixLossActive = false;
+      reasonSpeech = ChaseSpeechCandidate.fixRecovered(
+        destination.observedAt.toUtc().toIso8601String(),
+      );
+    }
     if (!_chaseGuidanceReroutePolicy.shouldReroute(
       now: now,
       target: destination.point,
@@ -5388,6 +5448,14 @@ class _ActiveRideShellState extends State<ActiveRideShell>
 
     _chaseGuidanceRouting = true;
     if (mounted) setState(() {});
+    final attemptRevision =
+        '${selected.name}:$_chaseGuidanceRouteSequence:${now.toUtc().toIso8601String()}';
+    _speakChaseRecoveryEvents([
+      ?reasonSpeech,
+      if (reasonSpeech == null && force && _activeChaseRendezvous != null)
+        ChaseSpeechCandidate.recalculation(attemptRevision),
+    ]);
+    final wasInitialRoadRendezvous = _activeChaseRendezvous == null;
     try {
       final rendezvous = await _chaseRendezvousPlanner.plan(
         origin: origin,
@@ -5451,6 +5519,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           : 'road endpoint updated · mapped access only';
       await _rideRouteStore?.saveActiveRoute(route);
       await _replaceAwarenessController(route);
+      if (wasInitialRoadRendezvous) _ensureChaseRoadEndpointDisclosure();
       if (mounted) setState(() {});
     } on Object catch (error) {
       if (mounted) {
@@ -5458,6 +5527,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         _warnings.add(
           'Personal chase guidance is unavailable; the previous road route is still in use. $error',
         );
+        _speakChaseRecoveryEvents([
+          ChaseSpeechCandidate.routeUnavailable(attemptRevision),
+        ]);
         setState(() {});
       }
     } finally {
@@ -5489,7 +5561,72 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       widget.spokenGuidance?.mode ?? SpokenAudioMode.silent;
 
   void _onSpokenGuidanceChanged() {
+    if (_spokenAudioMode == SpokenAudioMode.silent) {
+      unawaited(_spokenGuidance?.stop());
+    }
     unawaited(_warmNaturalVoiceIfNeeded());
+    _schedulePublish();
+  }
+
+  Future<void> _toggleSpokenGuidanceMute() async {
+    final controller = widget.spokenGuidance;
+    if (controller == null) return;
+    if (controller.mode == SpokenAudioMode.silent) {
+      await controller.setMode(
+        _spokenModeBeforeMute ?? SpokenAudioMode.everything,
+      );
+      return;
+    }
+    _spokenModeBeforeMute = controller.mode;
+    await controller.setMode(SpokenAudioMode.silent);
+    await _spokenGuidance?.stop();
+  }
+
+  void _speakChaseRecoveryEvents(Iterable<ChaseSpeechCandidate> candidates) {
+    final speaker = _spokenGuidance;
+    if (speaker == null) return;
+    final announcement = _chaseSpokenGuidancePolicy.choose(candidates);
+    if (announcement == null) return;
+    final controller = widget.rideController;
+    unawaited(
+      speaker.speakAlert(
+        key: announcement.key,
+        phrase: announcement.phrase,
+        enabled: spokenAudioAllows(_spokenAudioMode, announcement.audioClass),
+        rideActive:
+            controller.rideStarted &&
+            !controller.rideEnded &&
+            !controller.ridePaused,
+      ),
+    );
+  }
+
+  bool _ensureChaseRoadEndpointDisclosure() {
+    if (_chaseRoadEndpointDisclosureScheduled ||
+        !_isChaserPerspective ||
+        !spokenAudioAllows(_spokenAudioMode, SpokenAudioClass.navigation)) {
+      return false;
+    }
+    final speaker = _spokenGuidance;
+    if (speaker == null) return false;
+    final controller = widget.rideController;
+    final rideActive =
+        controller.rideStarted &&
+        !controller.rideEnded &&
+        !controller.ridePaused;
+    if (!rideActive) return false;
+    _chaseRoadEndpointDisclosureScheduled = true;
+    final rideRevision = controller.session?.rideId ?? 'current-flight';
+    final disclosure = ChaseSpeechCandidate.routeOverview(rideRevision);
+    unawaited(
+      speaker.speakAlert(
+        key: disclosure.key,
+        phrase: disclosure.phrase,
+        enabled: true,
+        rideActive: true,
+      ),
+    );
+    return true;
   }
 
   /// Pulls the expensive model load out of the first camera or turn prompt.
@@ -5554,6 +5691,17 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     if (guidance == null) return;
     final controller = widget.rideController;
     final identity = guidance.instruction.maneuver.identity;
+    if (_ensureChaseRoadEndpointDisclosure()) return;
+    if (_isChaserPerspective &&
+        guidance.instruction.kind == ManeuverKind.arrive &&
+        guidance.distanceMeters <= 75) {
+      _speakChaseRecoveryEvents([
+        ChaseSpeechCandidate.arrival(
+          _activeRoute?.id ?? guidance.instruction.maneuver.identity,
+        ),
+      ]);
+      return;
+    }
 
     // The instruction has moved on, so the one before it is now behind the rider
     // and its position is what the clearance rule measures against (#429).
@@ -6920,16 +7068,24 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                 animation: guidance,
                 builder: (context, _) => ListTile(
                   key: const Key('ride-menu-voice'),
-                  leading: Icon(switch (guidance.mode) {
-                    SpokenAudioMode.everything => Icons.volume_up,
-                    SpokenAudioMode.alertsOnly => Icons.notifications_active,
-                    SpokenAudioMode.silent => Icons.volume_off,
-                  }),
-                  title: Text(spokenAudioModeLabel(guidance.mode)),
-                  subtitle: Text(
-                    'Tap for ${spokenAudioModeLabel(guidance.nextMode).toLowerCase()}',
+                  minVerticalPadding: 18,
+                  leading: Icon(
+                    guidance.mode == SpokenAudioMode.silent
+                        ? Icons.volume_up
+                        : Icons.volume_off,
+                    size: 32,
                   ),
-                  onTap: () => unawaited(guidance.cycleMode()),
+                  title: Text(
+                    guidance.mode == SpokenAudioMode.silent
+                        ? 'Turn voice on'
+                        : 'Mute and stop voice',
+                  ),
+                  subtitle: Text(
+                    guidance.mode == SpokenAudioMode.silent
+                        ? 'Currently muted'
+                        : '${spokenAudioModeLabel(guidance.mode)} · stops the current prompt immediately',
+                  ),
+                  onTap: () => unawaited(_toggleSpokenGuidanceMute()),
                 ),
               ),
             const Divider(height: 1),

--- a/apps/mobile/lib/services/carplay_bridge.dart
+++ b/apps/mobile/lib/services/carplay_bridge.dart
@@ -219,6 +219,7 @@ class CarPlayBridge {
     this.onFreeRoamRequested,
     this.onStateRequested,
     this.onMapOrientationToggleRequested,
+    this.onVoiceMuteToggleRequested,
     @visibleForTesting MethodChannel? channel,
     @visibleForTesting DateTime Function()? clock,
     @visibleForTesting
@@ -280,6 +281,10 @@ class CarPlayBridge {
 
   /// Persists a CarPlay-only camera choice on the phone, then republishes it.
   final Future<void> Function()? onMapOrientationToggleRequested;
+
+  /// Toggles the phone-owned spoken-guidance mute state. Native CarPlay never
+  /// owns a second audio preference that could disagree after reconnect.
+  final Future<void> Function()? onVoiceMuteToggleRequested;
   DateTime? _lastPublishedAt;
 
   String? _publishedRideStartKey;
@@ -409,6 +414,9 @@ class CarPlayBridge {
       case 'toggleMapOrientation':
         _lastPublishedAt = null;
         await onMapOrientationToggleRequested?.call();
+      case 'toggleVoiceMute':
+        _lastPublishedAt = null;
+        await onVoiceMuteToggleRequested?.call();
     }
   }
 
@@ -448,6 +456,8 @@ class CarPlayBridge {
     CarPlayLandingArea? intendedLandingArea,
     CarPlayLandingArea? confirmedLanding,
     MapOrientationMode mapOrientation = MapOrientationMode.directionUp,
+    String? voiceMode,
+    bool voiceMuted = true,
   }) async {
     final now = _clock();
     // A question addressed to this rider is an event, not a state refresh. It
@@ -507,6 +517,8 @@ class CarPlayBridge {
       'distanceUnit': distanceUnit?.name,
       'groupStatus': groupStatus,
       'mapOrientation': mapOrientation.name,
+      'voiceMode': voiceMode,
+      'voiceMuted': voiceMuted,
       'sharedTraces': [for (final trace in sharedTraces) trace.toSnapshot()],
       'intendedLandingArea': intendedLandingArea?.toSnapshot(),
       'confirmedLanding': confirmedLanding?.toSnapshot(),

--- a/apps/mobile/lib/services/chase_spoken_guidance.dart
+++ b/apps/mobile/lib/services/chase_spoken_guidance.dart
@@ -1,0 +1,117 @@
+import 'spoken_audio_mode.dart';
+
+enum ChaseSpeechPriority {
+  routeOverview(10),
+  recalculation(20),
+  targetChange(30),
+  fixRecovered(40),
+  routeUnavailable(50),
+  staleFix(60),
+  arrival(70);
+
+  const ChaseSpeechPriority(this.weight);
+
+  final int weight;
+}
+
+class ChaseSpeechCandidate {
+  const ChaseSpeechCandidate({
+    required this.key,
+    required this.phrase,
+    required this.priority,
+    required this.audioClass,
+  });
+
+  final String key;
+  final String phrase;
+  final ChaseSpeechPriority priority;
+  final SpokenAudioClass audioClass;
+
+  factory ChaseSpeechCandidate.routeOverview(String routeRevision) =>
+      ChaseSpeechCandidate(
+        key: 'chase-route-overview:$routeRevision',
+        phrase:
+            'Road guidance ends at a road rendezvous near the balloon, not at '
+            'the balloon itself. Check access and stop only where it is lawful '
+            'and safe.',
+        priority: ChaseSpeechPriority.routeOverview,
+        audioClass: SpokenAudioClass.navigation,
+      );
+
+  factory ChaseSpeechCandidate.recalculation(String attemptRevision) =>
+      ChaseSpeechCandidate(
+        key: 'chase-recalculation:$attemptRevision',
+        phrase: 'Recalculating the road rendezvous.',
+        priority: ChaseSpeechPriority.recalculation,
+        audioClass: SpokenAudioClass.navigation,
+      );
+
+  factory ChaseSpeechCandidate.targetChanged({
+    required String revision,
+    required String phrase,
+  }) => ChaseSpeechCandidate(
+    key: 'chase-target:$revision',
+    phrase: phrase,
+    priority: ChaseSpeechPriority.targetChange,
+    audioClass: SpokenAudioClass.safety,
+  );
+
+  factory ChaseSpeechCandidate.fixRecovered(String fixRevision) =>
+      ChaseSpeechCandidate(
+        key: 'chase-fix-recovered:$fixRevision',
+        phrase:
+            'Balloon position recovered. Recalculating the road rendezvous.',
+        priority: ChaseSpeechPriority.fixRecovered,
+        audioClass: SpokenAudioClass.safety,
+      );
+
+  factory ChaseSpeechCandidate.routeUnavailable(String attemptRevision) =>
+      ChaseSpeechCandidate(
+        key: 'chase-route-unavailable:$attemptRevision',
+        phrase:
+            'A new road rendezvous is unavailable. Continue with the last '
+            'route and assess locally.',
+        priority: ChaseSpeechPriority.routeUnavailable,
+        audioClass: SpokenAudioClass.safety,
+      );
+
+  factory ChaseSpeechCandidate.staleFix(String lossRevision) =>
+      ChaseSpeechCandidate(
+        key: 'chase-stale-fix:$lossRevision',
+        phrase: 'Balloon position is stale. The last road route is being held.',
+        priority: ChaseSpeechPriority.staleFix,
+        audioClass: SpokenAudioClass.safety,
+      );
+
+  factory ChaseSpeechCandidate.arrival(String routeRevision) =>
+      ChaseSpeechCandidate(
+        key: 'chase-arrival:$routeRevision',
+        phrase:
+            'Arriving at the road rendezvous. Stop only where it is lawful and '
+            'safe. The balloon may still be elsewhere.',
+        priority: ChaseSpeechPriority.arrival,
+        audioClass: SpokenAudioClass.safety,
+      );
+}
+
+/// Chooses one unambiguous recovery message when several state changes happen
+/// together. Identity/deduplication remains in [SpokenGuidanceSpeaker], so a
+/// muted event is still eligible if the driver enables speech before the state
+/// changes again.
+class ChaseSpokenGuidancePolicy {
+  const ChaseSpokenGuidancePolicy();
+
+  ChaseSpeechCandidate? choose(Iterable<ChaseSpeechCandidate> candidates) {
+    final usable = candidates.where(
+      (candidate) =>
+          candidate.key.trim().isNotEmpty && candidate.phrase.trim().isNotEmpty,
+    );
+    if (usable.isEmpty) return null;
+    return usable.reduce(
+      (current, candidate) =>
+          candidate.priority.weight > current.priority.weight
+          ? candidate
+          : current,
+    );
+  }
+}

--- a/apps/mobile/lib/services/spoken_guidance.dart
+++ b/apps/mobile/lib/services/spoken_guidance.dart
@@ -231,14 +231,11 @@ abstract interface class WarmableSpokenGuidanceEngine {
 ///   that kills the music is worse than no prompt.
 /// - **Android must not request audio focus permanently**, for the same reason.
 ///
-/// **Foreground only, deliberately.** iOS would need the `audio` background mode
-/// declared for prompts to continue once the app is not frontmost, and that is not
-/// added here for two reasons. It is a release and review decision rather than a
-/// code one. And #205 means the app does not yet record position in the
-/// background at all - so background prompts would be guidance computed from a
-/// position that had stopped updating, which is worse than silence. A rider
-/// running another navigation app in front will not hear these; that is a known
-/// limit, not an oversight.
+/// iOS declares both active-flight location and audio background modes. The
+/// `voicePrompt` session is configured only when the driver enables speech, and
+/// every utterance remains short and interruptible. Physical lock-screen,
+/// Bluetooth and CarPlay evidence remains mandatory before reliability is
+/// claimed.
 class FlutterTtsSpokenGuidanceEngine implements SpokenGuidanceEngine {
   FlutterTtsSpokenGuidanceEngine({FlutterTts? tts, this.voiceProvider})
     : _tts = tts ?? FlutterTts();
@@ -253,6 +250,7 @@ class FlutterTtsSpokenGuidanceEngine implements SpokenGuidanceEngine {
     await _tts.setIosAudioCategory(IosTextToSpeechAudioCategory.playback, [
       IosTextToSpeechAudioCategoryOptions.mixWithOthers,
       IosTextToSpeechAudioCategoryOptions.duckOthers,
+      IosTextToSpeechAudioCategoryOptions.interruptSpokenAudioAndMixWithOthers,
     ], IosTextToSpeechAudioMode.voicePrompt);
     // Slightly slower than default: a phrase heard once at 50 mph through a
     // helmet has to land first time.

--- a/apps/mobile/test/features/carplay/carplay_layout_test.dart
+++ b/apps/mobile/test/features/carplay/carplay_layout_test.dart
@@ -13,6 +13,13 @@ void main() {
   ).readAsStringSync();
 
   group('the speed pair stays trailing while recovery status stays left', () {
+    test('active recovery exposes one-tap map and voice controls', () {
+      expect(source, contains('buttons.append(mapOrientationButton())'));
+      expect(source, contains('buttons.append(voiceMuteButton())'));
+      expect(source, contains('toggleCarPlayVoiceMute()'));
+      expect(source, contains('Mute and stop voice'));
+    });
+
     test('the recovery overview is not displaced by inherited branding', () {
       expect(source, isNot(contains('tecBadge')));
       expect(source, isNot(contains('CarPlayTecBadge')));

--- a/apps/mobile/test/services/carplay_bridge_test.dart
+++ b/apps/mobile/test/services/carplay_bridge_test.dart
@@ -82,6 +82,8 @@ void main() {
       'distanceUnit': null,
       'groupStatus': '5 riders visible',
       'mapOrientation': 'directionUp',
+      'voiceMode': null,
+      'voiceMuted': true,
       'sharedTraces': <Object?>[],
       'intendedLandingArea': null,
       'confirmedLanding': null,
@@ -137,6 +139,8 @@ void main() {
       riderLocations: const [],
       activeHazards: const [],
       mapOrientation: MapOrientationMode.northUp,
+      voiceMode: 'Alerts only',
+      voiceMuted: false,
       craftLocations: const [
         CarPlayCraftLocation(
           id: 'balloon',
@@ -180,6 +184,8 @@ void main() {
 
     final snapshot = received!.arguments as Map;
     expect(snapshot['mapOrientation'], 'northUp');
+    expect(snapshot['voiceMode'], 'Alerts only');
+    expect(snapshot['voiceMuted'], isFalse);
     expect(snapshot['riders'], hasLength(1));
     expect(
       (snapshot['riders'] as List).single,
@@ -868,6 +874,25 @@ void main() {
     await messenger.handlePlatformMessage(
       channel.name,
       channel.codec.encodeMethodCall(const MethodCall('toggleMapOrientation')),
+      (_) {},
+    );
+
+    expect(toggles, 1);
+  });
+
+  test('relays the one-tap CarPlay voice mute to the phone', () async {
+    var toggles = 0;
+    final bridge = CarPlayBridge(
+      channel: channel,
+      onVoiceMuteToggleRequested: () async {
+        toggles += 1;
+      },
+    );
+    addTearDown(bridge.dispose);
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      channel.codec.encodeMethodCall(const MethodCall('toggleVoiceMute')),
       (_) {},
     );
 

--- a/apps/mobile/test/services/chase_spoken_guidance_test.dart
+++ b/apps/mobile/test/services/chase_spoken_guidance_test.dart
@@ -1,0 +1,87 @@
+import 'package:balloon_crumbs/services/chase_spoken_guidance.dart';
+import 'package:balloon_crumbs/services/spoken_audio_mode.dart';
+import 'package:balloon_crumbs/services/spoken_guidance.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const policy = ChaseSpokenGuidancePolicy();
+
+  test('the first route instruction explains the road rendezvous boundary', () {
+    final announcement = policy.choose([
+      ChaseSpeechCandidate.routeOverview('route-1'),
+    ]);
+
+    expect(announcement!.phrase, contains('road rendezvous'));
+    expect(announcement.phrase, contains('not at the balloon'));
+    expect(announcement.phrase, contains('lawful and safe'));
+  });
+
+  test('stale and arrival messages outrank recalculation chatter', () {
+    final stale = policy.choose([
+      ChaseSpeechCandidate.recalculation('attempt-1'),
+      ChaseSpeechCandidate.staleFix('loss-1'),
+    ]);
+    final arrival = policy.choose([
+      ChaseSpeechCandidate.routeUnavailable('attempt-2'),
+      ChaseSpeechCandidate.arrival('route-1'),
+    ]);
+
+    expect(stale!.priority, ChaseSpeechPriority.staleFix);
+    expect(arrival!.priority, ChaseSpeechPriority.arrival);
+  });
+
+  test('repeated churn is deduplicated by semantic revision', () async {
+    final engine = _RecordingEngine();
+    final speaker = SpokenGuidanceSpeaker(engine);
+    final churn = [
+      for (var index = 0; index < 20; index += 1)
+        policy.choose([
+          ChaseSpeechCandidate.recalculation('attempt-1'),
+          ChaseSpeechCandidate.staleFix('loss-1'),
+        ])!,
+    ];
+
+    for (final announcement in churn) {
+      await speaker.speakAlert(
+        key: announcement.key,
+        phrase: announcement.phrase,
+        enabled: spokenAudioAllows(
+          SpokenAudioMode.everything,
+          announcement.audioClass,
+        ),
+        rideActive: true,
+      );
+    }
+
+    expect(engine.spoken, [
+      'Balloon position is stale. The last road route is being held.',
+    ]);
+  });
+
+  test('alerts-only keeps state warnings but silences route chatter', () {
+    final recalculation = ChaseSpeechCandidate.recalculation('attempt-1');
+    final stale = ChaseSpeechCandidate.staleFix('loss-1');
+
+    expect(
+      spokenAudioAllows(SpokenAudioMode.alertsOnly, recalculation.audioClass),
+      isFalse,
+    );
+    expect(
+      spokenAudioAllows(SpokenAudioMode.alertsOnly, stale.audioClass),
+      isTrue,
+    );
+  });
+}
+
+class _RecordingEngine implements SpokenGuidanceEngine {
+  final spoken = <String>[];
+
+  @override
+  Future<void> configure() async {}
+
+  @override
+  Future<void> speak(String phrase) async => spoken.add(phrase);
+
+  @override
+  Future<void> stop() async {}
+}

--- a/apps/mobile/test/services/spoken_background_contract_test.dart
+++ b/apps/mobile/test/services/spoken_background_contract_test.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'iOS declares active-flight location and spoken-audio background modes',
+    () {
+      final plist = File('ios/Runner/Info.plist').readAsStringSync();
+
+      expect(plist, contains('<key>UIBackgroundModes</key>'));
+      expect(plist, contains('<string>location</string>'));
+      expect(plist, contains('<string>audio</string>'));
+    },
+  );
+}

--- a/apps/mobile/test/services/spoken_guidance_test.dart
+++ b/apps/mobile/test/services/spoken_guidance_test.dart
@@ -122,6 +122,40 @@ void main() {
     expect(engine.spoken, hasLength(2));
   });
 
+  test('the one-action mute path stops the current utterance', () async {
+    await speaker.speakAlert(
+      key: 'stale-fix-1',
+      phrase: 'Balloon position is stale',
+      enabled: true,
+      rideActive: true,
+    );
+
+    await speaker.stop();
+
+    expect(engine.stopped, isTrue);
+  });
+
+  test('iOS uses a short navigation voice-prompt audio session', () async {
+    final tts = _AudioSessionRecordingTts();
+    final voiceEngine = FlutterTtsSpokenGuidanceEngine(tts: tts);
+
+    await voiceEngine.configure();
+
+    expect(tts.category, IosTextToSpeechAudioCategory.playback);
+    expect(tts.mode, IosTextToSpeechAudioMode.voicePrompt);
+    expect(
+      tts.options,
+      contains(IosTextToSpeechAudioCategoryOptions.duckOthers),
+    );
+    expect(
+      tts.options,
+      contains(
+        IosTextToSpeechAudioCategoryOptions
+            .interruptSpokenAudioAndMixWithOthers,
+      ),
+    );
+  });
+
   test('installed voice discovery keeps usable English voices', () async {
     final voices = await loadSpokenGuidanceVoices(_VoiceListTts());
 
@@ -283,6 +317,36 @@ class _VoiceListTts extends FlutterTts {
     {'name': 'Thomas', 'locale': 'fr-FR', 'identifier': 'thomas'},
     {'name': '', 'locale': 'en-US'},
   ];
+}
+
+class _AudioSessionRecordingTts extends FlutterTts {
+  IosTextToSpeechAudioCategory? category;
+  List<IosTextToSpeechAudioCategoryOptions> options = const [];
+  IosTextToSpeechAudioMode? mode;
+
+  @override
+  Future<dynamic> setSharedInstance(bool sharedSession) async => 1;
+
+  @override
+  Future<dynamic> setIosAudioCategory(
+    IosTextToSpeechAudioCategory category,
+    List<IosTextToSpeechAudioCategoryOptions> options, [
+    IosTextToSpeechAudioMode mode = IosTextToSpeechAudioMode.defaultMode,
+  ]) async {
+    this.category = category;
+    this.options = List.unmodifiable(options);
+    this.mode = mode;
+    return 1;
+  }
+
+  @override
+  Future<dynamic> setSpeechRate(double rate) async => 1;
+
+  @override
+  Future<dynamic> awaitSpeakCompletion(bool awaitCompletion) async => 1;
+
+  @override
+  Future<dynamic> clearVoice() async => 1;
 }
 
 class _VoiceRecordingTts extends FlutterTts {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -27,7 +27,7 @@ not a claim that every P0 item is small. Work packages are defined in
 | 7 | P0 | ~~Multiple chase vehicles and vehicle assignment~~ **done**; rendezvous remains in 7a | WP7 | 3, 5 |
 | 7a | P0 | ~~Chaser-selectable road guidance to the balloon or intended landing area, with bounded road-candidate selection, access uncertainty and reroute hysteresis~~ **done** | WP7 | 6, 7 |
 | 7b | P0 | ~~Mini-map and local viewpoint switching as the chase decision surface (balloon, track, area, vehicles)~~ **done** | WP7 | 7a |
-| 8 | P0 | Voice-first chase guidance for a moving target | WP8 | 7 |
+| 8 | P0 | Voice-first chase guidance for a moving target — automated policy and phone/CarPlay controls done; physical audio matrix remains | WP8 | 7 |
 | 9 | P0 | Ground notes and the retrieve | WP9 | 3 |
 | 10 | P0 | Landing-phase basemap (OS topographic / aerial) | WP6b | 6 |
 | 11 | P0 | Balloon/chase simulator and replay matrix | WP10 | 3–9 |

--- a/docs/launch-recovery-acceptance.md
+++ b/docs/launch-recovery-acceptance.md
@@ -80,6 +80,14 @@ also rescored and retained unless another saves at least 90 seconds.
 | Replay is deterministic and failures are bounded | `chase_rendezvous_planner_test.dart` covers crossings, reversals, stationary fixes, rejected candidates, all-unreachable candidates and identical replay results |
 | Provider use is within current terms | `docs/routing-provider-policy.md`; candidate calls are sequential at 1.1 seconds and identify Balloon Crumbs through `User-Agent` and `X-Client-Id` |
 
+## Voice-first chase closure
+
+The automated speech contract is in `docs/spoken-recovery-guidance.md`.
+`chase_spoken_guidance_test.dart` proves rendezvous disclosure, priority and
+deduplication under churn; the phone and CarPlay source tests prove one-action
+mute-and-stop wiring. Physical Bluetooth, interruption, background and head-unit
+rows remain mandatory before reliability is claimed.
+
 ## Balloon telemetry closure
 
 Balloon Crumbs stores telemetry internally in metres and converts only at the

--- a/docs/role-specific-live-flight-experience.md
+++ b/docs/role-specific-live-flight-experience.md
@@ -806,6 +806,19 @@ and a UI rebuild cannot change authority.
       preserve the last valid route on failure.
 - [x] Target selection, road endpoint, target age and reroute reason are visible.
 
+### P0.8 Voice-first chase guidance
+
+- [x] The first route prompt explains that guidance ends at a road rendezvous,
+      not the airborne balloon coordinate.
+- [x] Manoeuvre, target-change, recalculation, stale/recovered-fix,
+      route-failure and arrival phrases have explicit priorities and semantic
+      deduplication.
+- [x] Churn replay does not repeat or conflict with a higher-priority message.
+- [x] Phone and CarPlay expose one-tap mute-and-stop controls backed by the same
+      persisted phone preference.
+- [ ] Bluetooth, interruption, screen-off, app-background and physical CarPlay
+      evidence is recorded in `docs/spoken-recovery-guidance.md`.
+
 ## P1 requirements
 
 - Live projected track and possible-landing envelope from current telemetry and

--- a/docs/spoken-recovery-guidance.md
+++ b/docs/spoken-recovery-guidance.md
@@ -1,0 +1,74 @@
+# Spoken recovery guidance
+
+Status: automated policy and projected controls implemented; physical audio
+evidence remains a release gate.
+
+## Driver contract
+
+Road manoeuvres keep the inherited staged scheduler. Balloon recovery state is
+a separate, deduplicated channel whose messages use semantic revisions rather
+than map-refresh frequency.
+
+| Priority | Event | Driver-facing meaning |
+| --- | --- | --- |
+| 7 | Arrival | Arriving at a road rendezvous; stop only where lawful and safe; the balloon may be elsewhere |
+| 6 | Balloon fix stale | Freeze the last road route; do not imply a live target |
+| 5 | Route unavailable | Keep the previous route and assess locally |
+| 4 | Fix recovered | Reconsider the road rendezvous |
+| 3 | Target or landing intent changed | Name the change and reconsider the route |
+| 2 | Explicit recalculation | State that the road rendezvous is being recalculated |
+| 1 | First road route | Explain that the endpoint is near the balloon, not the airborne coordinate |
+
+If several events arrive together, only the highest-priority phrase is chosen.
+`SpokenGuidanceSpeaker` then refuses the same semantic key twice. Routine
+moving-target refreshes do not announce every recalculation: only an explicit
+target/landing revision, stale recovery, or driver-requested refresh speaks.
+
+“Alerts only” preserves stale, recovery, target, failure and arrival warnings
+while silencing the route overview, recalculation chatter and manoeuvres.
+“Muted” suppresses all speech.
+
+iOS declares the `audio` background mode alongside active-flight location and
+uses the system `voicePrompt` audio-session mode with temporary ducking and
+spoken-audio interruption. These are the platform facilities Apple documents
+for short turn-by-turn text-to-speech prompts; physical evidence is still
+required before claiming reliability.
+
+## Controls
+
+- The phone flight menu exposes one large **Mute and stop voice** action. It
+  changes the saved mode to muted and immediately stops the current utterance.
+- The CarPlay recovery map projects the same phone-owned state and exposes one
+  speaker button beside map orientation. It cannot drift into a separate native
+  preference; reconnect republishes the phone state.
+- Settings retains the full Voice on / Alerts only / Muted choice and voice
+  selection.
+
+## Automated evidence
+
+- `chase_spoken_guidance_test.dart`: road-endpoint disclosure, simultaneous
+  event priority, 20-update churn deduplication, alerts-only classification.
+- `spoken_guidance_schedule_test.dart`: staged manoeuvre timing and close-junction
+  behaviour.
+- `spoken_guidance_test.dart`: engine configuration, mute gates, alert and
+  manoeuvre deduplication, stop and OS fallback behaviour.
+- `carplay_bridge_test.dart` and `carplay_layout_test.dart`: phone-owned mute
+  projection and the one-tap projected control.
+
+## Required physical evidence
+
+Record build, phone/OS, audio route and outcome for each row. A simulator pass
+does not close these rows.
+
+| Case | iOS phone | Android phone | CarPlay head unit |
+| --- | --- | --- | --- |
+| Speaker foreground | | | |
+| Bluetooth foreground | | | |
+| Incoming-call/audio interruption and recovery | | | |
+| Screen locked with permitted background location | | | n/a |
+| App background with permitted background location | | | |
+| One-tap mute interrupts the current phrase | | | |
+| Reconnect restores mute state | n/a | n/a | |
+
+Do not claim background or projected reliability until the applicable rows are
+filled with physical-device evidence.


### PR DESCRIPTION
## Summary
- add prioritized, semantically deduplicated chase recovery announcements for route overview, target changes, stale/recovered fixes, route failures and safe arrival
- add one-tap mute-and-stop controls on the phone and CarPlay, backed by one phone-owned preference
- configure iOS short navigation voice prompts for permitted active-flight background audio and document the required physical-device evidence matrix

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- 88 focused spoken-guidance and CarPlay tests
- `git diff --check`

Implements the automated scope of #9. Physical Bluetooth, interruption, background and CarPlay head-unit evidence remains required before #9 can close.