### PR TITLE
feat: add per-device flight authority

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -172,17 +172,18 @@ Acceptance:
 
 - Retain Tail End Charlie's local journal, deduplication, bounded relay, QR
   bootstrap, diagnostics, and explicit stale states.
-- Replace the inherited group-HMAC trust model with per-device authority and
-  encrypted payloads before public release.
-- Default precise server-side data retention to the active flight plus a short,
-  documented recovery period.
+- Per-device Ed25519 authority now supplements the bounded group transport HMAC;
+  copied flight credentials cannot impersonate an established device or pilot.
+- Precise server-side retention is capped by data class and an ended flight is
+  deleted after a maximum 24-hour recovery window. See
+  `docs/security-privacy-field-gate.md`.
 
 Acceptance:
 
-- [ ] Replayed and duplicated events produce one canonical state.
-- [ ] Connectivity loss and recovery require no repair screen.
-- [ ] Logs redact codes, secrets, exact tracks, and provider credentials.
-- [ ] A participant can leave and delete their local flight data.
+- [x] Replayed and duplicated events produce one canonical state.
+- [x] Connectivity loss and recovery require no repair screen.
+- [x] Logs redact codes, secrets, exact tracks, and provider credentials.
+- [x] A participant can leave and delete their local flight data.
 
 ### P1 — useful after the core loop works
 
@@ -234,7 +235,9 @@ Lagging indicators:
   airspace, and NOTAM providers permit caching and redistribution in this app?
 - **Blocking — product:** What prediction horizon and recalculation cadence are
   acceptable to experienced UK chase crews?
-- **Blocking — privacy:** Exact retention durations and observer precision.
+- **Resolved — privacy:** Exact retention durations and deletion triggers are in
+  `docs/security-privacy-field-gate.md`; observer precision remains deliberately
+  reduced and separately gated by issue #14.
 - **Non-blocking — design:** Final altitude palette and simultaneous non-colour cue.
 - **Non-blocking — release:** Final product name, domains, and permanent bundle IDs.
 

--- a/apps/mobile/lib/controllers/nearby_relay_controller.dart
+++ b/apps/mobile/lib/controllers/nearby_relay_controller.dart
@@ -12,7 +12,15 @@ import '../relay/relay_presence.dart';
 /// particular radio SDK.
 class NearbyRelayController extends ChangeNotifier
     implements RelayPresenceGateway {
-  NearbyRelayController(this._engine) {
+  NearbyRelayController(
+    this._engine, {
+    RelayPresenceFactory? presenceFactory,
+    RelayPresenceVerifier? presenceVerifier,
+  }) : // Public constructor names stay free of library-private underscores.
+       // ignore: prefer_initializing_formals
+       _presenceFactory = presenceFactory,
+       // ignore: prefer_initializing_formals
+       _presenceVerifier = presenceVerifier {
     _subscription = _engine.statuses.listen((status) {
       _status = status;
       notifyListeners();
@@ -20,6 +28,8 @@ class NearbyRelayController extends ChangeNotifier
   }
 
   final RelayEngine _engine;
+  final RelayPresenceFactory? _presenceFactory;
+  final RelayPresenceVerifier? _presenceVerifier;
   late final StreamSubscription<RelayStatus> _subscription;
   RelayStatus _status = const RelayStatus.stopped();
 
@@ -35,6 +45,8 @@ class NearbyRelayController extends ChangeNotifier
       rideSecret: session.inviteSecret,
       localDeviceId: session.localRiderId,
       endpointName: session.displayName,
+      presenceFactory: _presenceFactory,
+      presenceVerifier: _presenceVerifier,
     ),
   );
 

--- a/apps/mobile/lib/controllers/observer_access_controller.dart
+++ b/apps/mobile/lib/controllers/observer_access_controller.dart
@@ -261,7 +261,9 @@ class ObserverAccessController extends ChangeNotifier {
         onError: (Object error, StackTrace stackTrace) {
           _publishLoop = null;
           if (kDebugMode) {
-            debugPrint('Observer snapshot publish failed: $error');
+            debugPrint(
+              'Observer snapshot publish failed (${error.runtimeType})',
+            );
           }
           _ensurePublishing();
         },

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -11,7 +11,10 @@ import '../data/in_memory_crew_room_store.dart';
 import '../domain/crew_room.dart';
 import '../domain/crew_room_store.dart';
 import '../domain/craft.dart';
+import '../domain/device_identity_store.dart';
 import '../services/craft_roster.dart';
+import '../services/device_identity.dart';
+import '../services/device_authority_policy.dart';
 import '../services/chase_guidance_target.dart';
 import '../domain/event_store.dart';
 import '../domain/flight_replay.dart';
@@ -37,6 +40,7 @@ import '../features/map/craft_icon.dart';
 import '../relay/live_presence.dart';
 import '../services/nearby_bridge.dart';
 import '../services/pilot_handover.dart';
+import '../services/presence_authenticator.dart';
 import '../services/completed_ride_archiver.dart';
 import '../services/ride_event_authenticator.dart';
 import '../services/ride_lifecycle.dart';
@@ -47,6 +51,7 @@ import '../services/ride_route_reducer.dart';
 import '../services/rider_contact_share.dart';
 import '../internet/internet_relay_client.dart';
 import '../internet/crew_room_directory.dart';
+import '../relay/relay_presence.dart';
 
 typedef Clock = DateTime Function();
 typedef IdFactory = String Function();
@@ -88,6 +93,7 @@ class RideController extends ChangeNotifier {
     CrewRoomStore? crewRoomStore,
     this._completedRideStore,
     this._installationId,
+    DeviceIdentityStore? deviceIdentityStore,
   }) : _clock = clock ?? DateTime.now,
        _idFactory = idFactory ?? const Uuid().v7,
        _random = random ?? Random.secure(),
@@ -95,7 +101,10 @@ class RideController extends ChangeNotifier {
            rideCodeDirectory ?? HttpRideCodeDirectory.fromEnvironment(),
        _crewRoomDirectory =
            crewRoomDirectory ?? HttpCrewRoomDirectory.fromEnvironment(),
-       _crewRoomStore = crewRoomStore ?? InMemoryCrewRoomStore();
+       _crewRoomStore = crewRoomStore ?? InMemoryCrewRoomStore(),
+       _deviceIdentityManager = deviceIdentityStore == null
+           ? null
+           : DeviceIdentityManager(deviceIdentityStore);
 
   static const endedRideRecoveryWindow = Duration(hours: 24);
 
@@ -110,6 +119,7 @@ class RideController extends ChangeNotifier {
   final RideCodeDirectory _rideCodeDirectory;
   final CrewRoomDirectory _crewRoomDirectory;
   final CrewRoomStore _crewRoomStore;
+  final DeviceIdentityManager? _deviceIdentityManager;
   List<CrewRoomMembership> _crewRooms = const [];
 
   RideSession? _session;
@@ -126,6 +136,7 @@ class RideController extends ChangeNotifier {
   RideRouteState _routeState = const RideRouteState();
   final Map<String, Set<RideTransportEvidence>> _transportByEventId = {};
   List<LiveRiderPresence> _livePresence = const [];
+  DeviceAuthorityPolicy? _deviceAuthorityPolicy;
 
   /// The relay's cursor-independent roster, including the riders it reports as
   /// having left. Live presence drops a departed rider — they are not there —
@@ -236,6 +247,9 @@ class RideController extends ChangeNotifier {
 
   PilotAuthorityState get pilotAuthority =>
       const PilotAuthorityReducer().fromEvents(events: _events, now: _clock());
+
+  Set<String> get revokedDeviceIds =>
+      _deviceAuthorityPolicy?.revokedDeviceIds ?? const {};
 
   PilotHandoverOffer? get pendingLocalPilotHandover {
     final localId = _session?.localRiderId;
@@ -660,7 +674,9 @@ class RideController extends ChangeNotifier {
     _session = await _sessionStore.load();
     final activeSession = _session;
     if (activeSession != null) {
-      _replaceEvents(await _eventStore.eventsForRide(activeSession.rideId));
+      await _replaceAuthenticatedEvents(
+        await _eventStore.eventsForRide(activeSession.rideId),
+      );
       _rebuildLifecycle();
       await _archiveCurrentRideIfComplete();
       await _expireEndedRideIfDue();
@@ -675,7 +691,9 @@ class RideController extends ChangeNotifier {
     if (activeSession == null) {
       return;
     }
-    _replaceEvents(await _eventStore.eventsForRide(activeSession.rideId));
+    await _replaceAuthenticatedEvents(
+      await _eventStore.eventsForRide(activeSession.rideId),
+    );
     _rebuildLifecycle();
     await _archiveCurrentRideIfComplete();
     await _expireEndedRideIfDue();
@@ -698,9 +716,43 @@ class RideController extends ChangeNotifier {
     final activeSession = _session;
     if (activeSession == null ||
         event.rideId != activeSession.rideId ||
+        (activeSession.usesDeviceAuthority
+            ? event.schemaVersion != 2
+            : event.schemaVersion != 1) ||
         _eventIds.contains(event.id) ||
         !RideEventAuthenticator.verify(event, activeSession.inviteSecret)) {
       return false;
+    }
+
+    if (activeSession.usesDeviceAuthority) {
+      final appendsInOrder =
+          _events.isEmpty ||
+          RideLifecycleReducer.compareEvents(_events.last, event) <= 0;
+      if (appendsInOrder) {
+        final policy =
+            _deviceAuthorityPolicy ?? DeviceAuthorityPolicy(activeSession);
+        if (!policy.accept(event)) return false;
+        _deviceAuthorityPolicy = policy;
+      } else {
+        final policy = DeviceAuthorityPolicy(activeSession);
+        final accepted = policy.filter([..._events, event]);
+        if (!accepted.any((candidate) => candidate.id == event.id)) {
+          return false;
+        }
+        _deviceAuthorityPolicy = policy;
+        _events = accepted.toList(growable: true);
+        _eventIds
+          ..clear()
+          ..addAll(_events.map((candidate) => candidate.id));
+        _invalidateMembershipProjection();
+        _landingZoneDirty = true;
+        _flightLandingDirty = true;
+        _operationalBoundaryDirty = true;
+        _rebuildLifecycle();
+        _applyLocalPilotAuthorityFromEvents();
+        if (notify) notifyListeners();
+        return true;
+      }
     }
 
     if (_events.isEmpty ||
@@ -878,6 +930,7 @@ class RideController extends ChangeNotifier {
         rideCode: operation.rideCode,
         inviteSecret: operation.inviteSecret,
         joinToken: operation.joinToken,
+        authorityRootPublicKey: operation.authorityRootPublicKey,
         displayName: membership.displayName,
         flightRole: membership.flightRole,
         vehicleLabel: membership.vehicleLabel,
@@ -1135,6 +1188,7 @@ class RideController extends ChangeNotifier {
         rideCode: invitation.rideCode,
         inviteSecret: invitation.inviteSecret,
         joinToken: invitation.joinToken,
+        authorityRootPublicKey: invitation.authorityRootPublicKey,
         displayName: displayName,
         flightRole: flightRole,
         vehicleLabel: vehicleLabel,
@@ -1177,7 +1231,8 @@ class RideController extends ChangeNotifier {
       } on CrewRoomDirectoryException catch (error) {
         if (kDebugMode) {
           debugPrint(
-            'Joined flight offline; returning room access was deferred: $error',
+            'Joined flight offline; returning room access was deferred '
+            '(${error.runtimeType})',
           );
         }
       }
@@ -1208,6 +1263,7 @@ class RideController extends ChangeNotifier {
         rideCode: credentials.rideCode,
         inviteSecret: credentials.inviteSecret,
         joinToken: credentials.joinToken,
+        authorityRootPublicKey: credentials.authorityRootPublicKey,
         displayName: displayName,
         flightRole: flightRole,
         vehicleLabel: vehicleLabel,
@@ -1224,6 +1280,7 @@ class RideController extends ChangeNotifier {
     required String rideCode,
     required String inviteSecret,
     required String joinToken,
+    String? authorityRootPublicKey,
     required String displayName,
     required FlightRole flightRole,
     required String vehicleLabel,
@@ -1271,12 +1328,20 @@ class RideController extends ChangeNotifier {
         kind: craftKind,
         label: craftLabel,
       );
+      final identity =
+          authorityRootPublicKey == null || _deviceIdentityManager == null
+          ? null
+          : await _deviceIdentityManager.loadOrCreate(credentials.rideId);
       final session = RideSession(
         rideId: credentials.rideId,
         rideCode: credentials.rideCode,
         inviteSecret: credentials.inviteSecret,
         joinToken: credentials.joinToken,
-        localRiderId: _localRiderIdForRide(credentials.rideId),
+        localRiderId:
+            identity?.deviceId ?? _localRiderIdForRide(credentials.rideId),
+        authorizationVersion: identity == null ? 1 : 2,
+        authorityRootPublicKey: authorityRootPublicKey,
+        localDevicePublicKey: identity?.publicKey,
         displayName: _normaliseName(displayName),
         role: flightRole == FlightRole.pilot ? RideRole.lead : RideRole.rider,
         flightRole: flightRole,
@@ -1291,7 +1356,9 @@ class RideController extends ChangeNotifier {
       );
       _session = session;
       await _sessionStore.save(session);
-      _replaceEvents(await _eventStore.eventsForRide(session.rideId));
+      await _replaceAuthenticatedEvents(
+        await _eventStore.eventsForRide(session.rideId),
+      );
       _invalidateMembershipProjection();
       _rebuildLifecycle();
       await _record(
@@ -1431,6 +1498,91 @@ class RideController extends ChangeNotifier {
           'toDeviceId': offer.toDeviceId,
         },
       );
+    });
+  }
+
+  /// Revokes one participant's operation-scoped signing identity. Possessing
+  /// the shared flight code may still reach the transport, but later events
+  /// from the revoked key are discarded before product state is reduced.
+  Future<void> revokeDeviceAuthority(
+    String targetDeviceId, {
+    String reason = 'removed by pilot',
+  }) async {
+    await _run(() async {
+      final session = _requireSession();
+      if (!session.usesDeviceAuthority || !hasFlightAuthority) {
+        throw const FormatException(
+          'Only the current pilot can revoke a crew device.',
+        );
+      }
+      if (targetDeviceId == session.localRiderId ||
+          !participants.any(
+            (participant) => participant.riderId == targetDeviceId,
+          )) {
+        throw const FormatException('Choose another active crew device.');
+      }
+      final trimmedReason = reason.trim();
+      await _record(
+        type: RideEventType.deviceAuthorityRevoked,
+        priority: EventPriority.critical,
+        payload: {
+          'targetDeviceId': targetDeviceId,
+          'reason': trimmedReason.isEmpty
+              ? 'removed by pilot'
+              : trimmedReason.length <= 120
+              ? trimmedReason
+              : trimmedReason.substring(0, 120),
+        },
+      );
+    });
+  }
+
+  /// Replaces this device's operation key without changing its roster identity.
+  /// The old key signs the rotation and the new key signs a detached proof, so
+  /// neither the relay nor another invite holder can substitute a replacement.
+  Future<void> rotateLocalDeviceAuthority() async {
+    await _run(() async {
+      final session = _requireSession();
+      final manager = _deviceIdentityManager;
+      final oldPublicKey = session.localDevicePublicKey;
+      if (!session.usesDeviceAuthority ||
+          manager == null ||
+          oldPublicKey == null) {
+        throw const FormatException(
+          'This legacy flight cannot rotate device authority.',
+        );
+      }
+      final previous = await manager.loadOrCreate(session.rideId);
+      final replacement = await manager.generateReplacement(session.rideId);
+      final proof = await RideEventAuthenticator.signRotationProof(
+        rideId: session.rideId,
+        deviceId: session.localRiderId,
+        oldPublicKey: oldPublicKey,
+        replacement: replacement,
+      );
+      final event = await createAuthenticatedEvent(
+        type: RideEventType.deviceAuthorityRotated,
+        priority: EventPriority.critical,
+        payload: {
+          'newPublicKey': replacement.publicKey,
+          'newDeviceSignature': proof,
+        },
+      );
+      await manager.save(replacement, rideId: session.rideId);
+      try {
+        await _eventStore.append(event);
+        if (!_acceptStoredEvent(event, notify: false)) {
+          throw StateError('Device authority rotation was rejected.');
+        }
+      } on Object {
+        await manager.save(previous, rideId: session.rideId);
+        rethrow;
+      }
+      final updated = session.copyWith(
+        localDevicePublicKey: replacement.publicKey,
+      );
+      _session = updated;
+      await _sessionStore.save(updated);
     });
   }
 
@@ -2366,12 +2518,16 @@ class RideController extends ChangeNotifier {
           await publishDeparture(departure);
         } on Object catch (error, stackTrace) {
           if (kDebugMode) {
-            debugPrint('Departure remains queued locally: $error\n$stackTrace');
+            debugPrint(
+              'Departure was not confirmed before local flight deletion '
+              '(${error.runtimeType})\n'
+              '$stackTrace',
+            );
           }
         }
       }
       await _archiveCurrentRideIfComplete(force: true);
-      await _removeRideData(deleteEvents: false);
+      await _removeRideData();
     });
   }
 
@@ -2381,39 +2537,148 @@ class RideController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<RideEvent> _record({
+  /// Builds an authenticated local event without storing it. The situational
+  /// controller uses this path so location and hazard updates receive the same
+  /// per-device author proof as lifecycle events.
+  Future<RideEvent> createAuthenticatedEvent({
     required RideEventType type,
     required Map<String, Object?> payload,
     EventPriority priority = EventPriority.routine,
     DateTime? expiresAt,
   }) async {
     final activeSession = _requireSession();
-    final now = _clock();
-    final id = _idFactory();
     final unsignedEvent = RideEvent(
-      id: id,
+      id: _idFactory(),
       rideId: activeSession.rideId,
       deviceId: activeSession.localRiderId,
       type: type,
       priority: priority,
-      createdAt: now,
+      createdAt: _clock(),
       expiresAt: expiresAt,
       payload: payload,
       signature: '',
+      devicePublicKey: activeSession.localDevicePublicKey,
+      schemaVersion: activeSession.usesDeviceAuthority ? 2 : 1,
     );
-    final event = RideEvent(
-      id: unsignedEvent.id,
-      rideId: unsignedEvent.rideId,
-      deviceId: unsignedEvent.deviceId,
-      type: unsignedEvent.type,
-      priority: unsignedEvent.priority,
-      createdAt: unsignedEvent.createdAt,
-      expiresAt: unsignedEvent.expiresAt,
-      payload: unsignedEvent.payload,
-      signature: RideEventAuthenticator.sign(
-        unsignedEvent,
-        activeSession.inviteSecret,
-      ),
+    if (!activeSession.usesDeviceAuthority) {
+      return RideEvent(
+        id: unsignedEvent.id,
+        rideId: unsignedEvent.rideId,
+        deviceId: unsignedEvent.deviceId,
+        type: unsignedEvent.type,
+        priority: unsignedEvent.priority,
+        createdAt: unsignedEvent.createdAt,
+        expiresAt: unsignedEvent.expiresAt,
+        payload: unsignedEvent.payload,
+        signature: RideEventAuthenticator.sign(
+          unsignedEvent,
+          activeSession.inviteSecret,
+        ),
+      );
+    }
+    var identity = await _deviceIdentityManager!.loadOrCreate(
+      activeSession.rideId,
+    );
+    if (identity.publicKey != activeSession.localDevicePublicKey ||
+        (identity.deviceId != activeSession.localRiderId &&
+            !_events.any(
+              (event) =>
+                  event.type == RideEventType.deviceAuthorityRotated &&
+                  event.deviceId == activeSession.localRiderId &&
+                  event.payload['newPublicKey'] == identity.publicKey,
+            ))) {
+      throw StateError(
+        'This device no longer holds the signing identity for the flight.',
+      );
+    }
+    identity = identity.boundToDeviceId(activeSession.localRiderId);
+    return RideEventAuthenticator.signForDevice(
+      event: unsignedEvent,
+      secret: activeSession.inviteSecret,
+      identity: identity,
+    );
+  }
+
+  Future<RelayPresenceUpdate> createAuthenticatedPresence({
+    required RiderLocation? position,
+    required bool clear,
+    required Duration ttl,
+  }) async {
+    final activeSession = _requireSession();
+    final now = _clock();
+    if (!activeSession.usesDeviceAuthority) {
+      return RelayPresenceUpdate(
+        riderId: activeSession.localRiderId,
+        sentAt: now,
+        expiresAt: now.add(ttl),
+        clear: clear,
+        position: position,
+      );
+    }
+    var identity = await _deviceIdentityManager!.loadOrCreate(
+      activeSession.rideId,
+    );
+    if (identity.publicKey != activeSession.localDevicePublicKey) {
+      throw StateError(
+        'This device no longer holds the live-position identity.',
+      );
+    }
+    identity = identity.boundToDeviceId(activeSession.localRiderId);
+    final proof = await PresenceAuthenticator.sign(
+      rideId: activeSession.rideId,
+      riderId: activeSession.localRiderId,
+      position: position,
+      clear: clear,
+      signedAt: now,
+      identity: identity,
+    );
+    return RelayPresenceUpdate(
+      riderId: activeSession.localRiderId,
+      sentAt: now,
+      expiresAt: now.add(ttl),
+      clear: clear,
+      position: position,
+      authorityProof: proof,
+    );
+  }
+
+  Future<bool> verifyAuthenticatedPresence(
+    RelayPresenceUpdate update,
+    DateTime trustedNow,
+  ) async {
+    final activeSession = _session;
+    if (activeSession == null) return false;
+    if (!activeSession.usesDeviceAuthority) {
+      return update.authorityProof == null;
+    }
+    final proof = update.authorityProof;
+    final policy = _deviceAuthorityPolicy;
+    if (proof == null ||
+        policy == null ||
+        !policy.authorizesDeviceKey(update.riderId, proof.devicePublicKey)) {
+      return false;
+    }
+    return PresenceAuthenticator.verify(
+      rideId: activeSession.rideId,
+      riderId: update.riderId,
+      position: update.position,
+      clear: update.clear,
+      proof: proof,
+      now: trustedNow,
+    );
+  }
+
+  Future<RideEvent> _record({
+    required RideEventType type,
+    required Map<String, Object?> payload,
+    EventPriority priority = EventPriority.routine,
+    DateTime? expiresAt,
+  }) async {
+    final event = await createAuthenticatedEvent(
+      type: type,
+      payload: payload,
+      priority: priority,
+      expiresAt: expiresAt,
     );
     await _eventStore.append(event);
     _acceptStoredEvent(event, notify: false);
@@ -2452,6 +2717,10 @@ class RideController extends ChangeNotifier {
     final now = _clock();
     final normalisedRideName = rideName?.trim();
     final rideId = _idFactory();
+    final identityManager = _deviceIdentityManager;
+    final identity = identityManager == null
+        ? null
+        : await identityManager.loadOrCreate(rideId);
     final balloonCraftId = _craftIdFor(
       rideId: rideId,
       kind: CraftKind.balloon,
@@ -2462,7 +2731,10 @@ class RideController extends ChangeNotifier {
       rideCode: _generateCode(),
       inviteSecret: _generateInviteSecret(),
       joinToken: _generateJoinToken(),
-      localRiderId: _localRiderIdForRide(rideId),
+      localRiderId: identity?.deviceId ?? _localRiderIdForRide(rideId),
+      authorizationVersion: identity == null ? 1 : 2,
+      authorityRootPublicKey: identity?.publicKey,
+      localDevicePublicKey: identity?.publicKey,
       displayName: normalisedDisplayName,
       role: RideRole.lead,
       flightRole: FlightRole.pilot,
@@ -2561,7 +2833,7 @@ class RideController extends ChangeNotifier {
       _errorMessage = 'That action could not be saved. Please try again.';
       _errorIsRetryable = true;
       if (kDebugMode) {
-        debugPrint('Flight action failed: $error\n$stackTrace');
+        debugPrint('Flight action failed (${error.runtimeType})\n$stackTrace');
       }
     } finally {
       _busy = false;
@@ -2722,7 +2994,8 @@ class RideController extends ChangeNotifier {
       _rideArchiveError = rideArchiveFailedMessage;
       if (kDebugMode) {
         debugPrint(
-          'Could not archive the completed flight: $error\n$stackTrace',
+          'Could not archive the completed flight (${error.runtimeType})\n'
+          '$stackTrace',
         );
       }
     }
@@ -2768,6 +3041,7 @@ class RideController extends ChangeNotifier {
     _endedRideSetAside = false;
     final rideId = _requireSession().rideId;
     if (deleteEvents) await _eventStore.deleteRide(rideId);
+    await _deviceIdentityManager?.delete(rideId);
     await _sessionStore.clear();
     _session = null;
     _replaceEvents(const []);
@@ -2782,7 +3056,15 @@ class RideController extends ChangeNotifier {
   }
 
   void _replaceEvents(Iterable<RideEvent> events) {
-    _events = events.toList(growable: true);
+    final session = _session;
+    if (session?.usesDeviceAuthority ?? false) {
+      final policy = DeviceAuthorityPolicy(session!);
+      _events = policy.filter(events).toList(growable: true);
+      _deviceAuthorityPolicy = policy;
+    } else {
+      _events = events.toList(growable: true);
+      _deviceAuthorityPolicy = null;
+    }
     _eventIds
       ..clear()
       ..addAll(_events.map((event) => event.id));
@@ -2791,6 +3073,24 @@ class RideController extends ChangeNotifier {
     _flightLandingDirty = true;
     _operationalBoundaryDirty = true;
     _applyLocalPilotAuthorityFromEvents();
+  }
+
+  Future<void> _replaceAuthenticatedEvents(Iterable<RideEvent> events) async {
+    final session = _requireSession();
+    final accepted = <RideEvent>[];
+    for (final event in events) {
+      final compatibleSchema = session.usesDeviceAuthority
+          ? event.schemaVersion == 2
+          : event.schemaVersion == 1;
+      if (compatibleSchema &&
+          await RideEventAuthenticator.verifyAsync(
+            event,
+            session.inviteSecret,
+          )) {
+        accepted.add(event);
+      }
+    }
+    _replaceEvents(accepted);
   }
 
   void _applyLocalPilotAuthorityFromEvents() {

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -11,7 +11,16 @@ import '../domain/rider_location.dart';
 import '../relay/live_presence.dart';
 import '../services/external_hazard_provider.dart';
 import '../services/hazard_deduplicator.dart';
+import '../services/ride_event_authenticator.dart';
 import '../services/situation_event_factory.dart';
+
+typedef AuthenticatedSituationEventFactory =
+    Future<RideEvent> Function({
+      required RideEventType type,
+      required Map<String, Object?> payload,
+      EventPriority priority,
+      DateTime? expiresAt,
+    });
 
 class SituationalAwarenessController extends ChangeNotifier {
   SituationalAwarenessController(
@@ -28,6 +37,7 @@ class SituationalAwarenessController extends ChangeNotifier {
     this.deduplicator = const HazardDeduplicator(),
     this.freshnessPolicy = const PresenceFreshnessPolicy(),
     this.onEventStored,
+    this.authenticatedEventFactory,
   }) : _route = List.unmodifiable(route),
        _externalProviders = List.unmodifiable(externalProviders),
        _clock = clock ?? DateTime.now,
@@ -68,6 +78,7 @@ class SituationalAwarenessController extends ChangeNotifier {
   /// at a time instead of re-reading the complete SQLite ride after every
   /// position fix (#165).
   final ValueChanged<RideEvent>? onEventStored;
+  final AuthenticatedSituationEventFactory? authenticatedEventFactory;
   late SituationEventFactory _eventFactory;
 
   final Map<String, RiderLocation> _locations = {};
@@ -224,7 +235,7 @@ class SituationalAwarenessController extends ChangeNotifier {
     );
     await _run(() async {
       await _appendAndApply(
-        _eventFactory.create(
+        await _createEvent(
           type: RideEventType.riderLocationUpdated,
           payload: {'location': location.toJson()},
           expiresAt: _clock().add(const Duration(minutes: 30)),
@@ -272,7 +283,7 @@ class SituationalAwarenessController extends ChangeNotifier {
               ),
       );
       result = deduplicator.mergeOrAdd(incoming, activeHazards);
-      final event = _eventFactory.create(
+      final event = await _createEvent(
         type: RideEventType.hazardReported,
         payload: {'hazard': result!.toJson()},
         priority: _priorityForSeverity(result!.severity),
@@ -288,7 +299,7 @@ class SituationalAwarenessController extends ChangeNotifier {
       return;
     }
     await _run(() async {
-      final event = _eventFactory.create(
+      final event = await _createEvent(
         type: RideEventType.hazardCleared,
         payload: {'hazardId': hazardId, 'reason': reason},
         priority: EventPriority.important,
@@ -303,7 +314,10 @@ class SituationalAwarenessController extends ChangeNotifier {
         !_supportedSituationalEventTypes.contains(event.type)) {
       throw const FormatException('Event is not valid for this flight.');
     }
-    if (!SituationEventFactory.verify(event, _session.inviteSecret)) {
+    if (!await RideEventAuthenticator.verifyAsync(
+      event,
+      _session.inviteSecret,
+    )) {
       throw const FormatException('Event signature is invalid.');
     }
     await _eventStore.append(event);
@@ -342,7 +356,7 @@ class SituationalAwarenessController extends ChangeNotifier {
                   existingProviderIncident?.providerId == provider.id
               ? hazard
               : deduplicator.mergeOrAdd(hazard, activeHazards);
-          final event = _eventFactory.create(
+          final event = await _createEvent(
             type: RideEventType.hazardReported,
             payload: {'hazard': merged.toJson()},
             priority: _priorityForSeverity(merged.severity),
@@ -376,6 +390,31 @@ class SituationalAwarenessController extends ChangeNotifier {
     if (_disposed) return;
     _applyEvent(event);
     onEventStored?.call(event);
+  }
+
+  Future<RideEvent> _createEvent({
+    required RideEventType type,
+    required Map<String, Object?> payload,
+    EventPriority priority = EventPriority.routine,
+    DateTime? expiresAt,
+  }) {
+    final authenticated = authenticatedEventFactory;
+    if (authenticated != null) {
+      return authenticated(
+        type: type,
+        payload: payload,
+        priority: priority,
+        expiresAt: expiresAt,
+      );
+    }
+    return Future.value(
+      _eventFactory.create(
+        type: type,
+        payload: payload,
+        priority: priority,
+        expiresAt: expiresAt,
+      ),
+    );
   }
 
   void _applyEvent(RideEvent event, {bool replaying = false}) {
@@ -431,6 +470,8 @@ class SituationalAwarenessController extends ChangeNotifier {
       case RideEventType.flightStartedByCrew:
       case RideEventType.flightLanded:
       case RideEventType.flightLandingRetracted:
+      case RideEventType.deviceAuthorityRevoked:
+      case RideEventType.deviceAuthorityRotated:
       case RideEventType.statusMessage:
       case RideEventType.ridePaused:
       case RideEventType.rideResumed:
@@ -547,7 +588,9 @@ class SituationalAwarenessController extends ChangeNotifier {
     } on Object catch (error, stackTrace) {
       _errorMessage = 'Situational awareness could not be updated.';
       if (kDebugMode) {
-        debugPrint('Situational awareness failed: $error\n$stackTrace');
+        debugPrint(
+          'Situational awareness failed (${error.runtimeType})\n$stackTrace',
+        );
       }
     } finally {
       _busy = false;

--- a/apps/mobile/lib/data/in_memory_device_identity_store.dart
+++ b/apps/mobile/lib/data/in_memory_device_identity_store.dart
@@ -1,0 +1,24 @@
+import '../domain/device_identity_store.dart';
+
+class InMemoryDeviceIdentityStore implements DeviceIdentityStore {
+  final Map<String, List<int>> _seeds = {};
+
+  @override
+  Future<void> delete(String rideId) async {
+    final removed = _seeds.remove(rideId);
+    if (removed != null) {
+      removed.fillRange(0, removed.length, 0);
+    }
+  }
+
+  @override
+  Future<List<int>?> readSeed(String rideId) async {
+    final seed = _seeds[rideId];
+    return seed == null ? null : List<int>.of(seed);
+  }
+
+  @override
+  Future<void> writeSeed(String rideId, List<int> seed) async {
+    _seeds[rideId] = List<int>.of(seed);
+  }
+}

--- a/apps/mobile/lib/data/ride_diagnostics_log_store.dart
+++ b/apps/mobile/lib/data/ride_diagnostics_log_store.dart
@@ -56,20 +56,23 @@ class RideDiagnosticsLog {
 
   final String rideId;
 
-  /// The ride's short code, read back out of the log's own header, or null if the
-  /// log was written without one. Read rather than stored alongside so there is
-  /// no second copy to fall out of step.
+  /// Retained as a compatibility field for old settings UI. New and migrated
+  /// logs always return null because a reusable flight code is a credential.
   final String? rideCode;
 
   final DateTime writtenAt;
   final String text;
 
   /// What the share sheet calls the attachment.
-  String get fileName => 'balloon-crumbs-diagnostics-${rideCode ?? rideId}.txt';
+  String get fileName => 'balloon-crumbs-diagnostics-$rideId.txt';
 
-  /// Parses the `Ride:` line the recorder's header writes.
-  static String? rideCodeIn(String text) =>
-      _headerValue(text, 'Flight:') ?? _headerValue(text, 'Ride:');
+  /// Legacy compatibility parser. Flight-code headers are no longer retained.
+  static String? rideCodeIn(String text) => null;
+
+  static String withoutCredentialHeader(String text) => text
+      .split('\n')
+      .where((line) => !line.startsWith('Flight:') && !line.startsWith('Ride:'))
+      .join('\n');
 
   /// Parses the `Written:` line the recorder's header writes.
   ///
@@ -85,8 +88,7 @@ class RideDiagnosticsLog {
   }
 
   static String? _headerValue(String text, String label) {
-    // Bounded to the header: a `Ride:` inside a recorded entry is not the ride
-    // code, and a whole log can be thousands of lines.
+    // Bounded to the header because a whole log can be thousands of lines.
     for (final line in text.split('\n').take(8)) {
       if (!line.startsWith(label)) continue;
       final value = line.substring(label.length).trim();
@@ -123,7 +125,10 @@ class FileRideDiagnosticsLogStore implements RideDiagnosticsLogStore {
     // previous log rather than a truncated one. Same reason the route stores do
     // it.
     final temporary = File('${file.path}.tmp');
-    await temporary.writeAsString(text, flush: true);
+    await temporary.writeAsString(
+      RideDiagnosticsLog.withoutCredentialHeader(text),
+      flush: true,
+    );
     if (await file.exists()) await file.delete();
     await temporary.rename(file.path);
     await _prune();
@@ -133,7 +138,10 @@ class FileRideDiagnosticsLogStore implements RideDiagnosticsLogStore {
   Future<String?> read(String rideId) async {
     final file = _fileFor(rideId);
     if (!await file.exists()) return null;
-    return file.readAsString();
+    final storedText = await file.readAsString();
+    final text = RideDiagnosticsLog.withoutCredentialHeader(storedText);
+    if (text != storedText) await file.writeAsString(text, flush: true);
+    return text;
   }
 
   @override
@@ -143,7 +151,9 @@ class FileRideDiagnosticsLogStore implements RideDiagnosticsLogStore {
     await for (final entity in directory.list()) {
       if (entity is! File || !entity.path.endsWith('.txt')) continue;
       try {
-        final text = await entity.readAsString();
+        final storedText = await entity.readAsString();
+        final text = RideDiagnosticsLog.withoutCredentialHeader(storedText);
+        if (text != storedText) await entity.writeAsString(text, flush: true);
         logs.add(
           RideDiagnosticsLog(
             rideId: path.basenameWithoutExtension(entity.path),
@@ -198,11 +208,12 @@ class InMemoryRideDiagnosticsLogStore implements RideDiagnosticsLogStore {
 
   @override
   Future<void> write({required String rideId, required String text}) async {
+    final safeText = RideDiagnosticsLog.withoutCredentialHeader(text);
     _logs[rideId] = RideDiagnosticsLog(
       rideId: rideId,
-      rideCode: RideDiagnosticsLog.rideCodeIn(text),
-      writtenAt: RideDiagnosticsLog.writtenAtIn(text) ?? _clock(),
-      text: text,
+      rideCode: null,
+      writtenAt: RideDiagnosticsLog.writtenAtIn(safeText) ?? _clock(),
+      text: safeText,
     );
   }
 

--- a/apps/mobile/lib/data/secure_device_identity_store.dart
+++ b/apps/mobile/lib/data/secure_device_identity_store.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../domain/device_identity_store.dart';
+
+class SecureDeviceIdentityStore implements DeviceIdentityStore {
+  const SecureDeviceIdentityStore({FlutterSecureStorage? storage})
+    : _storage = storage ?? const FlutterSecureStorage();
+
+  static const _prefix = 'balloon_crumbs_device_signing_seed_v1_';
+  final FlutterSecureStorage _storage;
+
+  String _key(String rideId) =>
+      '$_prefix${sha256.convert(utf8.encode(rideId)).toString()}';
+
+  @override
+  Future<void> delete(String rideId) => _storage.delete(key: _key(rideId));
+
+  @override
+  Future<List<int>?> readSeed(String rideId) async {
+    final encoded = await _storage.read(key: _key(rideId));
+    if (encoded == null) return null;
+    try {
+      final seed = base64Url.decode(base64Url.normalize(encoded));
+      return seed.length == 32 ? seed : null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> writeSeed(String rideId, List<int> seed) {
+    if (seed.length != 32) {
+      throw ArgumentError.value(seed.length, 'seed', 'Must contain 32 bytes');
+    }
+    return _storage.write(
+      key: _key(rideId),
+      value: base64Url.encode(seed).replaceAll('=', ''),
+    );
+  }
+}

--- a/apps/mobile/lib/domain/crew_room.dart
+++ b/apps/mobile/lib/domain/crew_room.dart
@@ -6,18 +6,22 @@ class CrewRoomOperation {
     required this.rideCode,
     required this.inviteSecret,
     required this.joinToken,
+    this.authorityRootPublicKey,
   });
 
   final String rideId;
   final String rideCode;
   final String inviteSecret;
   final String joinToken;
+  final String? authorityRootPublicKey;
 
   Map<String, Object?> toJson() => {
     'rideId': rideId,
     'rideCode': rideCode,
     'inviteSecret': inviteSecret,
     'resolveToken': joinToken,
+    if (authorityRootPublicKey != null)
+      'authorityRootPublicKey': authorityRootPublicKey,
   };
 
   factory CrewRoomOperation.fromJson(Map<String, Object?> json) {
@@ -25,6 +29,7 @@ class CrewRoomOperation {
     final rideCode = json['rideCode'];
     final inviteSecret = json['inviteSecret'];
     final joinToken = json['resolveToken'];
+    final authorityRootPublicKey = json['authorityRootPublicKey'];
     if (rideId is! String ||
         rideId.isEmpty ||
         rideCode is! String ||
@@ -32,7 +37,12 @@ class CrewRoomOperation {
         inviteSecret is! String ||
         inviteSecret.length < 16 ||
         joinToken is! String ||
-        joinToken.length < 16) {
+        joinToken.length < 16 ||
+        (authorityRootPublicKey != null &&
+            (authorityRootPublicKey is! String ||
+                !RegExp(
+                  r'^[A-Za-z0-9_-]{43}$',
+                ).hasMatch(authorityRootPublicKey)))) {
       throw const FormatException('Crew room operation is invalid.');
     }
     return CrewRoomOperation(
@@ -40,6 +50,7 @@ class CrewRoomOperation {
       rideCode: rideCode,
       inviteSecret: inviteSecret,
       joinToken: joinToken,
+      authorityRootPublicKey: authorityRootPublicKey as String?,
     );
   }
 }

--- a/apps/mobile/lib/domain/device_identity_store.dart
+++ b/apps/mobile/lib/domain/device_identity_store.dart
@@ -1,0 +1,7 @@
+abstract interface class DeviceIdentityStore {
+  Future<void> delete(String rideId);
+
+  Future<List<int>?> readSeed(String rideId);
+
+  Future<void> writeSeed(String rideId, List<int> seed);
+}

--- a/apps/mobile/lib/domain/landing_zone.dart
+++ b/apps/mobile/lib/domain/landing_zone.dart
@@ -124,6 +124,8 @@ class LandingZoneReducer {
         case RideEventType.flightStartedByCrew:
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/domain/operational_boundary.dart
+++ b/apps/mobile/lib/domain/operational_boundary.dart
@@ -173,6 +173,8 @@ class OperationalBoundaryReducer {
         case RideEventType.flightStartedByCrew:
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/domain/ride_event.dart
+++ b/apps/mobile/lib/domain/ride_event.dart
@@ -121,6 +121,16 @@ enum RideEventType {
   /// Naming the event prevents a late offline retraction from undoing a newer
   /// landing declaration.
   flightLandingRetracted,
+
+  /// The current pilot revokes one device's operation-scoped signing identity.
+  /// Later events from that identity are ignored even when they still possess
+  /// the shared transport credential.
+  deviceAuthorityRevoked,
+
+  /// A device replaces its operation-scoped signing key. The event is signed by
+  /// the old key and carries a proof made by the replacement key, preventing a
+  /// relay or another invite holder from substituting a key of their own.
+  deviceAuthorityRotated,
 }
 
 enum EventPriority { routine, important, critical }
@@ -135,6 +145,8 @@ class RideEvent {
     required this.createdAt,
     required this.payload,
     required this.signature,
+    this.devicePublicKey,
+    this.deviceSignature,
     this.expiresAt,
     this.acknowledged = false,
     this.schemaVersion = 1,
@@ -149,10 +161,12 @@ class RideEvent {
   final DateTime? expiresAt;
   final Map<String, Object?> payload;
   final String signature;
+  final String? devicePublicKey;
+  final String? deviceSignature;
   final bool acknowledged;
   final int schemaVersion;
 
-  RideEvent copyWith({bool? acknowledged}) => RideEvent(
+  RideEvent copyWith({bool? acknowledged, String? signature}) => RideEvent(
     id: id,
     rideId: rideId,
     deviceId: deviceId,
@@ -161,7 +175,9 @@ class RideEvent {
     createdAt: createdAt,
     expiresAt: expiresAt,
     payload: payload,
-    signature: signature,
+    signature: signature ?? this.signature,
+    devicePublicKey: devicePublicKey,
+    deviceSignature: deviceSignature,
     acknowledged: acknowledged ?? this.acknowledged,
     schemaVersion: schemaVersion,
   );
@@ -177,6 +193,8 @@ class RideEvent {
     'expiresAt': expiresAt?.toUtc().toIso8601String(),
     'payload': payload,
     'signature': signature,
+    if (devicePublicKey != null) 'devicePublicKey': devicePublicKey,
+    if (deviceSignature != null) 'deviceSignature': deviceSignature,
     'acknowledged': acknowledged,
   };
 
@@ -192,13 +210,15 @@ class RideEvent {
       'expiresAt',
       'payload',
       'signature',
+      'devicePublicKey',
+      'deviceSignature',
       'acknowledged',
     };
     if (json.keys.any((key) => !allowedKeys.contains(key))) {
       throw const FormatException('Event contains an unsupported field.');
     }
     final schemaVersion = _integer(json['schemaVersion'], 'schemaVersion');
-    if (schemaVersion != 1) {
+    if (schemaVersion != 1 && schemaVersion != 2) {
       throw const FormatException('Unsupported event schema version.');
     }
     final type = _enumValue(
@@ -228,6 +248,21 @@ class RideEvent {
     if (acknowledged != null && acknowledged is! bool) {
       throw const FormatException('Event acknowledgement is invalid.');
     }
+    final devicePublicKey = json['devicePublicKey'];
+    final deviceSignature = json['deviceSignature'];
+    if (schemaVersion == 2 &&
+        (devicePublicKey is! String ||
+            !_devicePublicKeyPattern.hasMatch(devicePublicKey) ||
+            deviceSignature is! String ||
+            !_deviceSignaturePattern.hasMatch(deviceSignature))) {
+      throw const FormatException('Event device authority is invalid.');
+    }
+    if (schemaVersion == 1 &&
+        (devicePublicKey != null || deviceSignature != null)) {
+      throw const FormatException(
+        'Legacy event cannot carry device authority.',
+      );
+    }
     return RideEvent(
       schemaVersion: schemaVersion,
       id: _string(json['id'], 'id', maximumLength: 128),
@@ -242,6 +277,8 @@ class RideEvent {
       },
       payload: payload,
       signature: _signature(json['signature']),
+      devicePublicKey: devicePublicKey as String?,
+      deviceSignature: deviceSignature as String?,
       acknowledged: acknowledged as bool? ?? false,
     );
   }
@@ -250,6 +287,8 @@ class RideEvent {
   static const _maximumJsonDepth = 16;
   static const _maximumCollectionEntries = 128;
   static final _signaturePattern = RegExp(r'^[0-9a-f]{64}$');
+  static final _devicePublicKeyPattern = RegExp(r'^[A-Za-z0-9_-]{43}$');
+  static final _deviceSignaturePattern = RegExp(r'^[A-Za-z0-9_-]{86}$');
 
   static String _string(
     Object? value,

--- a/apps/mobile/lib/domain/ride_join_payload.dart
+++ b/apps/mobile/lib/domain/ride_join_payload.dart
@@ -7,7 +7,8 @@
 /// no signal cannot form a ride at all, which is precisely the situation this
 /// product exists for.
 ///
-/// A QR code has room for all three, so scanning one needs no network.
+/// A QR code has room for the relay fields and (for current invitations) the
+/// authority root key, so scanning one needs no network.
 ///
 /// ## Why not a URL
 ///
@@ -29,6 +30,7 @@ class RideJoinPayload {
     required this.rideCode,
     required this.inviteSecret,
     required this.joinToken,
+    this.authorityRootPublicKey,
     this.crewRoomId,
     this.crewRoomAlias,
     this.crewRoomInviteToken,
@@ -37,36 +39,41 @@ class RideJoinPayload {
   /// Version prefix, so a payload from a future format is **rejected** rather
   /// than half-understood. A wrong join is worse than a refused one: a rider who
   /// silently ends up in a degraded session has no way to tell.
-  static const scheme = 'bc1';
+  static const scheme = 'bc2';
 
   /// The same format under its old name.
   ///
   /// This was `tec1` when the app was Tail End Charlie. Accepting it is not the
-  /// half-understanding the paragraph above refuses: the five fields and their
+  /// half-understanding the paragraph above refuses: the legacy fields and their
   /// bounds are byte-identical, so only the label differs, and every check below
   /// still runs. An invitation already printed on a QR code, or sitting in a
   /// message from an older build, still joins.
   ///
   /// New payloads are written as [scheme]. This can go once no build old enough
   /// to have written `tec1` is still installed anywhere.
-  static const legacyScheme = 'tec1';
+  static const legacyScheme = 'bc1';
+  static const inheritedScheme = 'tec1';
 
-  /// Colon-separated because none of the four fields can contain a colon: the
-  /// code is six digits, the id is a UUID, and both secrets are base64url, whose
-  /// alphabet is `A-Za-z0-9-_`. So splitting cannot be ambiguous, and no escaping
-  /// is needed to keep the payload short.
+  /// Colon-separated because none of the fields can contain a colon: identifiers
+  /// and aliases are bounded tokens, while secrets and public keys are base64url,
+  /// whose alphabet is `A-Za-z0-9-_`. So splitting cannot be ambiguous, and no
+  /// escaping is needed to keep the payload short.
   static const _separator = ':';
 
   final String rideId;
   final String rideCode;
   final String inviteSecret;
   final String joinToken;
+  final String? authorityRootPublicKey;
   final String? crewRoomId;
   final String? crewRoomAlias;
   final String? crewRoomInviteToken;
 
   String encode() {
-    final base = [scheme, rideCode, rideId, inviteSecret, joinToken];
+    final rootKey = authorityRootPublicKey;
+    final base = rootKey == null
+        ? [legacyScheme, rideCode, rideId, inviteSecret, joinToken]
+        : [scheme, rideCode, rideId, inviteSecret, joinToken, rootKey];
     if (crewRoomId == null ||
         crewRoomAlias == null ||
         crewRoomInviteToken == null) {
@@ -88,8 +95,13 @@ class RideJoinPayload {
   /// from a camera - anyone can print one.
   static RideJoinPayload decode(String raw) {
     final parts = raw.trim().split(_separator);
-    if ((parts.length != 5 && parts.length != 8) ||
-        (parts.first != scheme && parts.first != legacyScheme)) {
+    final isCurrent = parts.firstOrNull == scheme;
+    final isLegacy =
+        parts.firstOrNull == legacyScheme ||
+        parts.firstOrNull == inheritedScheme;
+    if ((!isCurrent && !isLegacy) ||
+        (isCurrent && parts.length != 6 && parts.length != 9) ||
+        (isLegacy && parts.length != 5 && parts.length != 8)) {
       throw const FormatException(
         'That code is not a Balloon Crumbs flight invitation.',
       );
@@ -98,6 +110,7 @@ class RideJoinPayload {
     final rideId = parts[2];
     final inviteSecret = parts[3];
     final joinToken = parts[4];
+    final authorityRootPublicKey = isCurrent ? parts[5] : null;
 
     if (!RegExp(r'^\d{6}$').hasMatch(rideCode)) {
       throw const FormatException('That invitation has no valid flight code.');
@@ -119,13 +132,20 @@ class RideJoinPayload {
         'That invitation is incomplete and cannot join securely.',
       );
     }
+    if (isCurrent &&
+        !RegExp(r'^[A-Za-z0-9_-]{43}$').hasMatch(authorityRootPublicKey!)) {
+      throw const FormatException(
+        'That invitation has no valid device authority.',
+      );
+    }
     String? crewRoomId;
     String? crewRoomAlias;
     String? crewRoomInviteToken;
-    if (parts.length == 8) {
-      crewRoomId = parts[5];
-      crewRoomAlias = parts[6];
-      crewRoomInviteToken = parts[7];
+    if (parts.length == 8 || parts.length == 9) {
+      final offset = isCurrent ? 1 : 0;
+      crewRoomId = parts[5 + offset];
+      crewRoomAlias = parts[6 + offset];
+      crewRoomInviteToken = parts[7 + offset];
       if (crewRoomId.isEmpty || crewRoomId.length > 128) {
         throw const FormatException('That invitation has no valid crew room.');
       }
@@ -145,6 +165,7 @@ class RideJoinPayload {
       rideCode: rideCode,
       inviteSecret: inviteSecret,
       joinToken: joinToken,
+      authorityRootPublicKey: authorityRootPublicKey,
       crewRoomId: crewRoomId,
       crewRoomAlias: crewRoomAlias,
       crewRoomInviteToken: crewRoomInviteToken,

--- a/apps/mobile/lib/domain/ride_session.dart
+++ b/apps/mobile/lib/domain/ride_session.dart
@@ -32,6 +32,9 @@ class RideSession {
     this.coordinationMode = RideCoordinationMode.keepTogether,
     this.rideName,
     this.crewRoomId,
+    this.authorizationVersion = 1,
+    this.authorityRootPublicKey,
+    this.localDevicePublicKey,
   }) : flightRole =
            flightRole ??
            (role == RideRole.lead ? FlightRole.pilot : FlightRole.chaseCrew),
@@ -51,6 +54,18 @@ class RideSession {
   /// carried in the "Share" text and a smart-paste, never displayed on its
   /// own - the six digits remain what a rider reads or types.
   final String joinToken;
+
+  /// Version one trusts only the shared flight HMAC and is retained solely for
+  /// local development-alpha recovery. Version two additionally binds every
+  /// accepted event to an operation-scoped device signing key.
+  final int authorizationVersion;
+  final String? authorityRootPublicKey;
+  final String? localDevicePublicKey;
+
+  bool get usesDeviceAuthority =>
+      authorizationVersion >= 2 &&
+      authorityRootPublicKey != null &&
+      localDevicePublicKey != null;
   final String localRiderId;
   final String displayName;
   final RideRole role;
@@ -93,11 +108,18 @@ class RideSession {
     CraftIconStyle? craftStyle,
     RideCoordinationMode? coordinationMode,
     String? crewRoomId,
+    int? authorizationVersion,
+    String? authorityRootPublicKey,
+    String? localDevicePublicKey,
   }) => RideSession(
     rideId: rideId,
     rideCode: rideCode ?? this.rideCode,
     inviteSecret: inviteSecret,
     joinToken: joinToken,
+    authorizationVersion: authorizationVersion ?? this.authorizationVersion,
+    authorityRootPublicKey:
+        authorityRootPublicKey ?? this.authorityRootPublicKey,
+    localDevicePublicKey: localDevicePublicKey ?? this.localDevicePublicKey,
     localRiderId: localRiderId,
     displayName: displayName,
     role: role ?? this.role,
@@ -121,6 +143,11 @@ class RideSession {
     'rideCode': rideCode,
     'inviteSecret': inviteSecret,
     'joinToken': joinToken,
+    if (authorizationVersion >= 2) 'authorizationVersion': authorizationVersion,
+    if (authorityRootPublicKey != null)
+      'authorityRootPublicKey': authorityRootPublicKey,
+    if (localDevicePublicKey != null)
+      'localDevicePublicKey': localDevicePublicKey,
     'localRiderId': localRiderId,
     'displayName': displayName,
     'role': role.name,
@@ -149,6 +176,9 @@ class RideSession {
       rideCode: json['rideCode']! as String,
       inviteSecret: json['inviteSecret']! as String,
       joinToken: _joinTokenOrFallback(json['joinToken']),
+      authorizationVersion: json['authorizationVersion'] as int? ?? 1,
+      authorityRootPublicKey: json['authorityRootPublicKey'] as String?,
+      localDevicePublicKey: json['localDevicePublicKey'] as String?,
       localRiderId: json['localRiderId']! as String,
       displayName: json['displayName']! as String,
       role: rideRoleFromName(json['role']),

--- a/apps/mobile/lib/features/map/resolved_route_map_preview.dart
+++ b/apps/mobile/lib/features/map/resolved_route_map_preview.dart
@@ -414,7 +414,11 @@ class _ResolvedRouteMapPreviewState extends State<ResolvedRouteMapPreview> {
       // rather than wherever the camera started (#157).
       widget.onStyleReady?.call();
     } on Object catch (error) {
-      if (kDebugMode) debugPrint('Could not prepare route preview map: $error');
+      if (kDebugMode) {
+        debugPrint(
+          'Could not prepare route preview map (${error.runtimeType})',
+        );
+      }
     }
   }
 
@@ -439,7 +443,11 @@ class _ResolvedRouteMapPreviewState extends State<ResolvedRouteMapPreview> {
       await controller.setGeoJsonSource(_pinSource, _pinGeoJson());
       if (fit) await _fit();
     } on Object catch (error) {
-      if (kDebugMode) debugPrint('Could not refresh route preview map: $error');
+      if (kDebugMode) {
+        debugPrint(
+          'Could not refresh route preview map (${error.runtimeType})',
+        );
+      }
     } finally {
       _syncing = false;
       if (_syncAgain) {

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -3108,9 +3108,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
               commanded.target,
             );
       debugPrint(
-        'Flight map camera: centre=${camera.target.latitude.toStringAsFixed(6)},'
-        '${camera.target.longitude.toStringAsFixed(6)} '
-        'zoom=${camera.zoom.toStringAsFixed(2)} '
+        'Flight map camera: zoom=${camera.zoom.toStringAsFixed(2)} '
         'follow=$_navigationMode '
         'commanded=${commanded != null} '
         'drift=${drift?.toStringAsFixed(1) ?? 'n/a'}m '
@@ -3670,7 +3668,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _navigationGuidance.value = next;
       widget.onNavigationGuidanceChanged?.call(next.guidance);
       if (stateChanged && kDebugMode) {
-        debugPrint('Navigation guidance: ${next.state.name} — ${next.message}');
+        debugPrint('Navigation guidance state: ${next.state.name}');
       }
       if ((visibilityChanged || stateChanged) && mounted) setState(() {});
     }
@@ -4819,7 +4817,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
     } on Object catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint(
-          'Could not prepare MapLibre flight layers: $error\n$stackTrace',
+          'Could not prepare MapLibre flight layers (${error.runtimeType})\n'
+          '$stackTrace',
         );
       }
     }
@@ -4902,7 +4901,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
       await controller.setGeoJsonSource(_overlaySource, _overlayGeoJson());
     } on Object catch (error) {
       if (kDebugMode) {
-        debugPrint('Could not refresh MapLibre flight layers: $error');
+        debugPrint(
+          'Could not refresh MapLibre flight layers (${error.runtimeType})',
+        );
       }
     }
   }
@@ -4965,7 +4966,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
       }
     } on Object catch (error) {
       if (kDebugMode) {
-        debugPrint('Could not refresh scheduled MapLibre layers: $error');
+        debugPrint(
+          'Could not refresh scheduled MapLibre layers (${error.runtimeType})',
+        );
       }
     } finally {
       _mapLibreSyncRunning = false;
@@ -6201,7 +6204,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
         'Registered-property extents are unavailable. The road map and private '
         'access notes are unaffected.',
       );
-      debugPrint('Could not load HMLR INSPIRE reference: $error');
+      debugPrint(
+        'Could not load HMLR INSPIRE reference (${error.runtimeType})',
+      );
     }
   }
 
@@ -6288,7 +6293,9 @@ class _RideMapScreenState extends State<RideMapScreen> {
       _showMessage(
         'OS detail could not be drawn. The ordinary road map remains active.',
       );
-      debugPrint('Could not change OS final-approach layer: $error');
+      debugPrint(
+        'Could not change OS final-approach layer (${error.runtimeType})',
+      );
     }
   }
 
@@ -6363,7 +6370,7 @@ class _RideMapScreenState extends State<RideMapScreen> {
       if (!mounted || !_osFinalApproachSelected) return;
       setState(() => _osFinalApproachSelected = false);
       _showMessage('OS detail was lost. The ordinary road map remains active.');
-      debugPrint('OS final-approach tile failed: $error');
+      debugPrint('OS final-approach tile failed (${error.runtimeType})');
     });
   }
 
@@ -7958,7 +7965,7 @@ class _GroupMiniMapState extends State<_GroupMiniMap> {
       await _fitGroup(snapshot);
     } on Object catch (error) {
       if (kDebugMode) {
-        debugPrint('Could not prepare group mini-map: $error');
+        debugPrint('Could not prepare group mini-map (${error.runtimeType})');
       }
     }
   }
@@ -7993,7 +8000,7 @@ class _GroupMiniMapState extends State<_GroupMiniMap> {
       } while (_refreshRequestedWhileBusy && mounted);
     } on Object catch (error) {
       if (kDebugMode) {
-        debugPrint('Could not refresh group mini-map: $error');
+        debugPrint('Could not refresh group mini-map (${error.runtimeType})');
       }
     } finally {
       _refreshing = false;

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -1631,7 +1631,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       reassertInterval: widget.screenWakeReassertInterval,
       onError: (error, _) {
         if (kDebugMode) {
-          debugPrint('Could not enforce flight wake lock: $error');
+          debugPrint(
+            'Could not enforce flight wake lock (${error.runtimeType})',
+          );
         }
       },
     )..start();
@@ -2003,7 +2005,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
           if (kDebugMode) {
             debugPrint(
               'Could not persist a location update; continuing: '
-              '$error\n$stackTrace',
+              '${error.runtimeType}\n$stackTrace',
             );
           }
           final added = _warnings.add(
@@ -2091,6 +2093,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             HttpPreStartPresenceClient(
               configuration: InternetRelayConfiguration.fromEnvironment(),
               client: http.Client(),
+              presenceFactory:
+                  widget.rideController.createAuthenticatedPresence,
+              presenceVerifier:
+                  widget.rideController.verifyAuthenticatedPresence,
             ),
           );
           _preStartPresenceController = preStartPresenceController;
@@ -2110,6 +2116,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             eventStore: widget.eventStore,
             queue: SqliteRelayQueue(),
           ),
+          presenceFactory: widget.rideController.createAuthenticatedPresence,
+          presenceVerifier: widget.rideController.verifyAuthenticatedPresence,
         );
         _relayController = relayController;
         _receivedEventSubscription = relayController.receivedEvents.listen(
@@ -2369,6 +2377,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       rideStarted: widget.rideController.rideStarted,
       rideStartedAt: widget.rideController.rideStartedAt,
       onEventStored: widget.rideController.ingestStoredEvent,
+      authenticatedEventFactory: widget.rideController.createAuthenticatedEvent,
     );
     await controller.initialize(restoredEvents: widget.rideController.events);
     if (!mounted || generation != _routeGeneration) {
@@ -3567,7 +3576,10 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       }
     } catch (error, stackTrace) {
       if (kDebugMode) {
-        debugPrint('Could not end the completed flight: $error\n$stackTrace');
+        debugPrint(
+          'Could not end the completed flight (${error.runtimeType})\n'
+          '$stackTrace',
+        );
       }
     } finally {
       _autoEndingRide = false;
@@ -4031,7 +4043,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       } on Object catch (error, stackTrace) {
         if (kDebugMode) {
           debugPrint(
-            'Rejected received situational event: $error\n$stackTrace',
+            'Rejected received situational event (${error.runtimeType})\n'
+            '$stackTrace',
           );
         }
       }
@@ -4251,7 +4264,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     } on Object catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint(
-          'Could not start GPS before the flight: $error\n$stackTrace',
+          'Could not start GPS before the flight (${error.runtimeType})\n'
+          '$stackTrace',
         );
       }
     }
@@ -4272,7 +4286,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       await locationController.resumeIfAuthorized();
     } on Object catch (error, stackTrace) {
       if (kDebugMode) {
-        debugPrint('Could not resume live GPS: $error\n$stackTrace');
+        debugPrint(
+          'Could not resume live GPS (${error.runtimeType})\n$stackTrace',
+        );
       }
       final added = _warnings.add(
         'Live GPS could not resume automatically. Use Follow me or Safety '
@@ -4517,7 +4533,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       } on Object catch (error) {
         retryNeeded = true;
         if (kDebugMode) {
-          debugPrint('Could not queue ${event.id} for nearby relay: $error');
+          debugPrint(
+            'Could not queue nearby relay event (${error.runtimeType})',
+          );
         }
       }
     }
@@ -5647,9 +5665,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     } on Object catch (error, stackTrace) {
       // OS speech remains configured as the fail-safe. A model-load problem is
       // useful in diagnostics but must never block or end a ride.
-      _diagnostics?.recordNote('Natural voice warm-up failed: $error');
+      _diagnostics?.recordNote(
+        'Natural voice warm-up failed (${error.runtimeType})',
+      );
       if (kDebugMode) {
-        debugPrint('Natural voice warm-up failed: $error\n$stackTrace');
+        debugPrint(
+          'Natural voice warm-up failed (${error.runtimeType})\n$stackTrace',
+        );
       }
     }
   }
@@ -5863,11 +5885,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       return true;
     } on Object catch (error, stackTrace) {
       _diagnostics?.recordNote(
-        'start flight failed from $source: ${error.runtimeType}: $error',
+        'start flight failed from $source (${error.runtimeType})',
       );
       if (kDebugMode) {
         debugPrint(
-          'Could not start the flight from $source: $error\n$stackTrace',
+          'Could not start the flight from $source (${error.runtimeType})\n'
+          '$stackTrace',
         );
       }
       final message = source == 'CarPlay'
@@ -6268,7 +6291,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             await _locationController?.requestAndStart();
           } on Object catch (error, stackTrace) {
             if (kDebugMode) {
-              debugPrint('Could not start live GPS: $error\n$stackTrace');
+              debugPrint(
+                'Could not start live GPS (${error.runtimeType})\n$stackTrace',
+              );
             }
             final added = _warnings.add(
               'The flight started, but live GPS could not start. Use Follow me '

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -1266,6 +1266,8 @@ class _EventRow extends StatelessWidget {
       RideEventType.flightStartedByCrew => 'Tracking started by chase crew',
       RideEventType.flightLanded => 'Balloon marked LANDED',
       RideEventType.flightLandingRetracted => 'Landing declaration retracted',
+      RideEventType.deviceAuthorityRevoked => 'Device access revoked',
+      RideEventType.deviceAuthorityRotated => 'Device security key rotated',
       // Also the acknowledgement of another rider's message, which is a
       // `statusMessage` carrying `acknowledgesQuickMessageEventId` and the label
       // "Seen: <what they raised>" (#151). One row either way: the log records

--- a/apps/mobile/lib/features/ride/ride_invitation_qr_sheet.dart
+++ b/apps/mobile/lib/features/ride/ride_invitation_qr_sheet.dart
@@ -49,6 +49,7 @@ class RideInvitationQrSheet extends StatelessWidget {
       rideCode: session.rideCode,
       inviteSecret: session.inviteSecret,
       joinToken: session.joinToken,
+      authorityRootPublicKey: session.authorityRootPublicKey,
       crewRoomId: crewRoom?.inviteToken == null ? null : crewRoom!.roomId,
       crewRoomAlias: crewRoom?.inviteToken == null ? null : crewRoom!.alias,
       crewRoomInviteToken: crewRoom?.inviteToken,

--- a/apps/mobile/lib/features/ride/ride_roster_sheet.dart
+++ b/apps/mobile/lib/features/ride/ride_roster_sheet.dart
@@ -75,6 +75,16 @@ class _RideRosterSheetState extends State<RideRosterSheet> {
                           '$liveCount currently included · ${all.length} recorded',
                           style: const TextStyle(color: Color(0xFF9DA8B6)),
                         ),
+                        if (widget.controller.session?.usesDeviceAuthority ==
+                            true)
+                          TextButton.icon(
+                            key: const Key('rotate-local-device-key'),
+                            onPressed: widget.controller.busy
+                                ? null
+                                : _rotateLocalKey,
+                            icon: const Icon(Icons.key_outlined, size: 18),
+                            label: const Text('Rotate this device key'),
+                          ),
                       ],
                     ),
                   ),
@@ -149,13 +159,31 @@ class _RideRosterSheetState extends State<RideRosterSheet> {
                       padding: const EdgeInsets.fromLTRB(12, 4, 12, 28),
                       itemCount: visible.length,
                       separatorBuilder: (_, _) => const Divider(height: 1),
-                      itemBuilder: (context, index) => _ParticipantTile(
-                        participant: visible[index],
-                        now: DateTime.now(),
-                        peerAppIsOlder: widget.legacyPeerRiderIds.contains(
-                          visible[index].riderId,
-                        ),
-                      ),
+                      itemBuilder: (context, index) {
+                        final participant = visible[index];
+                        final revoked = widget.controller.revokedDeviceIds
+                            .contains(participant.riderId);
+                        return _ParticipantTile(
+                          participant: participant,
+                          now: DateTime.now(),
+                          revoked: revoked,
+                          onRevoke:
+                              widget.controller.hasFlightAuthority &&
+                                  widget
+                                          .controller
+                                          .session
+                                          ?.usesDeviceAuthority ==
+                                      true &&
+                                  !participant.isLocal &&
+                                  !participant.hasLeft &&
+                                  !revoked
+                              ? () => _confirmRevoke(participant)
+                              : null,
+                          peerAppIsOlder: widget.legacyPeerRiderIds.contains(
+                            participant.riderId,
+                          ),
+                        );
+                      },
                     ),
             ),
           ],
@@ -185,6 +213,53 @@ class _RideRosterSheetState extends State<RideRosterSheet> {
     if (leftAttention != rightAttention) return leftAttention ? -1 : 1;
     if (left.isLocal != right.isLocal) return left.isLocal ? -1 : 1;
     return left.displayName.compareTo(right.displayName);
+  }
+
+  Future<void> _rotateLocalKey() async {
+    await widget.controller.rotateLocalDeviceAuthority();
+    if (!mounted) return;
+    final error = widget.controller.errorMessage;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          error ?? 'This device now uses a new flight security key.',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmRevoke(RideParticipant participant) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Remove device access?'),
+        content: Text(
+          '${participant.displayName} will stop contributing positions or '
+          'flight changes from this device. They can rejoin with a new '
+          'operation identity if invited again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const Key('confirm-revoke-device'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Remove access'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await widget.controller.revokeDeviceAuthority(participant.riderId);
+    if (!mounted) return;
+    final error = widget.controller.errorMessage;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(error ?? '${participant.displayName} access removed.'),
+      ),
+    );
   }
 }
 
@@ -300,11 +375,15 @@ class _ParticipantTile extends StatelessWidget {
     required this.participant,
     required this.now,
     this.peerAppIsOlder = false,
+    this.revoked = false,
+    this.onRevoke,
   });
 
   final RideParticipant participant;
   final DateTime now;
   final bool peerAppIsOlder;
+  final bool revoked;
+  final VoidCallback? onRevoke;
 
   @override
   Widget build(BuildContext context) {
@@ -327,6 +406,7 @@ class _ParticipantTile extends StatelessWidget {
       ?rejoin,
       ?lastKnownPosition,
       if (peerAppIsOlder) 'app is older',
+      if (revoked) 'device access revoked',
     ].join(', ');
     return Semantics(
       label: semanticLabel,
@@ -361,6 +441,7 @@ class _ParticipantTile extends StatelessWidget {
           child: Text(
             [
               '$role · ${participant.stateLabel}',
+              if (revoked) 'Device access revoked by pilot',
               'Last seen $lastSeen · ${participant.transportLabel}',
               ?rejoin,
               ?lastKnownPosition,
@@ -368,6 +449,14 @@ class _ParticipantTile extends StatelessWidget {
             style: const TextStyle(color: Color(0xFFA6B0BD), height: 1.35),
           ),
         ),
+        trailing: onRevoke == null
+            ? null
+            : IconButton(
+                key: Key('revoke-device-${participant.riderId}'),
+                tooltip: 'Remove device access',
+                onPressed: onRevoke,
+                icon: const Icon(Icons.person_remove_outlined),
+              ),
       ),
     );
   }

--- a/apps/mobile/lib/internet/crew_room_directory.dart
+++ b/apps/mobile/lib/internet/crew_room_directory.dart
@@ -231,6 +231,8 @@ class HttpCrewRoomDirectory implements CrewRoomDirectory {
     'rideCode': session.rideCode,
     'inviteSecret': session.inviteSecret,
     'resolveToken': session.joinToken,
+    if (session.authorityRootPublicKey != null)
+      'authorityRootPublicKey': session.authorityRootPublicKey,
   };
 
   Future<Map<String, Object?>> _request(

--- a/apps/mobile/lib/internet/internet_relay_client.dart
+++ b/apps/mobile/lib/internet/internet_relay_client.dart
@@ -11,6 +11,9 @@ import '../domain/rider_location.dart';
 import '../domain/ride_session.dart';
 import '../features/map/craft_icon.dart';
 import '../relay/relay_event_compatibility.dart';
+import '../relay/relay_engine.dart';
+import '../relay/relay_presence.dart';
+import '../services/presence_authenticator.dart';
 
 class InternetRelayConfiguration {
   const InternetRelayConfiguration({
@@ -65,6 +68,7 @@ abstract final class RelayProtocolCapabilities {
   /// cursor-independent ride roster. Supersedes [preStartPresence]; both are
   /// advertised so an older relay keeps working.
   static const livePresence = 'live-presence-v2';
+  static const deviceAuthority = 'device-authority-v1';
   static const routeRevisions = 'route-revisions-v1';
   static const pushNotifications = 'push-notifications-v1';
   static const observerAccess = 'observer-access-v1';
@@ -102,6 +106,7 @@ abstract final class RelayProtocolCapabilities {
     membership,
     preStartPresence,
     livePresence,
+    deviceAuthority,
     routeRevisions,
     pushNotifications,
     observerAccess,
@@ -399,6 +404,7 @@ class RideCodeCredentials {
     required this.rideCode,
     required this.inviteSecret,
     required this.joinToken,
+    this.authorityRootPublicKey,
   });
 
   final String rideId;
@@ -408,6 +414,7 @@ class RideCodeCredentials {
   /// So a rider who joins can also re-share a fully hardened invite later,
   /// not just the ride creator.
   final String joinToken;
+  final String? authorityRootPublicKey;
 }
 
 class RideCodeDirectoryException implements Exception {
@@ -479,6 +486,8 @@ class HttpRideCodeDirectory implements RideCodeDirectory {
           'rideId': session.rideId,
           'inviteSecret': session.inviteSecret,
           'resolveToken': session.joinToken,
+          if (session.authorityRootPublicKey != null)
+            'authorityRootPublicKey': session.authorityRootPublicKey,
         }),
     );
     if (response.statusCode == 204) return;
@@ -522,6 +531,7 @@ class HttpRideCodeDirectory implements RideCodeDirectory {
       final returnedCode = json['rideCode'];
       final secret = json['inviteSecret'];
       final returnedJoinToken = json['resolveToken'];
+      final authorityRootPublicKey = json['authorityRootPublicKey'];
       if (rideId is! String ||
           rideId.isEmpty ||
           rideId.length > 128 ||
@@ -535,11 +545,19 @@ class HttpRideCodeDirectory implements RideCodeDirectory {
           returnedJoinToken.length > 128) {
         throw const FormatException('Response fields are invalid.');
       }
+      if (authorityRootPublicKey != null &&
+          (authorityRootPublicKey is! String ||
+              !RegExp(
+                r'^[A-Za-z0-9_-]{43}$',
+              ).hasMatch(authorityRootPublicKey))) {
+        throw const FormatException('Response device authority is invalid.');
+      }
       return RideCodeCredentials(
         rideId: rideId,
         rideCode: returnedCode,
         inviteSecret: secret,
         joinToken: returnedJoinToken,
+        authorityRootPublicKey: authorityRootPublicKey as String?,
       );
     } on Object {
       // Deliberately not interpolated: a transport or TLS error message can
@@ -1001,7 +1019,7 @@ class HttpInternetRelayClient
       'rr1-${base64Url.encode(sha256.convert(bodyBytes).bytes).replaceAll('=', '')}';
 
   void _validateEventForRide(RideEvent event, String rideId) {
-    if (event.schemaVersion != 1 ||
+    if ((event.schemaVersion != 1 && event.schemaVersion != 2) ||
         event.rideId != rideId ||
         event.id.isEmpty ||
         event.id.length > 128 ||
@@ -1025,11 +1043,15 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
     required http.Client client,
     RelayClientDescriptor? clientDescriptor,
     DateTime Function()? clock,
+    RelayPresenceFactory? presenceFactory,
+    RelayPresenceVerifier? presenceVerifier,
   }) => HttpPreStartPresenceClient._(
     configuration,
     client,
     clientDescriptor ?? RelayClientDescriptor.current(),
     clock ?? DateTime.now,
+    presenceFactory,
+    presenceVerifier,
   );
 
   HttpPreStartPresenceClient._(
@@ -1037,6 +1059,8 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
     this._client,
     this._clientDescriptor,
     this._clock,
+    this._presenceFactory,
+    this._presenceVerifier,
   );
 
   @override
@@ -1044,6 +1068,8 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
   final http.Client _client;
   final RelayClientDescriptor _clientDescriptor;
   final DateTime Function() _clock;
+  final RelayPresenceFactory? _presenceFactory;
+  final RelayPresenceVerifier? _presenceVerifier;
   RelayCompatibilityResult? _cachedCompatibility;
 
   @override
@@ -1070,6 +1096,15 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
         code: 'feature_unsupported',
       );
     }
+    if (session.usesDeviceAuthority &&
+        (!compatibility.supports(RelayProtocolCapabilities.deviceAuthority) ||
+            _presenceFactory == null ||
+            _presenceVerifier == null)) {
+      throw const InternetRelayException(
+        'This flight service cannot authenticate live crew positions yet.',
+        code: 'feature_unsupported',
+      );
+    }
     if (clear && position != null) {
       throw const InternetRelayException(
         'A pre-start position cannot be published and cleared together.',
@@ -1089,6 +1124,13 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
         'A crew member can only publish their own pre-start position.',
       );
     }
+    final authorityUpdate = session.usesDeviceAuthority
+        ? await _presenceFactory!(
+            position: position,
+            clear: clear,
+            ttl: const Duration(seconds: 45),
+          )
+        : null;
     final bodyBytes = utf8.encode(
       jsonEncode({
         'protocolVersion': 1,
@@ -1106,6 +1148,8 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
                 'sample': position.sample.toJson(),
               },
         'clear': clear,
+        if (authorityUpdate?.authorityProof case final proof?)
+          ...proof.toJson(),
       }),
     );
     if (bodyBytes.length > configuration.maximumRequestBytes) {
@@ -1217,6 +1261,27 @@ class HttpPreStartPresenceClient implements PreStartPresenceApi {
             for (final field in _presenceLocationFields)
               if (raw.containsKey(field)) field: raw[field],
           });
+          if (session.usesDeviceAuthority) {
+            final proof = PresenceAuthorityProof.fromJson(raw);
+            final verified = await _presenceVerifier!(
+              RelayPresenceUpdate(
+                riderId: location.riderId,
+                sentAt: DateTime.fromMillisecondsSinceEpoch(
+                  proof.signedAtMilliseconds,
+                  isUtc: true,
+                ),
+                expiresAt: expiresAt,
+                clear: false,
+                position: location,
+                authorityProof: proof,
+              ),
+              serverTime ?? receivedAt,
+            );
+            if (!verified) {
+              unreadable += 1;
+              continue;
+            }
+          }
           if (raw['livePresence'] == false) legacyPeers.add(location.riderId);
           locations.add(location);
         } on Object {

--- a/apps/mobile/lib/internet/internet_relay_worker.dart
+++ b/apps/mobile/lib/internet/internet_relay_worker.dart
@@ -269,8 +269,13 @@ class InternetRelayWorker {
       if (!_isCurrent(generation, session)) return;
       for (final event in result.events) {
         if (event.rideId != session.rideId ||
-            event.schemaVersion != 1 ||
-            !RideEventAuthenticator.verify(event, session.inviteSecret)) {
+            (session.usesDeviceAuthority
+                ? event.schemaVersion != 2
+                : event.schemaVersion != 1) ||
+            !await RideEventAuthenticator.verifyAsync(
+              event,
+              session.inviteSecret,
+            )) {
           throw InternetRelayException(
             'Server returned an unauthenticated event ${event.id}.',
           );
@@ -284,6 +289,12 @@ class InternetRelayWorker {
         if (!_isCurrent(generation, session)) return;
         if (!knownEventIds.add(event.id)) continue;
         final stored = event.copyWith(acknowledged: true);
+        if (!await RideEventAuthenticator.verifyAsync(
+          stored,
+          session.inviteSecret,
+        )) {
+          continue;
+        }
         await _eventStore.append(stored);
         if (_isCurrent(generation, session) &&
             !_receivedEventController.isClosed) {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -24,6 +24,7 @@ import 'data/json_file_completed_ride_store.dart';
 import 'data/secure_land_access_note_store.dart';
 import 'data/shared_preferences_session_store.dart';
 import 'data/secure_crew_room_store.dart';
+import 'data/secure_device_identity_store.dart';
 import 'data/sqlite_event_store.dart';
 import 'services/nearby_bridge.dart';
 import 'services/test_control_registry.dart';
@@ -103,6 +104,7 @@ Future<void> main() async {
     installationId: riderProfile.installationId,
     completedRideStore: completedRides,
     crewRoomStore: const SecureCrewRoomStore(),
+    deviceIdentityStore: const SecureDeviceIdentityStore(),
   );
   final landAccessNotes = LandAccessNoteController(
     const SecureLandAccessNoteStore(),

--- a/apps/mobile/lib/relay/relay_engine.dart
+++ b/apps/mobile/lib/relay/relay_engine.dart
@@ -6,6 +6,7 @@ import 'package:uuid/uuid.dart';
 import '../domain/event_store.dart';
 import '../domain/rider_location.dart';
 import '../domain/ride_event.dart';
+import '../services/ride_event_authenticator.dart';
 import 'peer_transport.dart';
 import 'relay_protocol.dart';
 import 'relay_queue.dart';
@@ -14,6 +15,14 @@ import 'relay_presence.dart';
 typedef RelayClock = DateTime Function();
 typedef RelayIdFactory = String Function();
 typedef RelayDelay = Future<void> Function(Duration duration);
+typedef RelayPresenceFactory =
+    Future<RelayPresenceUpdate> Function({
+      required RiderLocation? position,
+      required bool clear,
+      required Duration ttl,
+    });
+typedef RelayPresenceVerifier =
+    Future<bool> Function(RelayPresenceUpdate update, DateTime trustedNow);
 
 enum RelayConnectionState {
   stopped,
@@ -111,6 +120,8 @@ class RelayEngineConfig {
     required this.localDeviceId,
     required this.endpointName,
     this.serviceId = 'me.osholt.balloon_crumbs.relay.v1',
+    this.presenceFactory,
+    this.presenceVerifier,
   });
 
   final String rideId;
@@ -118,6 +129,8 @@ class RelayEngineConfig {
   final String localDeviceId;
   final String endpointName;
   final String serviceId;
+  final RelayPresenceFactory? presenceFactory;
+  final RelayPresenceVerifier? presenceVerifier;
 }
 
 /// Durable, transport-neutral, application-layer relay.
@@ -268,13 +281,19 @@ class RelayEngine {
       throw ArgumentError('Invalid pre-start presence update');
     }
     final now = _clock();
-    final update = RelayPresenceUpdate(
-      riderId: config.localDeviceId,
-      sentAt: now,
-      expiresAt: now.add(ttl),
-      clear: clear,
-      position: position,
-    );
+    final update = config.presenceFactory == null
+        ? RelayPresenceUpdate(
+            riderId: config.localDeviceId,
+            sentAt: now,
+            expiresAt: now.add(ttl),
+            clear: clear,
+            position: position,
+          )
+        : await config.presenceFactory!(
+            position: position,
+            clear: clear,
+            ttl: ttl,
+          );
     _localPresence = clear ? null : update;
     await _sendPresence(update, peerIds: _status.peerIds);
   }
@@ -419,8 +438,16 @@ class RelayEngine {
     }
     if (frame.kind == RelayFrameKind.presence) {
       final presence = frame.presence;
-      if (presence != null && !_receivedPresenceController.isClosed) {
+      final accepted =
+          presence != null &&
+          (config.presenceVerifier == null ||
+              await config.presenceVerifier!(presence, now));
+      if (accepted && !_receivedPresenceController.isClosed) {
         _receivedPresenceController.add(presence);
+      } else if (presence != null) {
+        _emit(
+          _status.copyWith(rejectedFrameCount: _status.rejectedFrameCount + 1),
+        );
       }
       await _refreshQueueCount(lastExchangeAt: now);
       return;
@@ -428,6 +455,15 @@ class RelayEngine {
 
     final acknowledged = <String>[];
     for (final item in frame.events) {
+      if (!await RideEventAuthenticator.verifyAsync(
+        item.event,
+        config.rideSecret,
+      )) {
+        _emit(
+          _status.copyWith(rejectedFrameCount: _status.rejectedFrameCount + 1),
+        );
+        continue;
+      }
       acknowledged.add(item.event.id);
       if (await _queue.contains(item.event.id)) {
         continue;

--- a/apps/mobile/lib/relay/relay_event_compatibility.dart
+++ b/apps/mobile/lib/relay/relay_event_compatibility.dart
@@ -11,6 +11,8 @@ const _relayEventEnvelopeFields = {
   'expiresAt',
   'payload',
   'signature',
+  'devicePublicKey',
+  'deviceSignature',
   'acknowledged',
 };
 
@@ -31,7 +33,7 @@ const _relayEventEnvelopeFields = {
 /// into a total, silent presence outage.
 String? describeUnsupportedRelayEvent(Map<String, Object?> raw) {
   final schemaVersion = raw['schemaVersion'];
-  if (schemaVersion is int && schemaVersion != 1) {
+  if (schemaVersion is int && schemaVersion != 1 && schemaVersion != 2) {
     return 'schema-v$schemaVersion';
   }
   final type = raw['type'];

--- a/apps/mobile/lib/relay/relay_presence.dart
+++ b/apps/mobile/lib/relay/relay_presence.dart
@@ -1,4 +1,5 @@
 import '../domain/rider_location.dart';
+import '../services/presence_authenticator.dart';
 
 /// One authenticated, replace-only presence update carried by Nearby.
 ///
@@ -10,6 +11,7 @@ class RelayPresenceUpdate {
     required this.expiresAt,
     required this.clear,
     this.position,
+    this.authorityProof,
   });
 
   final String riderId;
@@ -17,6 +19,7 @@ class RelayPresenceUpdate {
   final DateTime expiresAt;
   final bool clear;
   final RiderLocation? position;
+  final PresenceAuthorityProof? authorityProof;
 }
 
 abstract interface class RelayPresenceGateway {

--- a/apps/mobile/lib/relay/relay_protocol.dart
+++ b/apps/mobile/lib/relay/relay_protocol.dart
@@ -8,6 +8,7 @@ import '../domain/ride_event.dart';
 import 'relay_event_compatibility.dart';
 import 'relay_queue.dart';
 import 'relay_presence.dart';
+import '../services/presence_authenticator.dart';
 
 enum RelayFrameKind { events, acknowledgement, presence }
 
@@ -234,6 +235,17 @@ class RelayProtocol {
           riderColor: position.riderColor,
         );
       }
+      PresenceAuthorityProof? authorityProof;
+      final authorityVersion = presence['authorityVersion'];
+      if (authorityVersion != null) {
+        try {
+          authorityProof = PresenceAuthorityProof.fromJson(presence);
+        } on Object {
+          throw const RelayProtocolException(
+            'Invalid presence authority proof',
+          );
+        }
+      }
       return RelayFrame(
         kind: kind,
         rideId: rideId,
@@ -246,6 +258,7 @@ class RelayProtocol {
           expiresAt: expiresAt,
           clear: clear,
           position: position,
+          authorityProof: authorityProof,
         ),
       );
     }
@@ -345,6 +358,7 @@ class RelayProtocol {
         'clear': frame.presence!.clear,
         if (frame.presence!.position case final position?)
           'position': position.toJson(),
+        if (frame.presence!.authorityProof case final proof?) ...proof.toJson(),
       },
   };
 

--- a/apps/mobile/lib/services/carplay_bridge.dart
+++ b/apps/mobile/lib/services/carplay_bridge.dart
@@ -610,7 +610,9 @@ class CarPlayBridge {
         _publishedRideStartKey = previousRideStartKey;
         _publishedSurfaceKey = previousSurfaceKey;
       }
-      if (kDebugMode) debugPrint('Could not publish CarPlay snapshot: $error');
+      if (kDebugMode) {
+        debugPrint('Could not publish CarPlay snapshot (${error.runtimeType})');
+      }
     }
   }
 
@@ -646,7 +648,9 @@ class CarPlayBridge {
         'mapStyleUrl': viewport.mapStyleUrl,
       });
     } on Object catch (error) {
-      if (kDebugMode) debugPrint('Could not publish CarPlay viewport: $error');
+      if (kDebugMode) {
+        debugPrint('Could not publish CarPlay viewport (${error.runtimeType})');
+      }
     }
   }
 
@@ -667,7 +671,11 @@ class CarPlayBridge {
       });
       _publishedMapStyleJson = styleJson;
     } on Object catch (error) {
-      if (kDebugMode) debugPrint('Could not publish CarPlay map style: $error');
+      if (kDebugMode) {
+        debugPrint(
+          'Could not publish CarPlay map style (${error.runtimeType})',
+        );
+      }
     }
   }
 

--- a/apps/mobile/lib/services/chase_guidance_target.dart
+++ b/apps/mobile/lib/services/chase_guidance_target.dart
@@ -91,6 +91,8 @@ class ChaseGuidanceSelectionReducer {
         case RideEventType.flightStartedByCrew:
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/services/craft_roster.dart
+++ b/apps/mobile/lib/services/craft_roster.dart
@@ -155,6 +155,8 @@ class CraftRosterReducer {
         case RideEventType.flightStartedByCrew:
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -99,6 +99,8 @@ class CraftTrackReducer {
         case RideEventType.flightStartedByCrew:
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/device_authority_policy.dart
+++ b/apps/mobile/lib/services/device_authority_policy.dart
@@ -1,0 +1,215 @@
+import '../domain/flight_role.dart';
+import '../domain/ride_event.dart';
+import '../domain/ride_role.dart';
+import '../domain/ride_session.dart';
+import 'device_identity.dart';
+import 'pilot_handover.dart';
+import 'ride_event_authenticator.dart';
+import 'ride_lifecycle.dart';
+
+/// Projects the operation-scoped trust graph before any product reducer sees
+/// an event. Possession of the shared flight secret remains enough to reach the
+/// transport, but is no longer enough to impersonate a participant or exercise
+/// pilot authority.
+class DeviceAuthorityPolicy {
+  DeviceAuthorityPolicy(this.session);
+
+  final RideSession session;
+  final Map<String, String> _currentPublicKeys = {};
+  final Map<String, FlightRole> _roles = {};
+  final Set<String> _revokedDeviceIds = {};
+  final Map<String, PilotHandoverOffer> _offers = {};
+  String? _pilotDeviceId;
+
+  String? get pilotDeviceId => _pilotDeviceId;
+  Set<String> get revokedDeviceIds => Set.unmodifiable(_revokedDeviceIds);
+
+  bool authorizesDeviceKey(String deviceId, String publicKey) =>
+      !_revokedDeviceIds.contains(deviceId) &&
+      _currentPublicKeys[deviceId] == publicKey;
+
+  List<RideEvent> filter(Iterable<RideEvent> events) {
+    final ordered = events.toList(growable: false)
+      ..sort(RideLifecycleReducer.compareEvents);
+    return [
+      for (final event in ordered)
+        if (accept(event)) event,
+    ];
+  }
+
+  bool accept(RideEvent event) {
+    if (!session.usesDeviceAuthority) {
+      return event.schemaVersion == 1 &&
+          RideEventAuthenticator.verify(event, session.inviteSecret);
+    }
+    if (event.schemaVersion != 2 ||
+        !RideEventAuthenticator.verify(event, session.inviteSecret)) {
+      return false;
+    }
+    final publicKey = event.devicePublicKey;
+    if (publicKey == null || _revokedDeviceIds.contains(event.deviceId)) {
+      return false;
+    }
+    final knownKey = _currentPublicKeys[event.deviceId];
+    if (knownKey == null) {
+      if (!DeviceIdentity.matchesDeviceId(
+        rideId: event.rideId,
+        publicKey: publicKey,
+        deviceId: event.deviceId,
+      )) {
+        return false;
+      }
+      if (!_acceptFirstEvent(event, publicKey)) return false;
+      _currentPublicKeys[event.deviceId] = publicKey;
+      return true;
+    }
+    if (knownKey != publicKey) return false;
+    if (!_isActionAuthorized(event)) return false;
+    _apply(event);
+    return true;
+  }
+
+  bool _acceptFirstEvent(RideEvent event, String publicKey) {
+    if (publicKey == session.authorityRootPublicKey) {
+      if (_pilotDeviceId != null || event.type != RideEventType.rideCreated) {
+        return false;
+      }
+      final role = flightRoleFromName(event.payload['flightRole']);
+      if (role != FlightRole.pilot ||
+          rideRoleFromName(event.payload['role']) != RideRole.lead) {
+        return false;
+      }
+      _pilotDeviceId = event.deviceId;
+      _roles[event.deviceId] = FlightRole.pilot;
+      return true;
+    }
+    if (event.type != RideEventType.riderJoined) {
+      return false;
+    }
+    final role = flightRoleFromName(
+      event.payload['flightRole'],
+      fallback: FlightRole.observer,
+    );
+    if (role == FlightRole.pilot || role == FlightRole.observer) return false;
+    if (rideRoleFromName(event.payload['role']) == RideRole.lead) return false;
+    _roles[event.deviceId] = role;
+    return true;
+  }
+
+  bool _isActionAuthorized(RideEvent event) {
+    final role = _roles[event.deviceId];
+    if (role == null) return false;
+    if (_pilotDeviceId == null && event.type != RideEventType.riderLeft) {
+      return false;
+    }
+    final isPilot = event.deviceId == _pilotDeviceId;
+    return switch (event.type) {
+      RideEventType.rideCreated || RideEventType.riderJoined => false,
+      RideEventType.riderLeft =>
+        event.payload['riderId'] == null ||
+            event.payload['riderId'] == event.deviceId,
+      RideEventType.roleChanged => _validSelfRoleChange(event),
+      RideEventType.rideStarted ||
+      RideEventType.ridePaused ||
+      RideEventType.rideResumed ||
+      RideEventType.rideReopened ||
+      RideEventType.routeRevisionChunk ||
+      RideEventType.routeRevisionPublished ||
+      RideEventType.routeCleared ||
+      RideEventType.craftPrimaryDeviceNominated ||
+      RideEventType.landingAreaNoted ||
+      RideEventType.operationalBoundaryUpserted ||
+      RideEventType.operationalBoundaryRemoved ||
+      RideEventType.pilotHandoverOffered ||
+      RideEventType.deviceAuthorityRevoked => isPilot,
+      RideEventType.windContextNoted =>
+        isPilot || role == FlightRole.balloonCrew,
+      RideEventType.flightStartedByCrew => role.isChasing,
+      RideEventType.flightLanded ||
+      RideEventType.flightLandingRetracted ||
+      RideEventType.rideEnded => role != FlightRole.observer,
+      RideEventType.pilotHandoverAccepted =>
+        event.payload['toDeviceId'] == event.deviceId,
+      RideEventType.deviceAttachedToCraft =>
+        event.payload['deviceId'] == event.deviceId,
+      RideEventType.craftChaseAssigned ||
+      RideEventType.chaseGuidanceTargetSelected => role.isChasing,
+      RideEventType.deviceAuthorityRotated => true,
+      _ => true,
+    };
+  }
+
+  bool _validSelfRoleChange(RideEvent event) {
+    final role = flightRoleFromName(
+      event.payload['flightRole'],
+      fallback: _roles[event.deviceId] ?? FlightRole.observer,
+    );
+    return role != FlightRole.pilot &&
+        rideRoleFromName(event.payload['role']) != RideRole.lead;
+  }
+
+  void _apply(RideEvent event) {
+    switch (event.type) {
+      case RideEventType.roleChanged:
+        _roles[event.deviceId] = flightRoleFromName(
+          event.payload['flightRole'],
+          fallback: _roles[event.deviceId]!,
+        );
+      case RideEventType.pilotHandoverOffered:
+        final offer = _handoverOffer(event);
+        if (offer != null && offer.fromDeviceId == _pilotDeviceId) {
+          _offers[offer.transferId] = offer;
+        }
+      case RideEventType.pilotHandoverAccepted:
+        final transferId = event.payload['transferId'];
+        final offer = transferId is String ? _offers[transferId] : null;
+        if (offer != null &&
+            offer.fromDeviceId == _pilotDeviceId &&
+            offer.toDeviceId == event.deviceId &&
+            !event.createdAt.isAfter(offer.expiresAt) &&
+            !event.createdAt.isBefore(
+              offer.offeredAt.subtract(PilotAuthorityReducer.maximumClockSkew),
+            )) {
+          final previousPilot = _pilotDeviceId!;
+          _roles[previousPilot] = FlightRole.balloonCrew;
+          _roles[event.deviceId] = FlightRole.pilot;
+          _pilotDeviceId = event.deviceId;
+        }
+      case RideEventType.deviceAuthorityRevoked:
+        final target = event.payload['targetDeviceId'];
+        if (target is String && target != _pilotDeviceId) {
+          _revokedDeviceIds.add(target);
+        }
+      case RideEventType.deviceAuthorityRotated:
+        final replacement = event.payload['newPublicKey'];
+        if (replacement is String) {
+          _currentPublicKeys[event.deviceId] = replacement;
+        }
+      default:
+        break;
+    }
+  }
+
+  static PilotHandoverOffer? _handoverOffer(RideEvent event) {
+    final transferId = event.payload['transferId'];
+    final fromDeviceId = event.payload['fromDeviceId'];
+    final toDeviceId = event.payload['toDeviceId'];
+    final expiresAtValue = event.payload['expiresAt'];
+    final expiresAt = expiresAtValue is String
+        ? DateTime.tryParse(expiresAtValue)?.toUtc()
+        : event.expiresAt?.toUtc();
+    if (transferId is! String ||
+        fromDeviceId is! String ||
+        toDeviceId is! String ||
+        expiresAt == null) {
+      return null;
+    }
+    return PilotHandoverOffer(
+      transferId: transferId,
+      fromDeviceId: fromDeviceId,
+      toDeviceId: toDeviceId,
+      offeredAt: event.createdAt,
+      expiresAt: expiresAt,
+    );
+  }
+}

--- a/apps/mobile/lib/services/device_identity.dart
+++ b/apps/mobile/lib/services/device_identity.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:cryptography/cryptography.dart';
+
+import '../domain/device_identity_store.dart';
+
+class DeviceIdentity {
+  const DeviceIdentity({
+    required this.deviceId,
+    required this.publicKey,
+    required this.privateSeed,
+  });
+
+  final String deviceId;
+  final String publicKey;
+  final List<int> privateSeed;
+
+  DeviceIdentity boundToDeviceId(String value) => DeviceIdentity(
+    deviceId: value,
+    publicKey: publicKey,
+    privateSeed: List<int>.of(privateSeed),
+  );
+
+  static Future<DeviceIdentity> fromSeed({
+    required String rideId,
+    required List<int> seed,
+  }) async {
+    if (seed.length != 32) {
+      throw ArgumentError.value(seed.length, 'seed', 'Must contain 32 bytes');
+    }
+    final keyPair = await Ed25519().newKeyPairFromSeed(seed);
+    final publicKeyBytes = (await keyPair.extractPublicKey()).bytes;
+    final encodedPublicKey = _base64Url(publicKeyBytes);
+    return DeviceIdentity(
+      deviceId: deviceIdFor(rideId: rideId, publicKey: encodedPublicKey),
+      publicKey: encodedPublicKey,
+      privateSeed: List<int>.of(seed),
+    );
+  }
+
+  static String deviceIdFor({
+    required String rideId,
+    required String publicKey,
+  }) {
+    final digest = sha256.convert(
+      utf8.encode('balloon-crumbs-device-id-v1\n$rideId\n$publicKey'),
+    );
+    return 'bcd1_${_base64Url(digest.bytes)}';
+  }
+
+  static bool matchesDeviceId({
+    required String rideId,
+    required String publicKey,
+    required String deviceId,
+  }) => deviceIdFor(rideId: rideId, publicKey: publicKey) == deviceId;
+
+  static String _base64Url(List<int> bytes) =>
+      base64Url.encode(bytes).replaceAll('=', '');
+}
+
+class DeviceIdentityManager {
+  DeviceIdentityManager(this._store, {Random? random})
+    : _random = random ?? Random.secure();
+
+  final DeviceIdentityStore _store;
+  final Random _random;
+
+  Future<DeviceIdentity> loadOrCreate(String rideId) async {
+    var seed = await _store.readSeed(rideId);
+    if (seed == null) {
+      seed = List<int>.generate(32, (_) => _random.nextInt(256));
+      await _store.writeSeed(rideId, seed);
+    }
+    return DeviceIdentity.fromSeed(rideId: rideId, seed: seed);
+  }
+
+  Future<DeviceIdentity> rotate(String rideId) async {
+    final identity = await generateReplacement(rideId);
+    await save(identity, rideId: rideId);
+    return identity;
+  }
+
+  Future<DeviceIdentity> generateReplacement(String rideId) =>
+      DeviceIdentity.fromSeed(
+        rideId: rideId,
+        seed: List<int>.generate(32, (_) => _random.nextInt(256)),
+      );
+
+  Future<void> save(DeviceIdentity identity, {required String rideId}) =>
+      _store.writeSeed(rideId, identity.privateSeed);
+
+  Future<void> delete(String rideId) => _store.delete(rideId);
+}

--- a/apps/mobile/lib/services/flight_replay_archiver.dart
+++ b/apps/mobile/lib/services/flight_replay_archiver.dart
@@ -115,6 +115,8 @@ class FlightReplayArchiver {
         case RideEventType.flightStartedByCrew:
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
         case RideEventType.statusMessage:
         case RideEventType.hazardReported:
         case RideEventType.hazardCleared:

--- a/apps/mobile/lib/services/group_pip_bridge.dart
+++ b/apps/mobile/lib/services/group_pip_bridge.dart
@@ -95,7 +95,9 @@ class GroupPipBridge {
       _active = entered == true;
       return _active;
     } on Object catch (error) {
-      if (kDebugMode) debugPrint('Could not open group PiP: $error');
+      if (kDebugMode) {
+        debugPrint('Could not open group PiP (${error.runtimeType})');
+      }
       _active = false;
       return false;
     }
@@ -110,7 +112,9 @@ class GroupPipBridge {
       );
       _active = stillActive == true;
     } on Object catch (error) {
-      if (kDebugMode) debugPrint('Could not update group PiP: $error');
+      if (kDebugMode) {
+        debugPrint('Could not update group PiP (${error.runtimeType})');
+      }
     }
   }
 
@@ -119,7 +123,9 @@ class GroupPipBridge {
     try {
       await _channel.invokeMethod<void>('close');
     } on Object catch (error) {
-      if (kDebugMode) debugPrint('Could not close group PiP: $error');
+      if (kDebugMode) {
+        debugPrint('Could not close group PiP (${error.runtimeType})');
+      }
     } finally {
       _active = false;
     }

--- a/apps/mobile/lib/services/natural_voice_pack.dart
+++ b/apps/mobile/lib/services/natural_voice_pack.dart
@@ -352,7 +352,10 @@ class NaturalVoicePackController extends ChangeNotifier {
       _status = NaturalVoicePackStatus.failed;
       _failure = _friendlyFailure(error);
       if (error is! FormatException && error is! HttpException) {
-        debugPrint('Natural voice installation failed: $error\n$stackTrace');
+        debugPrint(
+          'Natural voice installation failed (${error.runtimeType})\n'
+          '$stackTrace',
+        );
       }
     }
     notifyListeners();

--- a/apps/mobile/lib/services/presence_authenticator.dart
+++ b/apps/mobile/lib/services/presence_authenticator.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+
+import 'package:cryptography/cryptography.dart';
+
+import '../domain/rider_location.dart';
+import 'device_identity.dart';
+
+/// A short-lived author proof for a replace-only live position.
+///
+/// The shared flight secret still authenticates the transport. This proof binds
+/// the update to one operation-scoped device key, so an invite holder cannot
+/// publish a position under another crew member's device ID.
+class PresenceAuthorityProof {
+  const PresenceAuthorityProof({
+    required this.signedAtMilliseconds,
+    required this.devicePublicKey,
+    required this.deviceSignature,
+  });
+
+  final int signedAtMilliseconds;
+  final String devicePublicKey;
+  final String deviceSignature;
+
+  Map<String, Object?> toJson() => {
+    'authorityVersion': 1,
+    'signedAtMilliseconds': signedAtMilliseconds,
+    'devicePublicKey': devicePublicKey,
+    'deviceSignature': deviceSignature,
+  };
+
+  factory PresenceAuthorityProof.fromJson(Map<String, Object?> json) {
+    final version = json['authorityVersion'];
+    final signedAt = json['signedAtMilliseconds'];
+    final publicKey = json['devicePublicKey'];
+    final signature = json['deviceSignature'];
+    if (version != 1 ||
+        signedAt is! int ||
+        publicKey is! String ||
+        publicKey.length != 43 ||
+        signature is! String ||
+        signature.length != 86) {
+      throw const FormatException('Invalid live-position authority proof.');
+    }
+    return PresenceAuthorityProof(
+      signedAtMilliseconds: signedAt,
+      devicePublicKey: publicKey,
+      deviceSignature: signature,
+    );
+  }
+}
+
+class PresenceAuthenticator {
+  const PresenceAuthenticator._();
+
+  static const maximumAge = Duration(minutes: 5);
+  static const maximumFutureSkew = Duration(minutes: 2);
+
+  static Future<PresenceAuthorityProof> sign({
+    required String rideId,
+    required String riderId,
+    required RiderLocation? position,
+    required bool clear,
+    required DateTime signedAt,
+    required DeviceIdentity identity,
+  }) async {
+    if (clear != (position == null) ||
+        (position != null && position.riderId != riderId)) {
+      throw ArgumentError('Invalid live-position update.');
+    }
+    final milliseconds = signedAt.toUtc().millisecondsSinceEpoch;
+    final keyPair = await Ed25519().newKeyPairFromSeed(identity.privateSeed);
+    final signature = await Ed25519().sign(
+      utf8.encode(
+        challenge(
+          rideId: rideId,
+          riderId: riderId,
+          position: position,
+          clear: clear,
+          signedAtMilliseconds: milliseconds,
+        ),
+      ),
+      keyPair: keyPair,
+    );
+    return PresenceAuthorityProof(
+      signedAtMilliseconds: milliseconds,
+      devicePublicKey: identity.publicKey,
+      deviceSignature: _base64Url(signature.bytes),
+    );
+  }
+
+  static Future<bool> verify({
+    required String rideId,
+    required String riderId,
+    required RiderLocation? position,
+    required bool clear,
+    required PresenceAuthorityProof proof,
+    required DateTime now,
+  }) async {
+    if (clear != (position == null) ||
+        (position != null && position.riderId != riderId)) {
+      return false;
+    }
+    final signedAt = DateTime.fromMillisecondsSinceEpoch(
+      proof.signedAtMilliseconds,
+      isUtc: true,
+    );
+    final utcNow = now.toUtc();
+    if (signedAt.isBefore(utcNow.subtract(maximumAge)) ||
+        signedAt.isAfter(utcNow.add(maximumFutureSkew))) {
+      return false;
+    }
+    try {
+      final publicKey = _decodeBase64Url(proof.devicePublicKey);
+      final signature = _decodeBase64Url(proof.deviceSignature);
+      if (publicKey.length != 32 || signature.length != 64) return false;
+      return Ed25519().verify(
+        utf8.encode(
+          challenge(
+            rideId: rideId,
+            riderId: riderId,
+            position: position,
+            clear: clear,
+            signedAtMilliseconds: proof.signedAtMilliseconds,
+          ),
+        ),
+        signature: Signature(
+          signature,
+          publicKey: SimplePublicKey(publicKey, type: KeyPairType.ed25519),
+        ),
+      );
+    } on Object {
+      return false;
+    }
+  }
+
+  static String challenge({
+    required String rideId,
+    required String riderId,
+    required RiderLocation? position,
+    required bool clear,
+    required int signedAtMilliseconds,
+  }) =>
+      'balloon-crumbs-live-presence-v1\n'
+      '${_canonicalJson({'rideId': rideId, 'riderId': riderId, 'signedAtMilliseconds': signedAtMilliseconds, 'clear': clear, 'position': position == null ? null : _positionJson(position)})}';
+
+  /// The signed body excludes relay-owned arrival/expiry fields.
+  static Map<String, Object?> _positionJson(RiderLocation position) => {
+    'displayName': position.displayName,
+    'role': position.role.name,
+    'craftStyle': position.craftStyle.name,
+    'riderSymbol': position.riderSymbol.storageValue,
+    'motorcycleStyle': position.riderSymbol.wireValue(position.craftStyle),
+    'riderColor': position.riderColor.name,
+    'sample': position.sample.toJson(),
+  };
+
+  static String _canonicalJson(Object? value) {
+    if (value is Map<Object?, Object?>) {
+      final keys = value.keys.cast<String>().toList()..sort();
+      return '{${keys.map((key) => '${jsonEncode(key)}:${_canonicalJson(value[key])}').join(',')}}';
+    }
+    if (value is List<Object?>) {
+      return '[${value.map(_canonicalJson).join(',')}]';
+    }
+    return jsonEncode(value);
+  }
+
+  static String _base64Url(List<int> bytes) =>
+      base64Url.encode(bytes).replaceAll('=', '');
+
+  static List<int> _decodeBase64Url(String value) =>
+      base64Url.decode(base64Url.normalize(value));
+}

--- a/apps/mobile/lib/services/recap_basemap_snapshot.dart
+++ b/apps/mobile/lib/services/recap_basemap_snapshot.dart
@@ -101,7 +101,9 @@ class RecapBasemapSnapshotter {
       return RecapBasemapSnapshot.captured(await decode(bytes));
     } on Object catch (error, stackTrace) {
       if (kDebugMode) {
-        debugPrint('Recap basemap snapshot failed: $error\n$stackTrace');
+        debugPrint(
+          'Recap basemap snapshot failed (${error.runtimeType})\n$stackTrace',
+        );
       }
       // A timeout is worth distinguishing: it is the one a rider can fix by
       // waiting a moment and pressing Share again.

--- a/apps/mobile/lib/services/ride_diagnostics_recorder.dart
+++ b/apps/mobile/lib/services/ride_diagnostics_recorder.dart
@@ -265,12 +265,11 @@ class RideDiagnosticsRecorder {
   String render({String? rideCode, String? appBuild}) {
     final lines = <String>[
       'Balloon Crumbs · flight diagnostics',
-      if (rideCode != null) 'Flight:  $rideCode',
       if (appBuild != null) 'Build: $appBuild',
       'Written: ${_stamp()}',
       '',
       'Positions in this file are this phone\'s own. No other crew member\'s position,',
-      'no flight or invite secret, and no emergency-contact detail is recorded.',
+      'no flight code or invite secret, and no emergency-contact detail is recorded.',
       '',
       if (_dropped > 0) ...[
         '$_dropped earlier entries were dropped to stay inside the '

--- a/apps/mobile/lib/services/ride_event_authenticator.dart
+++ b/apps/mobile/lib/services/ride_event_authenticator.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
+import 'package:cryptography/cryptography.dart' hide Hmac;
 import 'package:meta/meta.dart';
 
 import '../domain/ride_event.dart';
+import 'device_identity.dart';
 
 /// Signs the current event schema and verifies both it and the development
 /// alpha's earlier event body so stored rides remain readable after upgrade.
@@ -11,7 +13,82 @@ class RideEventAuthenticator {
   const RideEventAuthenticator._();
 
   static String sign(RideEvent event, String secret) =>
-      _digest(_canonicalV1Body(event), secret);
+      _digest(_canonicalBody(event), secret);
+
+  /// Creates a schema-two event with an operation-scoped Ed25519 author proof
+  /// as well as the group HMAC retained by the transport layer.
+  static Future<RideEvent> signForDevice({
+    required RideEvent event,
+    required String secret,
+    required DeviceIdentity identity,
+  }) async {
+    if (event.schemaVersion != 2 ||
+        event.deviceId != identity.deviceId ||
+        event.devicePublicKey != identity.publicKey) {
+      throw ArgumentError('Event does not match its device identity.');
+    }
+    final groupSignature = sign(event, secret);
+    final keyPair = await Ed25519().newKeyPairFromSeed(identity.privateSeed);
+    final signature = await Ed25519().sign(
+      utf8.encode(_canonicalBody(event)),
+      keyPair: keyPair,
+    );
+    final signed = RideEvent(
+      id: event.id,
+      rideId: event.rideId,
+      deviceId: event.deviceId,
+      type: event.type,
+      priority: event.priority,
+      createdAt: event.createdAt,
+      expiresAt: event.expiresAt,
+      payload: event.payload,
+      signature: groupSignature,
+      devicePublicKey: identity.publicKey,
+      deviceSignature: _base64Url(signature.bytes),
+      acknowledged: event.acknowledged,
+      schemaVersion: 2,
+    );
+    _deviceVerdicts[signed] = true;
+    _verdicts[signed] = _Verdict(secret, true);
+    if (signed.type == RideEventType.deviceAuthorityRotated) {
+      final rotationVerdict = await _verifyRotationProof(signed);
+      _rotationVerdicts[signed] = rotationVerdict;
+      if (!rotationVerdict) {
+        throw ArgumentError('Device rotation proof is invalid.');
+      }
+    }
+    return signed;
+  }
+
+  static Future<String> signRotationProof({
+    required String rideId,
+    required String deviceId,
+    required String oldPublicKey,
+    required DeviceIdentity replacement,
+  }) async {
+    final keyPair = await Ed25519().newKeyPairFromSeed(replacement.privateSeed);
+    final signature = await Ed25519().sign(
+      utf8.encode(
+        rotationChallenge(
+          rideId: rideId,
+          deviceId: deviceId,
+          oldPublicKey: oldPublicKey,
+          newPublicKey: replacement.publicKey,
+        ),
+      ),
+      keyPair: keyPair,
+    );
+    return _base64Url(signature.bytes);
+  }
+
+  static String rotationChallenge({
+    required String rideId,
+    required String deviceId,
+    required String oldPublicKey,
+    required String newPublicKey,
+  }) =>
+      'balloon-crumbs-device-rotation-v1\n'
+      '$rideId\n$deviceId\n$oldPublicKey\n$newPublicKey';
 
   /// Verdicts already reached, keyed by event identity.
   ///
@@ -38,6 +115,54 @@ class RideEventAuthenticator {
   static int verificationsComputed = 0;
 
   static bool verify(RideEvent event, String secret) {
+    if (!_verifyGroup(event, secret)) return false;
+    if (event.schemaVersion == 1) return true;
+    if (_deviceVerdicts[event] != true) return false;
+    return event.type != RideEventType.deviceAuthorityRotated ||
+        _rotationVerdicts[event] == true;
+  }
+
+  /// Verifies the group envelope and, for schema two, the author's Ed25519
+  /// proof. Call this once at an ingress or cold-load boundary; synchronous
+  /// reducers then consume the memoized verdict through [verify].
+  static Future<bool> verifyAsync(RideEvent event, String secret) async {
+    if (!_verifyGroup(event, secret)) return false;
+    if (event.schemaVersion == 1) return true;
+    final cached = _deviceVerdicts[event];
+    if (cached != null) return cached;
+    final publicKeyText = event.devicePublicKey;
+    final signatureText = event.deviceSignature;
+    if (publicKeyText == null || signatureText == null) {
+      _deviceVerdicts[event] = false;
+      return false;
+    }
+    try {
+      final publicKeyBytes = _decodeBase64Url(publicKeyText);
+      final signatureBytes = _decodeBase64Url(signatureText);
+      if (publicKeyBytes.length != 32 || signatureBytes.length != 64) {
+        _deviceVerdicts[event] = false;
+        return false;
+      }
+      final verdict = await Ed25519().verify(
+        utf8.encode(_canonicalBody(event)),
+        signature: Signature(
+          signatureBytes,
+          publicKey: SimplePublicKey(publicKeyBytes, type: KeyPairType.ed25519),
+        ),
+      );
+      _deviceVerdicts[event] = verdict;
+      if (!verdict) return false;
+      if (event.type != RideEventType.deviceAuthorityRotated) return true;
+      final rotationVerdict = await _verifyRotationProof(event);
+      _rotationVerdicts[event] = rotationVerdict;
+      return rotationVerdict;
+    } on Object {
+      _deviceVerdicts[event] = false;
+      return false;
+    }
+  }
+
+  static bool _verifyGroup(RideEvent event, String secret) {
     final cached = _verdicts[event];
     if (cached != null && cached.secret == secret) return cached.verdict;
     verificationsComputed += 1;
@@ -49,7 +174,7 @@ class RideEventAuthenticator {
   static bool _verifyUncached(RideEvent event, String secret) {
     if (_constantTimeMatch(
           event.signature,
-          _digest(_canonicalV1Body(event), secret),
+          _digest(_canonicalBody(event), secret),
         ) ==
         1) {
       return true;
@@ -89,13 +214,13 @@ class RideEventAuthenticator {
   static String _digest(String body, String secret) =>
       Hmac(sha256, utf8.encode(secret)).convert(utf8.encode(body)).toString();
 
-  static String _canonicalV1Body(RideEvent event) =>
-      _canonicalJson(_v1Map(event));
+  static String _canonicalBody(RideEvent event) =>
+      _canonicalJson(_signedMap(event));
 
   static String _transitionalV1Body(RideEvent event) =>
-      jsonEncode(_v1Map(event));
+      jsonEncode(_signedMap(event));
 
-  static Map<String, Object?> _v1Map(RideEvent event) => {
+  static Map<String, Object?> _signedMap(RideEvent event) => {
     'schemaVersion': event.schemaVersion,
     'id': event.id,
     'rideId': event.rideId,
@@ -105,6 +230,7 @@ class RideEventAuthenticator {
     'createdAt': event.createdAt.toUtc().toIso8601String(),
     'expiresAt': event.expiresAt?.toUtc().toIso8601String(),
     'payload': event.payload,
+    if (event.schemaVersion >= 2) 'devicePublicKey': event.devicePublicKey,
   };
 
   static String _legacyBody(RideEvent event) => jsonEncode({
@@ -127,6 +253,53 @@ class RideEventAuthenticator {
     }
     return jsonEncode(value);
   }
+
+  static final Expando<bool> _deviceVerdicts = Expando<bool>(
+    'flight event device signature verdict',
+  );
+  static final Expando<bool> _rotationVerdicts = Expando<bool>(
+    'flight event replacement-key proof verdict',
+  );
+
+  static Future<bool> _verifyRotationProof(RideEvent event) async {
+    final cached = _rotationVerdicts[event];
+    if (cached != null) return cached;
+    final oldPublicKey = event.devicePublicKey;
+    final newPublicKey = event.payload['newPublicKey'];
+    final proof = event.payload['newDeviceSignature'];
+    if (oldPublicKey == null || newPublicKey is! String || proof is! String) {
+      return false;
+    }
+    try {
+      final publicKeyBytes = _decodeBase64Url(newPublicKey);
+      final signatureBytes = _decodeBase64Url(proof);
+      if (publicKeyBytes.length != 32 || signatureBytes.length != 64) {
+        return false;
+      }
+      return Ed25519().verify(
+        utf8.encode(
+          rotationChallenge(
+            rideId: event.rideId,
+            deviceId: event.deviceId,
+            oldPublicKey: oldPublicKey,
+            newPublicKey: newPublicKey,
+          ),
+        ),
+        signature: Signature(
+          signatureBytes,
+          publicKey: SimplePublicKey(publicKeyBytes, type: KeyPairType.ed25519),
+        ),
+      );
+    } on Object {
+      return false;
+    }
+  }
+
+  static String _base64Url(List<int> bytes) =>
+      base64Url.encode(bytes).replaceAll('=', '');
+
+  static List<int> _decodeBase64Url(String value) =>
+      base64Url.decode(base64Url.normalize(value));
 }
 
 class _Verdict {

--- a/apps/mobile/lib/services/ride_lifecycle.dart
+++ b/apps/mobile/lib/services/ride_lifecycle.dart
@@ -71,6 +71,8 @@ class RideLifecycleReducer {
           }
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
           break;
         case RideEventType.craftRegistered:
           final craftId = event.payload['craftId'];

--- a/apps/mobile/lib/services/ride_route_reducer.dart
+++ b/apps/mobile/lib/services/ride_route_reducer.dart
@@ -145,6 +145,8 @@ class RideRouteReducer {
         case RideEventType.flightStartedByCrew:
         case RideEventType.flightLanded:
         case RideEventType.flightLandingRetracted:
+        case RideEventType.deviceAuthorityRevoked:
+        case RideEventType.deviceAuthorityRotated:
         case RideEventType.statusMessage:
         case RideEventType.riderLocationUpdated:
         case RideEventType.hazardReported:

--- a/apps/mobile/lib/services/test_control_server.dart
+++ b/apps/mobile/lib/services/test_control_server.dart
@@ -95,7 +95,9 @@ class TestControlServer {
     server.listen(
       _handle,
       onError: (Object error) {
-        if (kDebugMode) debugPrint('Test control request failed: $error');
+        if (kDebugMode) {
+          debugPrint('Test control request failed (${error.runtimeType})');
+        }
       },
       cancelOnError: false,
     );
@@ -210,6 +212,7 @@ class TestControlServer {
           rideCode: session.rideCode,
           inviteSecret: session.inviteSecret,
           joinToken: session.joinToken,
+          authorityRootPublicKey: session.authorityRootPublicKey,
         ).encode(),
       });
       return;

--- a/apps/mobile/test/contracts/runtime_log_privacy_test.dart
+++ b/apps/mobile/test/contracts/runtime_log_privacy_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:balloon_crumbs/data/ride_diagnostics_log_store.dart';
+import 'package:balloon_crumbs/services/ride_diagnostics_recorder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('runtime debug output cannot interpolate locations or raw failures', () {
+    final files = Directory('lib')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((file) => file.path.endsWith('.dart'));
+    final unsafe = <String>[];
+    for (final file in files) {
+      final source = file.readAsStringSync();
+      for (final match in RegExp(
+        r'debugPrint\([\s\S]{0,240}?\);',
+      ).allMatches(source)) {
+        final statement = match.group(0)!;
+        if (statement.contains(r'$error') ||
+            statement.contains('camera.target.latitude') ||
+            statement.contains('camera.target.longitude')) {
+          unsafe.add('${file.path}: $statement');
+        }
+      }
+      for (final match in RegExp(
+        r'recordNote\([\s\S]{0,180}?\);',
+      ).allMatches(source)) {
+        if (match.group(0)!.contains(r'$error')) {
+          unsafe.add('${file.path}: ${match.group(0)}');
+        }
+      }
+    }
+    expect(unsafe, isEmpty, reason: unsafe.join('\n'));
+  });
+
+  test('diagnostic exports never retain the reusable flight code', () {
+    final recorder = RideDiagnosticsRecorder(
+      clock: () => DateTime.utc(2026, 8, 24),
+    )..recordNote('test');
+    final rendered = recorder.render(rideCode: 'TUCKER', appBuild: 'test');
+    expect(rendered, isNot(contains('TUCKER')));
+
+    final inherited = '$rendered\nFlight: TUCKER\nRide: TUCKER';
+    final sanitized = RideDiagnosticsLog.withoutCredentialHeader(inherited);
+    expect(sanitized, isNot(contains('TUCKER')));
+  });
+}

--- a/apps/mobile/test/controllers/device_authority_controller_test.dart
+++ b/apps/mobile/test/controllers/device_authority_controller_test.dart
@@ -1,0 +1,233 @@
+import 'dart:math';
+
+import 'package:balloon_crumbs/controllers/ride_controller.dart';
+import 'package:balloon_crumbs/data/in_memory_device_identity_store.dart';
+import 'package:balloon_crumbs/data/in_memory_event_store.dart';
+import 'package:balloon_crumbs/data/in_memory_session_store.dart';
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
+import 'package:balloon_crumbs/domain/quick_message.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/rider_location.dart';
+import 'package:balloon_crumbs/relay/relay_presence.dart';
+import 'package:balloon_crumbs/services/nearby_bridge.dart';
+import 'package:balloon_crumbs/services/ride_event_authenticator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'production identity path creates restorable schema-two events',
+    () async {
+      final eventStore = InMemoryEventStore();
+      final sessionStore = InMemorySessionStore();
+      final identities = InMemoryDeviceIdentityStore();
+      var id = 0;
+      final controller = RideController(
+        eventStore,
+        sessionStore,
+        const _Nearby(),
+        deviceIdentityStore: identities,
+        idFactory: () => 'event-${id++}',
+        random: Random(7),
+        clock: () => DateTime.utc(2026, 8, 24, 12),
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.createRide('Pilot');
+
+      final session = controller.session!;
+      expect(session.usesDeviceAuthority, isTrue);
+      expect(session.localRiderId, startsWith('bcd1_'));
+      expect(session.authorityRootPublicKey, session.localDevicePublicKey);
+      expect(controller.events, isNotEmpty);
+      for (final event in controller.events) {
+        expect(event.schemaVersion, 2);
+        expect(event.devicePublicKey, session.localDevicePublicKey);
+        expect(
+          await RideEventAuthenticator.verifyAsync(event, session.inviteSecret),
+          isTrue,
+        );
+        final restored = RideEvent.fromJson(event.toJson());
+        expect(
+          await RideEventAuthenticator.verifyAsync(
+            restored,
+            session.inviteSecret,
+          ),
+          isTrue,
+        );
+      }
+
+      final restoredController = RideController(
+        eventStore,
+        sessionStore,
+        const _Nearby(),
+        deviceIdentityStore: identities,
+        idFactory: () => 'restored-${id++}',
+      );
+      addTearDown(restoredController.dispose);
+      await restoredController.initialize();
+      expect(restoredController.events, hasLength(controller.events.length));
+      expect(restoredController.hasFlightAuthority, isTrue);
+    },
+  );
+
+  test(
+    'schema-one event is rejected inside a device-authority flight',
+    () async {
+      final eventStore = InMemoryEventStore();
+      var id = 0;
+      final controller = RideController(
+        eventStore,
+        InMemorySessionStore(),
+        const _Nearby(),
+        deviceIdentityStore: InMemoryDeviceIdentityStore(),
+        idFactory: () => 'id-${id++}',
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.createRide('Pilot');
+      final session = controller.session!;
+      final unsigned = RideEvent(
+        id: 'legacy-forgery',
+        rideId: session.rideId,
+        deviceId: session.localRiderId,
+        type: RideEventType.rideEnded,
+        priority: EventPriority.critical,
+        createdAt: DateTime.utc(2026, 8, 24, 13),
+        payload: const {},
+        signature: '',
+      );
+      await eventStore.append(
+        RideEvent(
+          id: unsigned.id,
+          rideId: unsigned.rideId,
+          deviceId: unsigned.deviceId,
+          type: unsigned.type,
+          priority: unsigned.priority,
+          createdAt: unsigned.createdAt,
+          payload: unsigned.payload,
+          signature: RideEventAuthenticator.sign(
+            unsigned,
+            session.inviteSecret,
+          ),
+        ),
+      );
+
+      await controller.reloadEvents();
+      expect(
+        controller.events,
+        isNot(
+          contains(
+            predicate<RideEvent>((event) => event.id == 'legacy-forgery'),
+          ),
+        ),
+      );
+      expect(controller.rideEnded, isFalse);
+    },
+  );
+
+  test(
+    'local key rotation preserves device identity and survives restore',
+    () async {
+      final eventStore = InMemoryEventStore();
+      final sessionStore = InMemorySessionStore();
+      final identities = InMemoryDeviceIdentityStore();
+      var id = 0;
+      final controller = RideController(
+        eventStore,
+        sessionStore,
+        const _Nearby(),
+        deviceIdentityStore: identities,
+        idFactory: () => 'rotate-${id++}',
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.createRide('Pilot');
+      final deviceId = controller.session!.localRiderId;
+      final oldPublicKey = controller.session!.localDevicePublicKey;
+
+      await controller.rotateLocalDeviceAuthority();
+
+      expect(controller.errorMessage, isNull);
+      expect(controller.session!.localRiderId, deviceId);
+      expect(controller.session!.localDevicePublicKey, isNot(oldPublicKey));
+      expect(
+        controller.events.where(
+          (event) => event.type == RideEventType.deviceAuthorityRotated,
+        ),
+        hasLength(1),
+      );
+      await controller.sendQuickMessage(QuickMessage.stopped);
+      expect(controller.errorMessage, isNull);
+
+      final restored = RideController(
+        eventStore,
+        sessionStore,
+        const _Nearby(),
+        deviceIdentityStore: identities,
+        idFactory: () => 'restored-${id++}',
+      );
+      addTearDown(restored.dispose);
+      await restored.initialize();
+      expect(restored.session!.localRiderId, deviceId);
+      expect(restored.events.length, controller.events.length);
+    },
+  );
+
+  test(
+    'a peer cannot bypass proof checks by claiming the local device id',
+    () async {
+      final now = DateTime.utc(2026, 8, 24, 12);
+      final controller = RideController(
+        InMemoryEventStore(),
+        InMemorySessionStore(),
+        const _Nearby(),
+        deviceIdentityStore: InMemoryDeviceIdentityStore(),
+        clock: () => now,
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.createRide('Pilot');
+      final session = controller.session!;
+      final position = RiderLocation(
+        riderId: session.localRiderId,
+        displayName: session.displayName,
+        role: RideRole.lead,
+        sample: LocationSample(
+          position: const GeoPoint(latitude: 51.25, longitude: -2.35),
+          recordedAt: now,
+          accuracyMeters: 4,
+        ),
+        receivedAt: now,
+      );
+      final signed = await controller.createAuthenticatedPresence(
+        position: position,
+        clear: false,
+        ttl: const Duration(seconds: 45),
+      );
+
+      expect(await controller.verifyAuthenticatedPresence(signed, now), isTrue);
+      expect(
+        await controller.verifyAuthenticatedPresence(
+          RelayPresenceUpdate(
+            riderId: session.localRiderId,
+            sentAt: now,
+            expiresAt: now.add(const Duration(seconds: 45)),
+            clear: false,
+            position: position,
+          ),
+          now,
+        ),
+        isFalse,
+      );
+    },
+  );
+}
+
+class _Nearby extends NearbyBridge {
+  const _Nearby();
+
+  @override
+  Future<NearbyCapabilities> capabilities() async =>
+      const NearbyCapabilities.unavailable();
+}

--- a/apps/mobile/test/controllers/ride_controller_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_test.dart
@@ -75,6 +75,13 @@ void main() {
     return joined;
   }
 
+  Future<void> appendAuthenticatedPeerEvent(RideEvent event) async {
+    final secret = controller.session!.inviteSecret;
+    await eventStore.append(
+      event.copyWith(signature: RideEventAuthenticator.sign(event, secret)),
+    );
+  }
+
   test(
     'new flight persists pilot role and atomic balloon assignment',
     () async {
@@ -1123,10 +1130,9 @@ void main() {
 
       expect(controller.hasActiveRide, isFalse);
       expect(await sessionStore.load(), isNull);
-      final retained = await eventStore.eventsForRide(rideId);
-      expect(retained.last.type, RideEventType.riderLeft);
-      expect(retained.last.payload['riderId'], retained.last.deviceId);
-      expect(published?.id, retained.last.id);
+      expect(await eventStore.eventsForRide(rideId), isEmpty);
+      expect(published?.type, RideEventType.riderLeft);
+      expect(published?.payload['riderId'], published?.deviceId);
       expect(published?.signature, hasLength(64));
     },
   );
@@ -1239,7 +1245,7 @@ void main() {
     final rideId = controller.session!.rideId;
     final myId = controller.session!.localRiderId;
 
-    await eventStore.append(
+    await appendAuthenticatedPeerEvent(
       RideEvent(
         id: 'broadcast-share',
         rideId: rideId,
@@ -1256,7 +1262,7 @@ void main() {
         signature: 'relay-test',
       ),
     );
-    await eventStore.append(
+    await appendAuthenticatedPeerEvent(
       RideEvent(
         id: 'addressed-to-me',
         rideId: rideId,
@@ -1274,7 +1280,7 @@ void main() {
         signature: 'relay-test',
       ),
     );
-    await eventStore.append(
+    await appendAuthenticatedPeerEvent(
       RideEvent(
         id: 'addressed-elsewhere',
         rideId: rideId,
@@ -1306,7 +1312,7 @@ void main() {
     final rideId = controller.session!.rideId;
     final myId = controller.session!.localRiderId;
 
-    await eventStore.append(
+    await appendAuthenticatedPeerEvent(
       RideEvent(
         id: 'their-share',
         rideId: rideId,
@@ -1351,7 +1357,7 @@ void main() {
         .id;
     expect(controller.sentIceShares.single.viewedAt, isNull);
 
-    await eventStore.append(
+    await appendAuthenticatedPeerEvent(
       RideEvent(
         id: 'their-view',
         rideId: rideId,
@@ -1376,7 +1382,7 @@ void main() {
     final rideId = controller.session!.rideId;
     final myId = controller.session!.localRiderId;
 
-    await eventStore.append(
+    await appendAuthenticatedPeerEvent(
       RideEvent(
         id: 'unused-share',
         rideId: rideId,
@@ -1393,7 +1399,7 @@ void main() {
         signature: 'relay-test',
       ),
     );
-    await eventStore.append(
+    await appendAuthenticatedPeerEvent(
       RideEvent(
         id: 'used-share',
         rideId: rideId,

--- a/apps/mobile/test/data/ride_diagnostics_log_store_test.dart
+++ b/apps/mobile/test/data/ride_diagnostics_log_store_test.dart
@@ -28,7 +28,7 @@ void main() {
     test('a written log survives and reads back whole', () async {
       await store.write(rideId: 'ride-1', text: _log('ABCD'));
 
-      expect(await store.read('ride-1'), _log('ABCD'));
+      expect(await store.read('ride-1'), _safeLog(_log('ABCD')));
     });
 
     test('writing again replaces rather than accumulates', () async {
@@ -39,15 +39,14 @@ void main() {
       expect(await store.list(), hasLength(1));
     });
 
-    test('the ride code is read back out of the log itself', () async {
+    test('a ride code is removed before the log reaches storage', () async {
       await store.write(rideId: 'ride-1', text: _log('ABCD'));
 
       final log = await store.latest();
 
-      // Read rather than stored alongside, so there is no second copy to fall out
-      // of step with the file a rider actually holds.
-      expect(log?.rideCode, 'ABCD');
-      expect(log?.fileName, 'balloon-crumbs-diagnostics-ABCD.txt');
+      expect(log?.rideCode, isNull);
+      expect(log?.text, isNot(contains('ABCD')));
+      expect(log?.fileName, 'balloon-crumbs-diagnostics-ride-1.txt');
     });
 
     test('a log with no ride code is still offered', () async {
@@ -81,7 +80,7 @@ void main() {
       final logs = await store.list();
 
       expect(logs, hasLength(kept));
-      expect(logs.first.rideCode, 'CODE${kept + 2}', reason: 'newest first');
+      expect(logs.first.rideId, 'ride-${kept + 2}', reason: 'newest first');
       expect(
         logs.map((log) => log.rideId),
         isNot(contains('ride-0')),
@@ -129,7 +128,7 @@ void main() {
       // A recorded entry can contain the word, and a log is thousands of lines.
       final log = '${_log('ABCD')}\n${'filler\n' * 20}Ride:  WRONG';
 
-      expect(RideDiagnosticsLog.rideCodeIn(log), 'ABCD');
+      expect(RideDiagnosticsLog.rideCodeIn(log), isNull);
     });
 
     test('a log with no written-at falls back to the file time', () async {
@@ -148,7 +147,7 @@ void main() {
       // path.
       await store.write(rideId: '../escaped', text: _log('ABCD'));
 
-      expect(await store.read('../escaped'), _log('ABCD'));
+      expect(await store.read('../escaped'), _safeLog(_log('ABCD')));
       final escaped = File('${directory.path}/escaped.txt');
       expect(await escaped.exists(), isFalse);
       expect(await store.list(), hasLength(1));
@@ -170,8 +169,8 @@ void main() {
 
       await memory.write(rideId: 'ride-1', text: _log('ABCD'));
 
-      expect(await memory.read('ride-1'), _log('ABCD'));
-      expect((await memory.latest())?.rideCode, 'ABCD');
+      expect(await memory.read('ride-1'), _safeLog(_log('ABCD')));
+      expect((await memory.latest())?.rideCode, isNull);
     });
   });
 }
@@ -187,3 +186,6 @@ String _log(String rideCode, {DateTime? at}) {
       '\n'
       '$written  NOTE       recording started';
 }
+
+String _safeLog(String value) =>
+    RideDiagnosticsLog.withoutCredentialHeader(value);

--- a/apps/mobile/test/domain/ride_join_payload_test.dart
+++ b/apps/mobile/test/domain/ride_join_payload_test.dart
@@ -6,6 +6,7 @@ import 'package:balloon_crumbs/domain/ride_join_payload.dart';
 void main() {
   const secret = '0123456789abcdef0123456789abcdef';
   const joinToken = 'resolve-token-0123456789';
+  const rootKey = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 
   const payload = RideJoinPayload(
     rideId: '019fb78c-4045-7213-b053-9197b4c2669f',
@@ -21,6 +22,21 @@ void main() {
     expect(decoded.rideCode, payload.rideCode);
     expect(decoded.inviteSecret, payload.inviteSecret);
     expect(decoded.joinToken, payload.joinToken);
+  });
+
+  test('current invitation carries the authority root', () {
+    const current = RideJoinPayload(
+      rideId: 'ride-1',
+      rideCode: '934893',
+      inviteSecret: secret,
+      joinToken: joinToken,
+      authorityRootPublicKey: rootKey,
+    );
+
+    final decoded = RideJoinPayload.decode(current.encode());
+
+    expect(current.encode(), startsWith('bc2:'));
+    expect(decoded.authorityRootPublicKey, rootKey);
   });
 
   test('tolerates surrounding whitespace from a scan', () {
@@ -87,6 +103,10 @@ void main() {
     test('too few or too many fields', () {
       expectRejected('bc1:934893:ride-1:$secret');
       expectRejected('bc1:934893:ride-1:$secret:$joinToken:extra');
+    });
+
+    test('a malformed authority root', () {
+      expectRejected('bc2:934893:ride-1:$secret:$joinToken:short');
     });
   });
 

--- a/apps/mobile/test/internet/internet_relay_client_test.dart
+++ b/apps/mobile/test/internet/internet_relay_client_test.dart
@@ -306,6 +306,7 @@ void main() {
     test(
       'registers and resolves a six-digit code over the configured relay',
       () async {
+        const rootKey = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
         final requests = <http.Request>[];
         final transport = MockClient((request) async {
           requests.add(request);
@@ -321,6 +322,7 @@ void main() {
               'rideCode': '123456',
               'inviteSecret': _session.inviteSecret,
               'resolveToken': _session.joinToken,
+              'authorityRootPublicKey': rootKey,
             }),
             200,
             headers: {'content-type': 'application/json'},
@@ -332,7 +334,12 @@ void main() {
           ),
           client: transport,
         );
-        final leader = _session.copyWith(rideCode: '123456');
+        final leader = _session.copyWith(
+          rideCode: '123456',
+          authorizationVersion: 2,
+          authorityRootPublicKey: rootKey,
+          localDevicePublicKey: rootKey,
+        );
 
         await directory.register(leader);
         final resolved = await directory.resolve('123456');
@@ -341,6 +348,7 @@ void main() {
         expect(resolved.rideCode, '123456');
         expect(resolved.inviteSecret, _session.inviteSecret);
         expect(resolved.joinToken, _session.joinToken);
+        expect(resolved.authorityRootPublicKey, rootKey);
         expect(requests, hasLength(3));
         expect(requests.first.url.path, '/base/v1/compatibility');
         expect(requests[1].method, 'PUT');
@@ -350,6 +358,7 @@ void main() {
           'rideId': _session.rideId,
           'inviteSecret': _session.inviteSecret,
           'resolveToken': _session.joinToken,
+          'authorityRootPublicKey': rootKey,
         });
         expect(requests.last.method, 'GET');
         expect(

--- a/apps/mobile/test/internet/relay_version_skew_test.dart
+++ b/apps/mobile/test/internet/relay_version_skew_test.dart
@@ -32,8 +32,8 @@ void main() {
         'rideTeleported',
       );
       expect(
-        describeUnsupportedRelayEvent(_rawEvent(schemaVersion: 2)),
-        'schema-v2',
+        describeUnsupportedRelayEvent(_rawEvent(schemaVersion: 3)),
+        'schema-v3',
       );
       expect(
         describeUnsupportedRelayEvent(_rawEvent(extra: {'convoyId': 'c-1'})),
@@ -68,7 +68,7 @@ void main() {
             'events': [
               _rawEvent(id: 'future', type: 'rideTeleported'),
               known.toJson(),
-              _rawEvent(id: 'future-schema', schemaVersion: 2),
+              _rawEvent(id: 'future-schema', schemaVersion: 3),
             ],
           }),
           200,
@@ -94,7 +94,7 @@ void main() {
       expect(result.events.map((event) => event.id), ['known']);
       expect(result.cursor, 'cursor-1');
       expect(result.ignoredEventCount, 2);
-      expect(result.ignoredEventTypes, {'rideTeleported', 'schema-v2'});
+      expect(result.ignoredEventTypes, {'rideTeleported', 'schema-v3'});
     },
   );
 

--- a/apps/mobile/test/relay/relay_engine_test.dart
+++ b/apps/mobile/test/relay/relay_engine_test.dart
@@ -10,6 +10,7 @@ import 'package:balloon_crumbs/domain/rider_location.dart';
 import 'package:balloon_crumbs/relay/in_memory_relay_queue.dart';
 import 'package:balloon_crumbs/relay/peer_transport.dart';
 import 'package:balloon_crumbs/relay/relay_engine.dart';
+import 'package:balloon_crumbs/services/ride_event_authenticator.dart';
 
 void main() {
   const secret = '0123456789abcdef0123456789abcdef';
@@ -68,7 +69,7 @@ void main() {
 
     await _drain();
     transportA.connect(transportB);
-    final event = RideEvent(
+    final unsignedEvent = RideEvent(
       id: 'event-1',
       rideId: 'ride-1',
       deviceId: 'device-a',
@@ -76,7 +77,10 @@ void main() {
       priority: EventPriority.critical,
       createdAt: now,
       payload: const {'message': 'emergencyStop'},
-      signature: 'a' * 64,
+      signature: '',
+    );
+    final event = unsignedEvent.copyWith(
+      signature: RideEventAuthenticator.sign(unsignedEvent, secret),
     );
     await storeA.append(event);
     await engineA.enqueueLocal(event);

--- a/apps/mobile/test/relay/relay_protocol_forward_compatibility_test.dart
+++ b/apps/mobile/test/relay/relay_protocol_forward_compatibility_test.dart
@@ -48,7 +48,7 @@ void main() {
       frame([
         _rawEvent(id: 'future', type: 'rideTeleported'),
         _rawEvent(id: 'known', type: 'riderJoined'),
-        _rawEvent(id: 'future-schema', schemaVersion: 2),
+        _rawEvent(id: 'future-schema', schemaVersion: 3),
         _rawEvent(id: 'known-position', type: 'riderLocationUpdated'),
       ]),
       secret: secret,

--- a/apps/mobile/test/services/device_authority_policy_test.dart
+++ b/apps/mobile/test/services/device_authority_policy_test.dart
@@ -1,0 +1,146 @@
+import 'package:balloon_crumbs/domain/flight_role.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/services/device_authority_policy.dart';
+import 'package:balloon_crumbs/services/device_identity.dart';
+import 'package:balloon_crumbs/services/ride_event_authenticator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const secret = 'operation-secret-with-enough-entropy';
+  const rideId = 'ride-device-authority';
+  late DeviceIdentity root;
+  late DeviceIdentity crew;
+  late RideSession session;
+
+  setUp(() async {
+    root = await DeviceIdentity.fromSeed(
+      rideId: rideId,
+      seed: List<int>.generate(32, (index) => index),
+    );
+    crew = await DeviceIdentity.fromSeed(
+      rideId: rideId,
+      seed: List<int>.generate(32, (index) => 255 - index),
+    );
+    session = RideSession(
+      rideId: rideId,
+      rideCode: '123456',
+      inviteSecret: secret,
+      joinToken: 'join-token-with-enough-entropy',
+      localRiderId: root.deviceId,
+      displayName: 'Pilot',
+      role: RideRole.lead,
+      flightRole: FlightRole.pilot,
+      joinedAt: DateTime.utc(2026, 8, 24),
+      authorizationVersion: 2,
+      authorityRootPublicKey: root.publicKey,
+      localDevicePublicKey: root.publicKey,
+    );
+  });
+
+  Future<RideEvent> signed({
+    required DeviceIdentity identity,
+    required RideEventType type,
+    required Map<String, Object?> payload,
+    required int minute,
+  }) {
+    return RideEventAuthenticator.signForDevice(
+      event: RideEvent(
+        id: '${identity.deviceId}-$minute-${type.name}',
+        rideId: rideId,
+        deviceId: identity.deviceId,
+        type: type,
+        priority: EventPriority.important,
+        createdAt: DateTime.utc(2026, 8, 24, 12, minute),
+        payload: payload,
+        signature: '',
+        devicePublicKey: identity.publicKey,
+        schemaVersion: 2,
+      ),
+      secret: secret,
+      identity: identity,
+    );
+  }
+
+  test(
+    'shared secret cannot impersonate pilot or exercise pilot authority',
+    () async {
+      final policy = DeviceAuthorityPolicy(session);
+      final created = await signed(
+        identity: root,
+        type: RideEventType.rideCreated,
+        payload: const {'role': 'lead', 'flightRole': 'pilot'},
+        minute: 0,
+      );
+      final joined = await signed(
+        identity: crew,
+        type: RideEventType.riderJoined,
+        payload: const {
+          'displayName': 'Crew',
+          'role': 'rider',
+          'flightRole': 'chaseCrew',
+        },
+        minute: 1,
+      );
+      final forgedPilotAction = await signed(
+        identity: crew,
+        type: RideEventType.landingAreaNoted,
+        payload: const {'landingZoneId': 'forged'},
+        minute: 2,
+      );
+      final realPilotAction = await signed(
+        identity: root,
+        type: RideEventType.landingAreaNoted,
+        payload: const {'landingZoneId': 'pilot'},
+        minute: 3,
+      );
+
+      expect(policy.accept(created), isTrue);
+      expect(policy.accept(joined), isTrue);
+      expect(policy.accept(forgedPilotAction), isFalse);
+      expect(policy.accept(realPilotAction), isTrue);
+    },
+  );
+
+  test('pilot revocation makes all later device events inert', () async {
+    final events = <RideEvent>[
+      await signed(
+        identity: root,
+        type: RideEventType.rideCreated,
+        payload: const {'role': 'lead', 'flightRole': 'pilot'},
+        minute: 0,
+      ),
+      await signed(
+        identity: crew,
+        type: RideEventType.riderJoined,
+        payload: const {
+          'displayName': 'Crew',
+          'role': 'rider',
+          'flightRole': 'chaseCrew',
+        },
+        minute: 1,
+      ),
+      await signed(
+        identity: root,
+        type: RideEventType.deviceAuthorityRevoked,
+        payload: {'targetDeviceId': crew.deviceId},
+        minute: 2,
+      ),
+      await signed(
+        identity: crew,
+        type: RideEventType.statusMessage,
+        payload: const {'message': 'should not be visible'},
+        minute: 3,
+      ),
+    ];
+
+    final policy = DeviceAuthorityPolicy(session);
+    expect(policy.filter(events).map((event) => event.type), [
+      RideEventType.rideCreated,
+      RideEventType.riderJoined,
+      RideEventType.deviceAuthorityRevoked,
+    ]);
+    expect(policy.revokedDeviceIds, contains(crew.deviceId));
+  });
+}

--- a/apps/mobile/test/services/presence_authenticator_test.dart
+++ b/apps/mobile/test/services/presence_authenticator_test.dart
@@ -1,0 +1,82 @@
+import 'package:balloon_crumbs/domain/geo_point.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/rider_location.dart';
+import 'package:balloon_crumbs/services/device_identity.dart';
+import 'package:balloon_crumbs/services/presence_authenticator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 24, 12);
+
+  test('live position proof binds the device, coordinates and time', () async {
+    final identity = await DeviceIdentity.fromSeed(
+      rideId: 'ride-1',
+      seed: List<int>.generate(32, (index) => index),
+    );
+    final position = RiderLocation(
+      riderId: identity.deviceId,
+      displayName: 'Alex',
+      role: RideRole.rider,
+      sample: LocationSample(
+        position: const GeoPoint(latitude: 51.25, longitude: -2.35),
+        recordedAt: now,
+        accuracyMeters: 4,
+        speedMetersPerSecond: 12,
+        headingDegrees: 90,
+      ),
+      receivedAt: now,
+    );
+    final proof = await PresenceAuthenticator.sign(
+      rideId: 'ride-1',
+      riderId: identity.deviceId,
+      position: position,
+      clear: false,
+      signedAt: now,
+      identity: identity,
+    );
+
+    expect(
+      await PresenceAuthenticator.verify(
+        rideId: 'ride-1',
+        riderId: identity.deviceId,
+        position: position,
+        clear: false,
+        proof: proof,
+        now: now,
+      ),
+      isTrue,
+    );
+    expect(
+      await PresenceAuthenticator.verify(
+        rideId: 'ride-1',
+        riderId: identity.deviceId,
+        position: RiderLocation(
+          riderId: identity.deviceId,
+          displayName: 'Alex',
+          role: RideRole.rider,
+          sample: LocationSample(
+            position: const GeoPoint(latitude: 51.26, longitude: -2.35),
+            recordedAt: now,
+            accuracyMeters: 4,
+          ),
+          receivedAt: now,
+        ),
+        clear: false,
+        proof: proof,
+        now: now,
+      ),
+      isFalse,
+    );
+    expect(
+      await PresenceAuthenticator.verify(
+        rideId: 'ride-1',
+        riderId: identity.deviceId,
+        position: position,
+        clear: false,
+        proof: proof,
+        now: now.add(const Duration(minutes: 6)),
+      ),
+      isFalse,
+    );
+  });
+}

--- a/apps/mobile/test/services/ride_diagnostics_recorder_test.dart
+++ b/apps/mobile/test/services/ride_diagnostics_recorder_test.dart
@@ -359,8 +359,8 @@ void main() {
       final report = recorder.render(rideCode: '123456', appBuild: '1.2.3+46');
 
       expect(report, contains("this phone's own"));
-      expect(report, contains('no flight or invite secret'));
-      expect(report, contains('Flight:  123456'));
+      expect(report, contains('no flight code or invite secret'));
+      expect(report, isNot(contains('123456')));
       expect(report, contains('Build: 1.2.3+46'));
     });
   });

--- a/apps/server/src/balloon_crumbs_server/app.py
+++ b/apps/server/src/balloon_crumbs_server/app.py
@@ -532,6 +532,7 @@ def create_app(
             invite_secret=payload.inviteSecret,
             bearer_token=authorization[7:],
             resolve_token=payload.resolveToken,
+            authority_root_public_key=payload.authorityRootPublicKey,
         )
         join_code_requests.labels(outcome="registered").inc()
         return Response(status_code=204)
@@ -563,7 +564,9 @@ def create_app(
             resolve_token=resolve_token,
         )
         join_code_requests.labels(outcome="resolved").inc()
-        return JSONResponse(content=JoinCodeResponse.model_validate(result).model_dump())
+        return JSONResponse(
+            content=JoinCodeResponse.model_validate(result).model_dump(exclude_none=True)
+        )
 
     def _crew_room_rate_limit(request: Request) -> Response | None:
         client_ip = request.client.host if request.client is not None else "unknown"
@@ -585,6 +588,13 @@ def create_app(
             raise RelayServiceError(401, "Ride credential rejected")
         return token
 
+    def _crew_room_content(result: dict[str, object]) -> dict[str, object]:
+        content = CrewRoomResponse.model_validate(result).model_dump(mode="json")
+        operation = content.get("operation")
+        if isinstance(operation, dict) and operation.get("authorityRootPublicKey") is None:
+            operation.pop("authorityRootPublicKey", None)
+        return content
+
     @app.post("/api/v1/crew-rooms/create", include_in_schema=False)
     def create_crew_room(
         payload: CreateCrewRoomRequest,
@@ -603,7 +613,7 @@ def create_app(
         )
         return JSONResponse(
             status_code=201,
-            content=CrewRoomResponse.model_validate(result).model_dump(mode="json"),
+            content=_crew_room_content(result),
         )
 
     @app.post("/api/v1/crew-rooms/open", include_in_schema=False)
@@ -620,7 +630,7 @@ def create_app(
             device_id=payload.deviceId,
             device_credential=payload.deviceCredential,
         )
-        return JSONResponse(content=CrewRoomResponse.model_validate(result).model_dump(mode="json"))
+        return JSONResponse(content=_crew_room_content(result))
 
     @app.post("/api/v1/crew-rooms/join", include_in_schema=False)
     def join_crew_room(
@@ -637,7 +647,7 @@ def create_app(
             device_id=payload.deviceId,
             display_name=payload.displayName,
         )
-        return JSONResponse(content=CrewRoomResponse.model_validate(result).model_dump(mode="json"))
+        return JSONResponse(content=_crew_room_content(result))
 
     @app.post("/api/v1/crew-rooms/start-operation", include_in_schema=False)
     def start_crew_room_operation(
@@ -655,7 +665,7 @@ def create_app(
             operation=payload.operation.model_dump(),
             bearer_token=_ride_bearer_for_room(request),
         )
-        return JSONResponse(content=CrewRoomResponse.model_validate(result).model_dump(mode="json"))
+        return JSONResponse(content=_crew_room_content(result))
 
     @app.post("/api/v1/crew-rooms/devices", include_in_schema=False)
     def list_crew_room_devices(
@@ -1136,7 +1146,8 @@ def create_app(
             )
 
         try:
-            payload = PresenceSyncRequest.model_validate_json(body)
+            raw_payload = json.loads(body)
+            payload = PresenceSyncRequest.model_validate(raw_payload)
         except (ValidationError, json.JSONDecodeError, UnicodeDecodeError) as error:
             raise RelayServiceError(400, "Malformed presence request") from error
         request_protocol = client_protocol(request, payload.protocolVersion)
@@ -1159,6 +1170,7 @@ def create_app(
             bearer_token=bearer_token,
             device_header=request.headers.get("x-balloon-crumbs-device", ""),
             request=payload,
+            raw_position=(raw_payload.get("position") if isinstance(raw_payload, dict) else None),
             live_presence=live_presence,
             client_protocol=request_protocol,
         )

--- a/apps/server/src/balloon_crumbs_server/config.py
+++ b/apps/server/src/balloon_crumbs_server/config.py
@@ -82,6 +82,10 @@ class Settings(BaseSettings):
             # cursor-independent ride roster. Advertised alongside the legacy
             # pre-start capability so an older client keeps working unchanged.
             "live-presence-v2",
+            # Per-device Ed25519 proof on ephemeral positions. The shared ride
+            # bearer remains transport access, not authority to impersonate a
+            # crew device.
+            "device-authority-v1",
             "route-revisions-v1",
             "push-notifications-v1",
             "observer-access-v1",

--- a/apps/server/src/balloon_crumbs_server/schemas.py
+++ b/apps/server/src/balloon_crumbs_server/schemas.py
@@ -45,6 +45,11 @@ class PresenceLocationSample(BaseModel):
     accuracyMeters: float = Field(ge=0, le=500)
     speedMetersPerSecond: float | None = Field(default=None, ge=0, le=100)
     headingDegrees: float | None = Field(default=None, ge=0, lt=360)
+    altitudeMeters: float | None = Field(default=None, ge=-1000, le=30000)
+    altitudeSource: str | None = Field(default=None, min_length=1, max_length=40)
+    altitudeDatum: str | None = Field(default=None, min_length=1, max_length=40)
+    altitudeAccuracyMeters: float | None = Field(default=None, ge=0, le=10000)
+    verticalSpeedMetersPerSecond: float | None = Field(default=None, ge=-100, le=100)
 
 
 class PresencePositionRequest(BaseModel):
@@ -77,11 +82,25 @@ class PresenceSyncRequest(BaseModel):
     deviceId: str = Field(min_length=1, max_length=128)
     position: PresencePositionRequest | None = None
     clear: bool = False
+    authorityVersion: Literal[1] | None = None
+    signedAtMilliseconds: int | None = Field(default=None, ge=0)
+    devicePublicKey: str | None = Field(default=None, pattern=r"^[A-Za-z0-9_-]{43}$")
+    deviceSignature: str | None = Field(default=None, pattern=r"^[A-Za-z0-9_-]{86}$")
 
     @model_validator(mode="after")
     def clear_cannot_publish(self) -> PresenceSyncRequest:
         if self.clear and self.position is not None:
             raise ValueError("A presence request cannot publish and clear together")
+        authority = (
+            self.authorityVersion,
+            self.signedAtMilliseconds,
+            self.devicePublicKey,
+            self.deviceSignature,
+        )
+        if any(value is not None for value in authority) and not all(
+            value is not None for value in authority
+        ):
+            raise ValueError("A presence authority proof must be complete")
         return self
 
 
@@ -95,6 +114,10 @@ class PresencePositionResponse(PresencePositionRequest):
     # unexplained gap once the ride starts.
     livePresence: bool = False
     clientProtocol: int = Field(default=1, ge=1, le=1000)
+    authorityVersion: Literal[1] | None = None
+    signedAtMilliseconds: int | None = Field(default=None, ge=0)
+    devicePublicKey: str | None = Field(default=None, pattern=r"^[A-Za-z0-9_-]{43}$")
+    deviceSignature: str | None = Field(default=None, pattern=r"^[A-Za-z0-9_-]{86}$")
 
 
 class PresenceMemberResponse(BaseModel):
@@ -179,6 +202,7 @@ class RegisterJoinCodeRequest(BaseModel):
     rideId: str = Field(min_length=1, max_length=128)
     inviteSecret: str = Field(min_length=16, max_length=512)
     resolveToken: str = Field(min_length=16, max_length=128)
+    authorityRootPublicKey: str | None = Field(default=None, pattern=r"^[A-Za-z0-9_-]{43}$")
 
 
 class JoinCodeResponse(BaseModel):
@@ -188,6 +212,7 @@ class JoinCodeResponse(BaseModel):
     rideCode: str
     inviteSecret: str
     resolveToken: str
+    authorityRootPublicKey: str | None = None
 
 
 class CrewRoomOperation(BaseModel):
@@ -197,6 +222,7 @@ class CrewRoomOperation(BaseModel):
     rideCode: str = Field(pattern=r"^\d{6}$")
     inviteSecret: str = Field(min_length=16, max_length=512)
     resolveToken: str = Field(min_length=16, max_length=128)
+    authorityRootPublicKey: str | None = Field(default=None, pattern=r"^[A-Za-z0-9_-]{43}$")
 
 
 class CreateCrewRoomRequest(BaseModel):

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hmac
 import json
 import math
@@ -9,6 +10,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -98,6 +101,8 @@ EVENT_TYPES = {
     "flightStartedByCrew",
     "flightLanded",
     "flightLandingRetracted",
+    "deviceAuthorityRevoked",
+    "deviceAuthorityRotated",
 }
 PRIORITIES = {"routine", "important", "critical"}
 EVENT_FIELDS = {
@@ -111,6 +116,8 @@ EVENT_FIELDS = {
     "expiresAt",
     "payload",
     "signature",
+    "devicePublicKey",
+    "deviceSignature",
     "acknowledged",
 }
 
@@ -279,6 +286,7 @@ class RelayService:
         bearer_token: str,
         device_header: str,
         request: PresenceSyncRequest,
+        raw_position: dict[str, Any] | None = None,
         live_presence: bool = False,
         client_protocol: int = 1,
         now: datetime | None = None,
@@ -295,9 +303,9 @@ class RelayService:
         self._validate_identity(ride_id, request.deviceId, device_header)
         if not TOKEN.fullmatch(bearer_token):
             raise RelayServiceError(401, "Ride credential rejected")
-        position = (
-            request.position.model_dump(mode="json") if request.position is not None else None
-        )
+        position = raw_position
+        if request.position is not None and position is None:
+            position = request.position.model_dump(mode="json", exclude_unset=True)
         if position is not None:
             recorded_at = request.position.sample.recordedAt
             if recorded_at < now - timedelta(minutes=5):
@@ -310,6 +318,22 @@ class RelayService:
                 raise RelayServiceError(404, "Ride is not ready for presence")
             if not hmac.compare_digest(ride.token_hash, token_hash(bearer_token)):
                 raise RelayServiceError(403, "Ride credential rejected")
+            authority_required = self._ride_uses_device_authority(session, ride_id)
+            authority_present = request.authorityVersion is not None
+            if authority_required and not authority_present:
+                raise RelayServiceError(403, "Device authority proof required")
+            if authority_present:
+                self._verify_presence_authority(
+                    ride_id=ride_id,
+                    rider_id=request.deviceId,
+                    position=position,
+                    clear=request.clear,
+                    authority_version=request.authorityVersion,
+                    signed_at_milliseconds=request.signedAtMilliseconds,
+                    public_key=request.devicePublicKey,
+                    signature=request.deviceSignature,
+                    now=now,
+                )
             session.execute(
                 delete(PreStartPosition).where(
                     PreStartPosition.ride_id == ride_id,
@@ -349,6 +373,10 @@ class RelayService:
                         "expiresAt": expires_at.isoformat(),
                         "livePresence": live_presence,
                         "clientProtocol": client_protocol,
+                        "authorityVersion": request.authorityVersion,
+                        "signedAtMilliseconds": request.signedAtMilliseconds,
+                        "devicePublicKey": request.devicePublicKey,
+                        "deviceSignature": request.deviceSignature,
                     }
                     ciphertext = self._cipher.encrypt_json(
                         snapshot,
@@ -393,6 +421,76 @@ class RelayService:
             # age a peer's position without trusting that peer's own clock.
             "serverTime": now.isoformat(),
         }
+
+    def _ride_uses_device_authority(self, session: Session, ride_id: str) -> bool:
+        row = session.scalar(
+            select(StoredEvent)
+            .where(
+                StoredEvent.ride_id == ride_id,
+                StoredEvent.event_type == "rideCreated",
+            )
+            .order_by(StoredEvent.sequence)
+            .limit(1)
+        )
+        if row is None:
+            return False
+        try:
+            body = self._cipher.decrypt_json(
+                row.body_ciphertext,
+                associated_data=self._event_aad(ride_id, row.event_id),
+            )
+        except ValueError:
+            return False
+        return isinstance(body, dict) and body.get("schemaVersion") == 2
+
+    @staticmethod
+    def _verify_presence_authority(
+        *,
+        ride_id: str,
+        rider_id: str,
+        position: dict[str, Any] | None,
+        clear: bool,
+        authority_version: int | None,
+        signed_at_milliseconds: int | None,
+        public_key: str | None,
+        signature: str | None,
+        now: datetime,
+    ) -> None:
+        if (
+            authority_version != 1
+            or signed_at_milliseconds is None
+            or public_key is None
+            or signature is None
+        ):
+            raise RelayServiceError(403, "Device authority proof rejected")
+        signed_at = datetime.fromtimestamp(signed_at_milliseconds / 1000, tz=UTC)
+        if signed_at < now - timedelta(minutes=5) or signed_at > now + timedelta(minutes=2):
+            raise RelayServiceError(400, "Device authority proof is outside its time window")
+        body = {
+            "rideId": ride_id,
+            "riderId": rider_id,
+            "signedAtMilliseconds": signed_at_milliseconds,
+            "clear": clear,
+            "position": position,
+        }
+        challenge = "balloon-crumbs-live-presence-v1\n" + json.dumps(
+            body,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        try:
+            key_bytes = base64.urlsafe_b64decode(public_key + "=")
+            signature_bytes = base64.urlsafe_b64decode(signature + "==")
+            if len(key_bytes) != 32 or len(signature_bytes) != 64:
+                raise ValueError
+            Ed25519PublicKey.from_public_bytes(key_bytes).verify(
+                signature_bytes,
+                challenge.encode(),
+            )
+        except (InvalidSignature, ValueError) as error:
+            raise RelayServiceError(403, "Device authority proof rejected") from error
 
     @staticmethod
     def _ride_presence_phase(session: Session, ride_id: str) -> str:
@@ -496,6 +594,7 @@ class RelayService:
         invite_secret: str,
         bearer_token: str,
         resolve_token: str,
+        authority_root_public_key: str | None = None,
         now: datetime | None = None,
     ) -> None:
         now = now or datetime.now(UTC)
@@ -503,9 +602,21 @@ class RelayService:
         self._validate_join_credential(ride_id, invite_secret, bearer_token)
         if not 16 <= len(resolve_token) <= 128:
             raise RelayServiceError(400, "Invalid ride credential")
+        if authority_root_public_key is not None and not re.fullmatch(
+            r"[A-Za-z0-9_-]{43}", authority_root_public_key
+        ):
+            raise RelayServiceError(400, "Invalid device authority")
         credential_hash = token_hash(bearer_token)
         secret_ciphertext = self._cipher.encrypt_json(
-            {"inviteSecret": invite_secret, "resolveToken": resolve_token},
+            {
+                "inviteSecret": invite_secret,
+                "resolveToken": resolve_token,
+                **(
+                    {"authorityRootPublicKey": authority_root_public_key}
+                    if authority_root_public_key is not None
+                    else {}
+                ),
+            },
             associated_data=self._join_code_aad(ride_code),
         )
         with session.begin():
@@ -554,12 +665,20 @@ class RelayService:
                 raise RelayServiceError(500, "Ride code record is invalid") from error
             secret = value.get("inviteSecret") if isinstance(value, dict) else None
             stored_resolve_token = value.get("resolveToken") if isinstance(value, dict) else None
+            authority_root_public_key = (
+                value.get("authorityRootPublicKey") if isinstance(value, dict) else None
+            )
             if not isinstance(secret, str) or not 16 <= len(secret) <= 512:
                 raise RelayServiceError(500, "Ride code record is invalid")
             valid_resolve_token = (
                 isinstance(stored_resolve_token, str) and 16 <= len(stored_resolve_token) <= 128
             )
             if not valid_resolve_token:
+                raise RelayServiceError(500, "Ride code record is invalid")
+            if authority_root_public_key is not None and not (
+                isinstance(authority_root_public_key, str)
+                and re.fullmatch(r"[A-Za-z0-9_-]{43}", authority_root_public_key)
+            ):
                 raise RelayServiceError(500, "Ride code record is invalid")
             if resolve_token is not None and not hmac.compare_digest(
                 stored_resolve_token, resolve_token
@@ -570,6 +689,11 @@ class RelayService:
                 "rideCode": record.code,
                 "inviteSecret": secret,
                 "resolveToken": stored_resolve_token,
+                **(
+                    {"authorityRootPublicKey": authority_root_public_key}
+                    if authority_root_public_key is not None
+                    else {}
+                ),
             }
 
     def create_crew_room(
@@ -1089,12 +1213,22 @@ class RelayService:
         operation: dict[str, str],
         bearer_token: str,
     ) -> dict[str, str]:
-        expected_fields = {"rideId", "rideCode", "inviteSecret", "resolveToken"}
-        if set(operation) != expected_fields or not all(
-            isinstance(operation.get(field), str) for field in expected_fields
+        required_fields = {"rideId", "rideCode", "inviteSecret", "resolveToken"}
+        allowed_fields = required_fields | {"authorityRootPublicKey"}
+        if (
+            not required_fields.issubset(operation)
+            or not set(operation).issubset(allowed_fields)
+            or not all(isinstance(operation.get(field), str) for field in required_fields)
         ):
             raise RelayServiceError(400, "Crew room operation is invalid")
-        clean = {field: operation[field] for field in expected_fields}
+        clean = {field: operation[field] for field in required_fields}
+        authority_root_public_key = operation.get("authorityRootPublicKey")
+        if authority_root_public_key is not None:
+            if not isinstance(authority_root_public_key, str) or not re.fullmatch(
+                r"[A-Za-z0-9_-]{43}", authority_root_public_key
+            ):
+                raise RelayServiceError(400, "Crew room device authority is invalid")
+            clean["authorityRootPublicKey"] = authority_root_public_key
         self._validate_join_code(clean["rideCode"])
         self._validate_join_credential(clean["rideId"], clean["inviteSecret"], bearer_token)
         if not 16 <= len(clean["resolveToken"]) <= 128:
@@ -1443,9 +1577,15 @@ class RelayService:
         ride_id: str,
         now: datetime,
     ) -> ValidatedEvent:
-        if set(value) != EVENT_FIELDS:
+        schema_version = value.get("schemaVersion")
+        expected_fields = (
+            EVENT_FIELDS
+            if schema_version == 2
+            else EVENT_FIELDS - {"devicePublicKey", "deviceSignature"}
+        )
+        if set(value) != expected_fields:
             raise RelayServiceError(400, "Event fields are invalid")
-        if value.get("schemaVersion") != 1 or value.get("rideId") != ride_id:
+        if schema_version not in {1, 2} or value.get("rideId") != ride_id:
             raise RelayServiceError(400, "Event is invalid for this ride")
         event_id = value.get("id")
         device_id = value.get("deviceId")
@@ -1463,6 +1603,17 @@ class RelayService:
         signature = value.get("signature")
         if not isinstance(signature, str) or not SIGNATURE.fullmatch(signature):
             raise RelayServiceError(400, "Event signature is invalid")
+        if schema_version == 2:
+            public_key = value.get("devicePublicKey")
+            device_signature = value.get("deviceSignature")
+            if not isinstance(public_key, str) or not re.fullmatch(
+                r"[A-Za-z0-9_-]{43}", public_key
+            ):
+                raise RelayServiceError(400, "Event device authority is invalid")
+            if not isinstance(device_signature, str) or not re.fullmatch(
+                r"[A-Za-z0-9_-]{86}", device_signature
+            ):
+                raise RelayServiceError(400, "Event device authority is invalid")
         created_at = self._parse_timestamp(value.get("createdAt"), "createdAt")
         if created_at > now + timedelta(minutes=10):
             raise RelayServiceError(400, "Event creation time is too far in the future")
@@ -1570,6 +1721,8 @@ class RelayService:
             "chaseGuidanceTargetSelected": timedelta(hours=72),
             "pilotHandoverOffered": timedelta(hours=72),
             "pilotHandoverAccepted": timedelta(hours=72),
+            "deviceAuthorityRevoked": timedelta(hours=72),
+            "deviceAuthorityRotated": timedelta(hours=72),
             # Who was asked to cover the back of the group, and what they said.
             # Ride-scoped coordination, not history worth keeping for days.
         }.get(event_type, timedelta(hours=72))

--- a/apps/server/tests/test_additive_event_types.py
+++ b/apps/server/tests/test_additive_event_types.py
@@ -52,6 +52,8 @@ def test_retention_table_matches_the_documented_bands() -> None:
     assert retention("flightStartedByCrew") == timedelta(hours=72)
     assert retention("flightLanded") == timedelta(hours=72)
     assert retention("flightLandingRetracted") == timedelta(hours=72)
+    assert retention("deviceAuthorityRevoked") == timedelta(hours=72)
+    assert retention("deviceAuthorityRotated") == timedelta(hours=72)
 
 
 def test_ground_crew_start_is_accepted_and_relayed(client, synchronize, make_event) -> None:

--- a/apps/server/tests/test_compatibility.py
+++ b/apps/server/tests/test_compatibility.py
@@ -10,6 +10,7 @@ CURRENT_CAPABILITIES = [
     "crew-rooms-v1",
     "ride-start-v1",
     "live-presence-v2",
+    "device-authority-v1",
     "membership-v1",
     "observer-access-v1",
     "pilot-handover-v1",

--- a/apps/server/tests/test_join_codes.py
+++ b/apps/server/tests/test_join_codes.py
@@ -10,6 +10,7 @@ from .conftest import ride_token
 
 SECRET = "0123456789abcdef0123456789abcdef"
 RESOLVE_TOKEN = "resolve-token-0123456789abcdef"
+ROOT_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 
 def _register(
@@ -45,6 +46,25 @@ def test_register_and_resolve_six_digit_ride_code(client, settings) -> None:
         assert stored is not None
         assert SECRET.encode() not in stored.secret_ciphertext
         assert RESOLVE_TOKEN.encode() not in stored.secret_ciphertext
+
+
+def test_join_code_round_trips_the_device_authority_root(client) -> None:
+    registered = client.put(
+        "/api/v1/join-codes/123456",
+        json={
+            "rideId": "ride-device-authority",
+            "inviteSecret": SECRET,
+            "resolveToken": RESOLVE_TOKEN,
+            "authorityRootPublicKey": ROOT_KEY,
+        },
+        headers={"authorization": f"Bearer {ride_token('ride-device-authority', SECRET)}"},
+    )
+    assert registered.status_code == 204
+
+    resolved = client.get("/api/v1/join-codes/123456")
+
+    assert resolved.status_code == 200
+    assert resolved.json()["authorityRootPublicKey"] == ROOT_KEY
 
 
 def test_resolve_with_correct_token_succeeds(client) -> None:

--- a/apps/server/tests/test_pre_start_presence.py
+++ b/apps/server/tests/test_pre_start_presence.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import base64
+import json
 from datetime import UTC, datetime, timedelta
 
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from sqlalchemy import func, select
 
 from balloon_crumbs_server.crypto import CursorCodec, DataCipher
@@ -12,6 +15,42 @@ from balloon_crumbs_server.service import RelayService
 from .conftest import event, ride_token
 
 SECRET = "0123456789abcdef0123456789abcdef"
+
+
+def _b64(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode().rstrip("=")
+
+
+def _authority_proof(
+    *,
+    ride_id: str,
+    rider_id: str,
+    position: dict | None,
+    clear: bool,
+    signed_at: datetime,
+    seed: bytes,
+) -> dict:
+    signed_at_milliseconds = int(signed_at.timestamp() * 1000)
+    body = {
+        "rideId": ride_id,
+        "riderId": rider_id,
+        "signedAtMilliseconds": signed_at_milliseconds,
+        "clear": clear,
+        "position": position,
+    }
+    challenge = "balloon-crumbs-live-presence-v1\n" + json.dumps(
+        body,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    private_key = Ed25519PrivateKey.from_private_bytes(seed)
+    return {
+        "authorityVersion": 1,
+        "signedAtMilliseconds": signed_at_milliseconds,
+        "devicePublicKey": _b64(private_key.public_key().public_bytes_raw()),
+        "deviceSignature": _b64(private_key.sign(challenge.encode())),
+    }
 
 
 def _position(
@@ -182,6 +221,53 @@ def test_presence_requires_matching_authenticated_device(client, synchronize) ->
     )
 
     assert response.status_code == 400
+
+
+def test_device_authority_flight_requires_and_verifies_live_position_proof(
+    client, synchronize
+) -> None:
+    ride_id = "ride-device-presence"
+    now = datetime.now(UTC)
+    seed = bytes(range(32))
+    private_key = Ed25519PrivateKey.from_private_bytes(seed)
+    public_key = _b64(private_key.public_key().public_bytes_raw())
+    created = event(ride_id, "ride-created", device_id="pilot")
+    created.update(
+        {
+            "schemaVersion": 2,
+            "devicePublicKey": public_key,
+            "deviceSignature": "A" * 86,
+        }
+    )
+    assert (
+        synchronize(
+            client,
+            ride_id=ride_id,
+            secret=SECRET,
+            device_id="pilot",
+            events=[created],
+        ).status_code
+        == 200
+    )
+
+    position = _position(51.2, recorded_at=now)
+    without_proof = _presence(client, ride_id, "pilot", position=position)
+    assert without_proof.status_code == 403
+    proof = _authority_proof(
+        ride_id=ride_id,
+        rider_id="pilot",
+        position=position,
+        clear=False,
+        signed_at=now,
+        seed=seed,
+    )
+    published = _presence(client, ride_id, "pilot", position=position, **proof)
+    assert published.status_code == 200
+    assert published.json()["positions"][0]["devicePublicKey"] == public_key
+
+    tampered = _position(51.3, recorded_at=now)
+    rejected = _presence(client, ride_id, "pilot", position=tampered, **proof)
+    assert rejected.status_code == 403
 
 
 def test_five_devices_survive_a_45_minute_pre_launch_without_ghosts(client, synchronize) -> None:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -32,7 +32,7 @@ not a claim that every P0 item is small. Work packages are defined in
 | 10 | P0 | Landing-phase basemap (OS topographic / aerial) | WP6b | 6 |
 | 11 | P0 | ~~Balloon/chase simulator and replay matrix, including seeded multi-route chase and controllable link/fix degradation~~ **done** | WP10 | 3–9 |
 | 11a | P0 | Full-flight archive v2: time-align balloon telemetry, available chaser/craft locations, wind observations and guidance target changes; replay any previous flight, not only the bundled Fiesta scenario | WP10 | 5–9 |
-| 12 | P0 | Security, privacy, retention, and field-test gates | WP12 | 3–11 |
+| 12 | P0 | Per-device authority, signed presence, retention and log privacy are automated; mixed-device/vehicle field evidence remains | WP12 | 3–11 |
 | 12a | P0 | Multiple operational boundaries and altitude bands: draw, name, share and update more than one line/area in the web planner or app; alert on crossing with source, age and hysteresis; support configurable high/low altitude alerts | WP10b | 5, 6, 12 |
 | 13 | P1 | ~~Carry balloon altitude through GPX export and import (#16)~~ **done** | WP5 | 2 |
 | 14 | P1 | Retarget posted speed limits at the chase driver; remove inherited camera/enforcement alerts | WP7 | 3 |

--- a/docs/field-run-template.md
+++ b/docs/field-run-template.md
@@ -1,0 +1,53 @@
+# Balloon Crumbs field-run record
+
+One copy is required for every physical run, including an aborted run. Use no
+real flight code, invite secret, full track or provider credential in the issue
+or CI artifact. Attach private evidence only in the approved tester channel.
+
+## Run identity
+
+- Evidence ID:
+- Date and local time zone:
+- Recorder:
+- Objective / ticket:
+- Outcome: pass / pass with limitations / fail / aborted
+- Route type and approximate area (no precise private field):
+- Duration: pre-launch / flight / recovery / total
+- Conditions: daylight, precipitation, temperature, wind, terrain/road context
+
+## Device matrix
+
+| Role | Hardware | OS | App build/track | Power state | Network/SIM | Bluetooth/audio | Vehicle/head unit |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Pilot/balloon | | | | | | | |
+| Chase driver 1 | | | | | | | |
+| Chase crew / second vehicle | | | | | | | |
+
+## Required observations
+
+- Join/restart time and any ghost or duplicate participant:
+- Balloon GNSS and altitude source/accuracy; foreground/background transitions:
+- Internet relay delay/loss/recovery:
+- Nearby relay connection/loss/recovery:
+- Fix states observed: live / relayed / stale / unknown:
+- Voice prompt audibility, timing, interruption and Bluetooth routing:
+- Chase route target, lawful road endpoint and reroute behaviour:
+- North-up/Direction-up and CarPlay reconnect behaviour:
+- Landing declaration and exact recovery rendezvous handoff:
+- End/leave/local deletion and server cleanup evidence:
+- Accessibility: large text, VoiceOver/TalkBack, colour-independent states,
+  reachable controls:
+- Driver/pilot distraction: every task that required phone touch or eyes away:
+- Battery start/end and charging:
+- Thermal warnings or throttling:
+
+## Failures and artifacts
+
+| Time offset | Device/role | Expected | Actual | Freshness/source shown | Recovery/action | Ticket |
+| --- | --- | --- | --- | --- | --- | --- |
+| | | | | | | |
+
+- Sanitized screenshots/video/log references:
+- Missing evidence and reason:
+- Follow-up tickets:
+- Release-gate decision:

--- a/docs/launch-recovery-acceptance.md
+++ b/docs/launch-recovery-acceptance.md
@@ -35,11 +35,14 @@ criteria without putting a pre-launch action back on the pilot:
 | Five devices gather before launch without duplicate membership | `test_pre_start_presence.py::test_five_devices_survive_a_45_minute_pre_launch_without_ghosts` |
 | Multiple independent chasers and role-specific viewpoints | `launch_recovery_acceptance_fixture_test.dart`, `ride_controller_craft_test.dart`, `craft_roster_test.dart`, `role_specific_map_responsive_test.dart` |
 | Restart preserves operation, role, device and craft identity | `shared_preferences_session_store_test.dart`, `live_presence_two_device_test.dart::a rider who restarts the app rejoins without re-opting in`, `ride_controller_craft_test.dart::the roster survives a journal replay` |
-| Only the current pilot can end the flight or transfer pilot authority | `ride_controller_test.dart::pilot handover is offered, accepted and applied on both devices`, `pilot_handover_test.dart` and the authority tests in `ride_controller_test.dart` |
+| Only the current pilot can end a flight before recovery or transfer pilot authority; after LANDED any operational crew member can complete recovery | `ride_controller_test.dart::pilot handover is offered, accepted and applied on both devices`, `pilot_handover_test.dart`, `flight_landing_test.dart` and the authority tests in `ride_controller_test.dart` |
 | Release can be marked by the pilot or chase roles, never an observer or forged balloon role | `ride_controller_test.dart::chase crew can start live tracking at balloon release` and `balloon device cannot forge a chase role to start tracking` |
 | End stops location publication and begins bounded retention | `situational_awareness_controller_test.dart::the durable journal rejects a location fix queued after flight end`, `_handleRideEnded` in `active_ride_shell.dart`, `test_sync.py::test_ride_end_shortens_retention_and_cleanup_deletes_ride` |
 | Typed-code lookup is bounded and credentials are not stored in plaintext | `test_join_codes.py::test_ride_code_lookup_is_numeric_and_rate_limited`, `test_token_less_lookups_share_a_global_budget_across_callers`, and `test_register_and_resolve_six_digit_ride_code` |
 | Offline/out-of-order authority changes converge | `pilot_handover_test.dart` and `ride_controller_test.dart::offline leader handover and duplicate starts converge deterministically` |
+| A copied group credential cannot impersonate a device, pilot or live position | `device_authority_policy_test.dart`, `device_authority_controller_test.dart`, `presence_authenticator_test.dart`, `test_pre_start_presence.py` |
+| Revocation and rotation converge through the signed journal | `device_authority_policy_test.dart`, `device_authority_controller_test.dart` |
+| Local leave removes the journal, active session and secure signing seed | `ride_controller_test.dart`, `device_authority_controller_test.dart`; exact shared relay deletion remains bounded as specified in `security-privacy-field-gate.md` |
 
 The bounded CI set is deliberately virtual-time driven. It does not sleep for
 45 minutes and it never publishes synthetic positions to a live relay.

--- a/docs/security-privacy-field-gate.md
+++ b/docs/security-privacy-field-gate.md
@@ -1,0 +1,114 @@
+# Security, privacy, retention and field gate
+
+Status: implementation complete for automated checks; physical mixed-device and
+vehicle evidence remains a release gate.
+
+This is the release boundary for issue #11. It describes what a flight code can
+do, what the relay can see, exactly how long data remains, and what evidence a
+real field run must record. It does not turn simulator evidence into a claim
+about background GPS, Bluetooth, CarPlay, battery or thermal behaviour.
+
+## Authority and encryption
+
+- A new operation creates an Ed25519 identity in iOS Keychain or Android
+  encrypted storage. Its public key is carried by the `bc2` invitation; the
+  32-byte private seed never leaves that device.
+- Every schema-two event has two proofs: the existing operation HMAC for bounded
+  transport access and an Ed25519 author signature. Product reducers accept an
+  event only after both proofs and the device-authority policy pass.
+- A device ID is derived from the operation ID and its first public key. A copied
+  flight code cannot select another device ID and sign as that device.
+- Pilot-only event types are accepted only from the current pilot key. Pilot
+  handover requires an offer by the current pilot and acceptance by the named
+  balloon-crew key.
+- The pilot can revoke another device from the crew roster. Later events and live
+  positions from that device are inert. A device can rotate its key; the old key
+  signs the rotation and the replacement key signs a detached possession proof.
+- Nearby and internet live-position snapshots carry their own short-lived
+  Ed25519 proof. They are not trusted merely because a sender knows the shared
+  flight code.
+- Internet transport requires TLS. Event bodies, live snapshots, bootstrap
+  credentials and crew-room operation data are AES-256-GCM encrypted at rest;
+  lookup credentials are stored as hashes or keyed blind indexes.
+
+The relay is not an end-to-end opaque store: it decrypts event bodies in memory
+to validate bounds and project the cursor-independent membership roster. A
+relay operator with the runtime encryption key is therefore inside the trust
+boundary. Logs and metrics remain outside it and contain no body, credential,
+provider key or coordinate. End-to-end payload encryption would require a new
+minimal projection protocol and is not claimed by this release.
+
+## Threat model
+
+| Threat | Control | Residual limitation |
+| --- | --- | --- |
+| Six-digit code is photographed, guessed or reused | Rate-limited lookup; encrypted bootstrap; schema-two device signatures; self-certifying first device ID | A valid invite still permits a new non-pilot crew device to join until the operation expires or the pilot revokes it |
+| Code holder impersonates pilot or another device | Ed25519 author proof plus root/current-key authority graph | A compromised unlocked participant phone can act as that participant until revoked |
+| Code holder spoofs a live position | Position-specific short-lived signature; current-key and revocation check on recipients | A compromised device can lie about its own sensor reading; source age/accuracy remain visible |
+| Relay or database is copied | TLS in transit; AES-GCM bodies; hash-only bearer token; keyed alias index | Runtime relay operator is trusted as described above |
+| Event is replayed, duplicated or reordered | Signed immutable IDs, idempotency, deduplication and deterministic event ordering | A delayed but unexpired event may arrive as `relayed`; freshness reducers must not label it live |
+| Key is lost or suspected compromised | Pilot revocation and two-key rotation protocol | Revocation must reach a recipient before that recipient can reject later traffic |
+| Observer link leaks | Separate bounded credential, reduced observer surface, revocation and expiry | Observer functionality has its own issue #14 evidence gate |
+| Personal/contact data reaches diagnostics | Personal-share stores stay outside diagnostics; ordinary failures log only error types; flight-code headers are stripped from diagnostic files | Opt-in diagnostic exports contain the recording phone's manoeuvre points and must be shared deliberately |
+| Old local data accumulates | Explicit deletion, 24-hour ended-flight journal window, bounded five-file opt-in diagnostics, user-controlled previous-flight deletion | Deliberately retained exports and previous-flight archives remain until their owner deletes them |
+
+## Exact retention and deletion
+
+Durations below are defaults and maximums enforced by code. Operators may set a
+shorter value, never a silent longer one beyond the configured validation range.
+
+| Data | Retention | Deletion trigger |
+| --- | --- | --- |
+| Internet live position | 45 seconds | TTL, explicit clear, flight end or whole-flight cleanup |
+| Relayed location event | 30 minutes | Event TTL or whole-flight cleanup |
+| Status and personal contact-share events | 2 hours | Event TTL; unused received personal shares are also purged locally at flight end |
+| Hazard events | 24 hours | Event TTL or whole-flight cleanup |
+| Other operation events and encrypted join bootstrap | Up to 72 hours while active | Last activity moves the active deadline; flight end shortens it to at most 24 hours |
+| Idempotency replay | 24 hours | Cleanup job |
+| Ended operation, including dependent positions, observers and events | At most 24 hours after end | Scheduled cleanup transaction |
+| Stored web plan | 30 days | Plan cleanup job |
+| Active local journal and secure device key | For the active operation | Leave/delete clears the session, journal and key; end archives then clears the journal after 24 hours |
+| Local previous-flight archive | Until its owner deletes it | Previous flights > Delete |
+| Opt-in navigation diagnostic export | Newest five files; feature compiled out and off by default | Automatic oldest-first pruning; app-data deletion; flight codes are never written |
+| Private land-access note | Device-local until delete or its review/retention workflow | Per-record edit/delete; governed separately by `land-access-notes-privacy.md` |
+
+Leaving one phone does not delete the shared server operation, because any
+participant may still be recovering the balloon. Ending the flight starts the
+server's 24-hour recovery deletion window. An immediate shared delete is not
+offered to a bearer-token holder: allowing any copied group credential to erase
+every crew member's recovery state would be a data-loss vulnerability.
+
+Automated evidence:
+
+- local leave/delete/key removal: `ride_controller_test.dart`,
+  `device_authority_controller_test.dart`;
+- received contact purge: `ride_controller_test.dart`;
+- server end/TTL/cascade cleanup: `test_sync.py`,
+  `test_pre_start_presence.py`, `test_additive_event_types.py`;
+- stale/relayed labels: `simulator_replay_matrix_test.dart`,
+  `live_flight_projection_test.dart`;
+- log/code redaction: `runtime_log_privacy_test.dart` and production-disabled
+  Uvicorn access logs.
+
+## Driver/pilot distraction and accessibility review
+
+- Driver surfaces are voice-first. Retarget, mute and stop are bounded actions;
+  route guidance ends at a lawful road rendezvous and never at a raw airborne or
+  off-road coordinate.
+- Pilot surfaces omit speed limits, turn prompts and route manipulation while
+  airborne. Landing and handover actions require deliberate confirmation.
+- Every freshness/authority state has text and semantics, not colour alone.
+  Altitude trails retain a legend and unavailable-altitude treatment; touch
+  targets use platform sizing and dynamic text must not hide the primary map.
+- Simulator and widget checks are necessary but do not prove usability while
+  driving or flying. Physical evidence must record unsafe interaction attempts,
+  missed spoken prompts and any task that required touching the phone while the
+  vehicle was moving.
+
+## Physical release gate
+
+Every real run must use [the field-run record](field-run-template.md). Public
+release remains blocked until the mixed iOS/Android matrix covers foreground and
+background GPS/altitude, internet loss/recovery, Nearby transport, battery,
+thermal state, Bluetooth audio, a physical CarPlay head unit, accessibility and
+end-to-recovery deletion. Failures are evidence, not omitted runs.


### PR DESCRIPTION
## Summary
- replace group-HMAC-only product authority with operation-scoped Ed25519 device identities while retaining the HMAC as bounded transport access
- sign and verify live internet/Nearby presence, add pilot revocation and two-key rotation, and carry the authority root through typed/QR/crew-room joins
- remove flight credentials from diagnostics and runtime logs, delete local journal/session/key on leave, and document exact retention, threat boundaries, and the mandatory physical field matrix

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (1,816 passed, 24 skipped)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (153 passed)

Advances #11. Physical mixed-device, Bluetooth and vehicle/head-unit evidence remains a release gate and is not claimed by this PR.