### PR TITLE
feat: complete automated operational boundary advisories

### DIFF
--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -39,6 +39,7 @@ import '../domain/session_store.dart';
 import '../features/map/craft_icon.dart';
 import '../relay/live_presence.dart';
 import '../services/nearby_bridge.dart';
+import '../services/operational_boundary_monitor.dart';
 import '../services/pilot_handover.dart';
 import '../services/presence_authenticator.dart';
 import '../services/completed_ride_archiver.dart';
@@ -2357,6 +2358,49 @@ class RideController extends ChangeNotifier {
         payload: {
           'leaderRiderId': session.localRiderId,
           'boundaryId': boundaryId,
+        },
+      );
+    });
+  }
+
+  Future<void> recordOperationalBoundaryAlert(
+    OperationalBoundaryAlert alert, {
+    double? horizontalAccuracyMeters,
+    AltitudeSource altitudeSource = AltitudeSource.unknown,
+    AltitudeDatum altitudeDatum = AltitudeDatum.unknown,
+    double? altitudeAccuracyMeters,
+  }) async {
+    await _run(() async {
+      final session = _requireSession();
+      if (!session.flightRole.isAboardBalloon) {
+        throw const FormatException(
+          'Only a device aboard the balloon can record this warning.',
+        );
+      }
+      await _record(
+        type: RideEventType.operationalBoundaryAlerted,
+        priority: alert.confirmed
+            ? EventPriority.critical
+            : EventPriority.important,
+        payload: {
+          'boundaryId': alert.boundary.id,
+          'boundaryRevision': alert.boundary.updatedAt
+              .toUtc()
+              .toIso8601String(),
+          'boundaryLabel': alert.boundary.label,
+          'kind': alert.kind.name,
+          'assessment': alert.assessment.name,
+          'confirmed': alert.confirmed,
+          'message': alert.message,
+          'observedAt': alert.observedAt.toUtc().toIso8601String(),
+          'latitude': ?alert.position?.latitude,
+          'longitude': ?alert.position?.longitude,
+          'horizontalAccuracyMeters': ?horizontalAccuracyMeters,
+          'altitudeMeters': ?alert.altitudeMeters,
+          'altitudeSource': altitudeSource.name,
+          'altitudeDatum': altitudeDatum.name,
+          'altitudeAccuracyMeters': ?altitudeAccuracyMeters,
+          'limitations': alert.boundary.limitations,
         },
       );
     });

--- a/apps/mobile/lib/controllers/situational_awareness_controller.dart
+++ b/apps/mobile/lib/controllers/situational_awareness_controller.dart
@@ -491,6 +491,7 @@ class SituationalAwarenessController extends ChangeNotifier {
       case RideEventType.windContextNoted:
       case RideEventType.operationalBoundaryUpserted:
       case RideEventType.operationalBoundaryRemoved:
+      case RideEventType.operationalBoundaryAlerted:
       case RideEventType.chaseGuidanceTargetSelected:
       case RideEventType.pilotHandoverOffered:
       case RideEventType.pilotHandoverAccepted:

--- a/apps/mobile/lib/domain/flight_replay.dart
+++ b/apps/mobile/lib/domain/flight_replay.dart
@@ -215,6 +215,64 @@ class FlightReplayLandingArea {
       );
 }
 
+class FlightReplayBoundaryAlert {
+  const FlightReplayBoundaryAlert({
+    required this.recordedAt,
+    required this.boundaryId,
+    required this.boundaryLabel,
+    required this.kind,
+    required this.assessment,
+    required this.confirmed,
+    required this.message,
+    this.position,
+    this.altitudeMeters,
+  });
+
+  final DateTime recordedAt;
+  final String boundaryId;
+  final String boundaryLabel;
+  final String kind;
+  final String assessment;
+  final bool confirmed;
+  final String message;
+  final GeoPoint? position;
+  final double? altitudeMeters;
+
+  Map<String, Object?> toJson() => {
+    'recordedAt': recordedAt.toUtc().toIso8601String(),
+    'boundaryId': boundaryId,
+    'boundaryLabel': boundaryLabel,
+    'kind': kind,
+    'assessment': assessment,
+    'confirmed': confirmed,
+    'message': message,
+    if (position != null) 'latitude': position!.latitude,
+    if (position != null) 'longitude': position!.longitude,
+    if (altitudeMeters != null) 'altitudeMeters': altitudeMeters,
+  };
+
+  factory FlightReplayBoundaryAlert.fromJson(Map<String, Object?> json) {
+    final latitude = json['latitude'];
+    final longitude = json['longitude'];
+    return FlightReplayBoundaryAlert(
+      recordedAt: DateTime.parse(json['recordedAt']! as String).toUtc(),
+      boundaryId: json['boundaryId']! as String,
+      boundaryLabel: json['boundaryLabel']! as String,
+      kind: json['kind']! as String,
+      assessment: json['assessment']! as String,
+      confirmed: json['confirmed']! as bool,
+      message: json['message']! as String,
+      position: latitude is num && longitude is num
+          ? GeoPoint(
+              latitude: latitude.toDouble(),
+              longitude: longitude.toDouble(),
+            )
+          : null,
+      altitudeMeters: _optionalFinite(json['altitudeMeters']),
+    );
+  }
+}
+
 class FlightReplay {
   const FlightReplay({
     required this.startedAt,
@@ -223,6 +281,7 @@ class FlightReplay {
     required this.windContexts,
     required this.landingAreas,
     required this.peerTracksIncluded,
+    this.boundaryAlerts = const [],
   });
 
   final DateTime startedAt;
@@ -230,6 +289,7 @@ class FlightReplay {
   final List<FlightReplayTrack> tracks;
   final List<FlightReplayWindContext> windContexts;
   final List<FlightReplayLandingArea> landingAreas;
+  final List<FlightReplayBoundaryAlert> boundaryAlerts;
   final bool peerTracksIncluded;
 
   Duration get duration => endedAt.difference(startedAt).abs();
@@ -242,6 +302,7 @@ class FlightReplay {
     'tracks': tracks.map((track) => track.toJson()).toList(),
     'windContexts': windContexts.map((wind) => wind.toJson()).toList(),
     'landingAreas': landingAreas.map((area) => area.toJson()).toList(),
+    'boundaryAlerts': boundaryAlerts.map((alert) => alert.toJson()).toList(),
   };
 
   factory FlightReplay.fromJson(Map<String, Object?> json) => FlightReplay(
@@ -256,6 +317,10 @@ class FlightReplay {
     landingAreas: _objects(
       json['landingAreas'],
       FlightReplayLandingArea.fromJson,
+    ),
+    boundaryAlerts: _objects(
+      json['boundaryAlerts'],
+      FlightReplayBoundaryAlert.fromJson,
     ),
   );
 }

--- a/apps/mobile/lib/domain/landing_zone.dart
+++ b/apps/mobile/lib/domain/landing_zone.dart
@@ -147,6 +147,7 @@ class LandingZoneReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.operationalBoundaryAlerted:
         case RideEventType.chaseGuidanceTargetSelected:
         case RideEventType.pilotHandoverOffered:
         case RideEventType.pilotHandoverAccepted:

--- a/apps/mobile/lib/domain/operational_boundary.dart
+++ b/apps/mobile/lib/domain/operational_boundary.dart
@@ -1,9 +1,18 @@
 import 'altitude.dart';
+import 'altitude_unit.dart';
 import 'geo_point.dart';
 import 'ride_event.dart';
 import 'ride_role.dart';
 
 enum OperationalBoundaryKind { line, area, altitudeBand }
+
+/// Which transition should raise an alert.
+///
+/// For an area this has the ordinary inside/outside meaning. For an oriented
+/// line, [entering] means right-to-left into the line's left side and [leaving]
+/// means left-to-right. Altitude bands use [either]: either upper or lower
+/// limit is a departure from the configured band.
+enum OperationalBoundaryWarningDirection { entering, leaving, either }
 
 class OperationalBoundary {
   const OperationalBoundary({
@@ -13,9 +22,20 @@ class OperationalBoundary {
     required this.points,
     required this.source,
     required this.updatedAt,
+    this.enabled = true,
+    this.warningDirection = OperationalBoundaryWarningDirection.either,
+    this.effectiveFrom,
+    this.validUntil,
+    this.limitations =
+        'Advisory only; verify against current official information.',
     this.lowerAltitudeMeters,
     this.upperAltitudeMeters,
     this.altitudeDatum = AltitudeDatum.wgs84Geoid,
+    this.altitudeUnit = AltitudeUnit.metres,
+    this.acceptedAltitudeSources = const {
+      AltitudeSource.gnss,
+      AltitudeSource.barometric,
+    },
   });
 
   final String id;
@@ -24,9 +44,26 @@ class OperationalBoundary {
   final List<GeoPoint> points;
   final String source;
   final DateTime updatedAt;
+  final bool enabled;
+  final OperationalBoundaryWarningDirection warningDirection;
+
+  /// When this advisory starts applying; [updatedAt] for legacy definitions.
+  final DateTime? effectiveFrom;
+  final DateTime? validUntil;
+  final String limitations;
   final double? lowerAltitudeMeters;
   final double? upperAltitudeMeters;
   final AltitudeDatum altitudeDatum;
+  final AltitudeUnit altitudeUnit;
+  final Set<AltitudeSource> acceptedAltitudeSources;
+
+  DateTime get effectiveAt => effectiveFrom ?? updatedAt;
+
+  bool appliesAt(DateTime value) {
+    final utc = value.toUtc();
+    return !utc.isBefore(effectiveAt.toUtc()) &&
+        (validUntil == null || !utc.isAfter(validUntil!.toUtc()));
+  }
 
   bool get hasAltitudeBand =>
       lowerAltitudeMeters != null || upperAltitudeMeters != null;
@@ -44,14 +81,29 @@ class OperationalBoundary {
             (lowerAltitudeMeters == null ||
                 upperAltitudeMeters == null ||
                 lowerAltitudeMeters! < upperAltitudeMeters!));
+    final timeValid =
+        validUntil == null || validUntil!.isAfter(effectiveAt.toUtc());
+    final sourceRequirementsValid =
+        !hasAltitudeBand ||
+        (altitudeDatum != AltitudeDatum.unknown &&
+            acceptedAltitudeSources.isNotEmpty &&
+            !acceptedAltitudeSources.contains(AltitudeSource.unknown));
+    final directionValid =
+        kind != OperationalBoundaryKind.altitudeBand ||
+        warningDirection == OperationalBoundaryWarningDirection.either;
     return id.trim().isNotEmpty &&
         id.length <= 96 &&
         label.trim().isNotEmpty &&
         label.length <= 96 &&
         source.trim().isNotEmpty &&
         source.length <= 160 &&
+        limitations.trim().isNotEmpty &&
+        limitations.length <= 500 &&
         pointCountValid &&
         altitudeValid &&
+        timeValid &&
+        sourceRequirementsValid &&
+        directionValid &&
         points.every(
           (point) =>
               point.latitude.isFinite &&
@@ -78,9 +130,19 @@ class OperationalBoundary {
     ],
     'source': source,
     'updatedAt': updatedAt.toUtc().toIso8601String(),
+    'enabled': enabled,
+    'warningDirection': warningDirection.name,
+    'effectiveFrom': effectiveAt.toUtc().toIso8601String(),
+    if (validUntil != null) 'validUntil': validUntil!.toUtc().toIso8601String(),
+    'limitations': limitations,
     if (lowerAltitudeMeters != null) 'lowerAltitudeMeters': lowerAltitudeMeters,
     if (upperAltitudeMeters != null) 'upperAltitudeMeters': upperAltitudeMeters,
     'altitudeDatum': altitudeDatum.name,
+    'altitudeUnit': altitudeUnit.name,
+    'acceptedAltitudeSources': [
+      for (final source in AltitudeSource.values)
+        if (acceptedAltitudeSources.contains(source)) source.name,
+    ],
   };
 
   factory OperationalBoundary.fromJson(Map<String, Object?> json) {
@@ -94,6 +156,17 @@ class OperationalBoundary {
     if (kind == null) {
       throw const FormatException('Boundary kind is invalid.');
     }
+    final updatedAt = DateTime.parse(json['updatedAt']! as String).toUtc();
+    final warningDirection = OperationalBoundaryWarningDirection.values
+        .where((direction) => direction.name == json['warningDirection'])
+        .firstOrNull;
+    final rawAcceptedSources = json['acceptedAltitudeSources'];
+    final acceptedSources = rawAcceptedSources is List
+        ? {
+            for (final value in rawAcceptedSources.whereType<String>())
+              ...AltitudeSource.values.where((source) => source.name == value),
+          }
+        : const {AltitudeSource.gnss, AltitudeSource.barometric};
     final boundary = OperationalBoundary(
       id: json['id']! as String,
       label: json['label']! as String,
@@ -106,7 +179,19 @@ class OperationalBoundary {
           ),
       ],
       source: json['source']! as String,
-      updatedAt: DateTime.parse(json['updatedAt']! as String).toUtc(),
+      updatedAt: updatedAt,
+      enabled: json['enabled'] as bool? ?? true,
+      warningDirection:
+          warningDirection ?? OperationalBoundaryWarningDirection.either,
+      effectiveFrom: DateTime.tryParse(
+        json['effectiveFrom'] as String? ?? '',
+      )?.toUtc(),
+      validUntil: DateTime.tryParse(
+        json['validUntil'] as String? ?? '',
+      )?.toUtc(),
+      limitations:
+          json['limitations'] as String? ??
+          'Advisory only; verify against current official information.',
       lowerAltitudeMeters: (json['lowerAltitudeMeters'] as num?)?.toDouble(),
       upperAltitudeMeters: (json['upperAltitudeMeters'] as num?)?.toDouble(),
       altitudeDatum:
@@ -114,6 +199,12 @@ class OperationalBoundary {
               .where((datum) => datum.name == json['altitudeDatum'])
               .firstOrNull ??
           AltitudeDatum.unknown,
+      altitudeUnit:
+          AltitudeUnit.values
+              .where((unit) => unit.name == json['altitudeUnit'])
+              .firstOrNull ??
+          AltitudeUnit.metres,
+      acceptedAltitudeSources: acceptedSources,
     );
     if (!boundary.isValid) {
       throw const FormatException('Boundary is invalid.');
@@ -168,6 +259,7 @@ class OperationalBoundaryReducer {
           }
           final id = event.payload['boundaryId'];
           if (id is String) boundaries.remove(id);
+        case RideEventType.operationalBoundaryAlerted:
         case RideEventType.riderLeft:
         case RideEventType.rideStarted:
         case RideEventType.flightStartedByCrew:

--- a/apps/mobile/lib/domain/ride_event.dart
+++ b/apps/mobile/lib/domain/ride_event.dart
@@ -131,6 +131,11 @@ enum RideEventType {
   /// the old key and carries a proof made by the replacement key, preventing a
   /// relay or another invite holder from substituting a key of their own.
   deviceAuthorityRotated,
+
+  /// A balloon-side device records a boundary warning and the quality of the
+  /// fix that produced it. Chasers replay the shared warning rather than
+  /// evaluating the vehicle's road position against a balloon boundary.
+  operationalBoundaryAlerted,
 }
 
 enum EventPriority { routine, important, critical }

--- a/apps/mobile/lib/features/replay/flight_replay_screen.dart
+++ b/apps/mobile/lib/features/replay/flight_replay_screen.dart
@@ -89,6 +89,15 @@ class _FlightReplayScreenState extends State<FlightReplayScreen> {
             ),
             const SizedBox(height: 12),
             _WindCard(frame.wind, altitudeUnit: widget.altitudeUnit),
+            if (widget.replay.boundaryAlerts
+                    .where(
+                      (alert) => !alert.recordedAt.isAfter(frame.recordedAt),
+                    )
+                    .lastOrNull
+                case final alert?) ...[
+              const SizedBox(height: 10),
+              _BoundaryAlertCard(alert),
+            ],
             const SizedBox(height: 10),
             Text(
               widget.replay.peerTracksIncluded
@@ -274,6 +283,26 @@ class _WindCard extends StatelessWidget {
       ),
     );
   }
+}
+
+class _BoundaryAlertCard extends StatelessWidget {
+  const _BoundaryAlertCard(this.alert);
+
+  final FlightReplayBoundaryAlert alert;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    color: alert.confirmed ? const Color(0xFF572531) : null,
+    child: ListTile(
+      leading: Icon(
+        alert.confirmed ? Icons.warning_amber_rounded : Icons.gps_off,
+      ),
+      title: Text(alert.message),
+      subtitle: Text(
+        '${_clock(alert.recordedAt)} · ${alert.confirmed ? 'confirmed from a usable fix' : '${alert.assessment}; not confirmed'}',
+      ),
+    ),
+  );
 }
 
 class _FlightReplayPainter extends CustomPainter {

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -1338,19 +1338,38 @@ class _OperationalBoundaryDraft {
     required this.label,
     required this.kind,
     required this.source,
+    this.enabled = true,
+    this.warningDirection = OperationalBoundaryWarningDirection.either,
+    this.effectiveFrom,
+    this.validUntil,
+    this.limitations =
+        'Advisory only; verify against current official information.',
     this.lowerAltitudeMeters,
     this.upperAltitudeMeters,
     this.altitudeDatum = AltitudeDatum.wgs84Geoid,
-  });
+    this.altitudeUnit = AltitudeUnit.metres,
+    this.acceptedAltitudeSources = const {
+      AltitudeSource.gnss,
+      AltitudeSource.barometric,
+    },
+    List<route_domain.GeoPoint> points = const [],
+  }) : points = List.of(points);
 
   final String id;
   final String label;
   final OperationalBoundaryKind kind;
   final String source;
+  final bool enabled;
+  final OperationalBoundaryWarningDirection warningDirection;
+  final DateTime? effectiveFrom;
+  final DateTime? validUntil;
+  final String limitations;
   final double? lowerAltitudeMeters;
   final double? upperAltitudeMeters;
   final AltitudeDatum altitudeDatum;
-  final List<route_domain.GeoPoint> points = [];
+  final AltitudeUnit altitudeUnit;
+  final Set<AltitudeSource> acceptedAltitudeSources;
+  final List<route_domain.GeoPoint> points;
 }
 
 class _ActiveRideShellState extends State<ActiveRideShell>
@@ -1407,6 +1426,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   /// Every staged prompt already spoken, so a stage is not repeated on each fix
   /// and the early one does not suppress the ones after it (#410).
   final _spokenGuidanceKeys = <String>{};
+  final _surfacedOperationalBoundaryAlertIds = <String>{};
   static const _chaseSpokenGuidancePolicy = ChaseSpokenGuidancePolicy();
   SpokenAudioMode? _spokenModeBeforeMute;
 
@@ -1667,6 +1687,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     widget.rideController.addListener(_onRideControllerChanged);
     _syncSharedLandingZone();
     _syncOperationalBoundaries();
+    _surfaceSharedOperationalBoundaryAlerts();
     widget.sharedRoutes.addListener(_onSharedRoutesChanged);
     _capturePlannerLinkError();
     if (widget.sharedRoutes.pending case final file?) {
@@ -4102,6 +4123,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         : null;
     _syncSharedLandingZone();
     _syncOperationalBoundaries();
+    _surfaceSharedOperationalBoundaryAlerts();
     if (_isChaserPerspective && _chaseGuidanceTarget == null) {
       _chaseGuidanceTarget = widget.rideController.landingZone == null
           ? ChaseGuidanceTarget.balloon
@@ -4197,7 +4219,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final draft = _operationalBoundaryDraft;
     _operationalBoundaryTraces = List.unmodifiable([
       for (final boundary in widget.rideController.operationalBoundaries)
-        if (boundary.kind != OperationalBoundaryKind.altitudeBand)
+        if (boundary.enabled &&
+            boundary.appliesAt(DateTime.now()) &&
+            boundary.kind != OperationalBoundaryKind.altitudeBand)
           MapOverlayTrace(
             id: 'operational-boundary-${boundary.id}',
             points: [
@@ -4435,6 +4459,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   }
 
   void _checkOperationalBoundaries() {
+    if (widget.rideController.session?.flightRole.isAboardBalloon != true) {
+      return;
+    }
     final navigation = _mapNavigationPosition.value;
     if (navigation == null) return;
     final alerts = _operationalBoundaryMonitor.evaluate(
@@ -4444,14 +4471,29 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         longitude: navigation.point.longitude,
       ),
       now: DateTime.now(),
+      recordedAt: navigation.recordedAt,
+      horizontalAccuracyMeters: navigation.accuracyMeters,
       altitudeMeters: navigation.altitudeMeters,
+      altitudeSource: navigation.altitudeSource,
       altitudeDatum: navigation.altitudeDatum,
+      altitudeAccuracyMeters: navigation.altitudeAccuracyMeters,
     );
     if (alerts.isEmpty || !mounted) return;
     for (final alert in alerts) {
       _warnings.add(
         '${alert.message}. Advisory only — confirm the source and current flight information.',
       );
+      if (!_isSimulation) {
+        unawaited(
+          widget.rideController.recordOperationalBoundaryAlert(
+            alert,
+            horizontalAccuracyMeters: navigation.accuracyMeters,
+            altitudeSource: navigation.altitudeSource,
+            altitudeDatum: navigation.altitudeDatum,
+            altitudeAccuracyMeters: navigation.altitudeAccuracyMeters,
+          ),
+        );
+      }
     }
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -4462,6 +4504,53 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         duration: const Duration(seconds: 8),
       ),
     );
+  }
+
+  void _surfaceSharedOperationalBoundaryAlerts() {
+    final session = widget.rideController.session;
+    if (session == null || !session.flightRole.isChasing || !mounted) return;
+    final now = DateTime.now();
+    for (final event in widget.rideController.events.where(
+      (event) => event.type == RideEventType.operationalBoundaryAlerted,
+    )) {
+      if (!_surfacedOperationalBoundaryAlertIds.add(event.id) ||
+          event.deviceId == session.localRiderId) {
+        continue;
+      }
+      final age = now.difference(event.createdAt);
+      if (age < const Duration(seconds: -30) ||
+          age > const Duration(minutes: 2)) {
+        continue;
+      }
+      final message = event.payload['message'] as String?;
+      if (message == null || message.trim().isEmpty) continue;
+      _warnings.add(
+        '$message. Shared from the balloon; advisory only — verify before acting.',
+      );
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor: const Color(0xFF8F2638),
+          duration: const Duration(seconds: 8),
+        ),
+      );
+      final speaker = _spokenGuidance;
+      if (speaker != null) {
+        unawaited(
+          speaker.speakAlert(
+            key: 'operational-boundary:${event.id}',
+            phrase: message,
+            enabled: spokenAudioAllows(
+              _spokenAudioMode,
+              SpokenAudioClass.safety,
+            ),
+            rideActive:
+                widget.rideController.rideStarted &&
+                !widget.rideController.rideEnded,
+          ),
+        );
+      }
+    }
   }
 
   @override
@@ -4957,6 +5046,20 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final minimum = draft.kind == OperationalBoundaryKind.line ? 2 : 3;
     if (draft.points.length < minimum) return;
     await widget.rideController.upsertOperationalBoundary(
+      _boundaryFromDraft(draft),
+    );
+    if (!mounted) return;
+    if (widget.rideController.errorMessage case final message?) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(message)));
+      return;
+    }
+    setState(() => _operationalBoundaryDraft = null);
+    _syncOperationalBoundaries();
+  }
+
+  OperationalBoundary _boundaryFromDraft(_OperationalBoundaryDraft draft) =>
       OperationalBoundary(
         id: draft.id,
         label: draft.label,
@@ -4970,21 +5073,17 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         ],
         source: draft.source,
         updatedAt: DateTime.now(),
+        enabled: draft.enabled,
+        warningDirection: draft.warningDirection,
+        effectiveFrom: draft.effectiveFrom,
+        validUntil: draft.validUntil,
+        limitations: draft.limitations,
         lowerAltitudeMeters: draft.lowerAltitudeMeters,
         upperAltitudeMeters: draft.upperAltitudeMeters,
         altitudeDatum: draft.altitudeDatum,
-      ),
-    );
-    if (!mounted) return;
-    if (widget.rideController.errorMessage case final message?) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(message)));
-      return;
-    }
-    setState(() => _operationalBoundaryDraft = null);
-    _syncOperationalBoundaries();
-  }
+        altitudeUnit: draft.altitudeUnit,
+        acceptedAltitudeSources: draft.acceptedAltitudeSources,
+      );
 
   Future<void> _updateLandingZoneFromMap(route_domain.GeoPoint point) async {
     await widget.rideController.setLandingZone(
@@ -6631,38 +6730,109 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                             final altitude = [
                               if (boundary.lowerAltitudeMeters
                                   case final value?)
-                                'min ${value.round()} m',
+                                'min ${boundary.altitudeUnit.altitude(value)}',
                               if (boundary.upperAltitudeMeters
                                   case final value?)
-                                'max ${value.round()} m',
+                                'max ${boundary.altitudeUnit.altitude(value)}',
                             ].join(' · ');
+                            final validity = boundary.validUntil == null
+                                ? 'from ${_formatBoundaryTime(boundary.effectiveAt)}'
+                                : '${_formatBoundaryTime(boundary.effectiveAt)}–${_formatBoundaryTime(boundary.validUntil!)}';
+                            final updated = _formatBoundaryTime(
+                              boundary.updatedAt,
+                            );
                             return ListTile(
-                              leading: Icon(switch (boundary.kind) {
-                                OperationalBoundaryKind.line => Icons.polyline,
-                                OperationalBoundaryKind.area =>
-                                  Icons.pentagon_outlined,
-                                OperationalBoundaryKind.altitudeBand =>
-                                  Icons.height,
-                              }, color: const Color(0xFFFF5D73)),
-                              title: Text(boundary.label),
+                              leading: Icon(
+                                switch (boundary.kind) {
+                                  OperationalBoundaryKind.line =>
+                                    Icons.polyline,
+                                  OperationalBoundaryKind.area =>
+                                    Icons.pentagon_outlined,
+                                  OperationalBoundaryKind.altitudeBand =>
+                                    Icons.height,
+                                },
+                                color: boundary.enabled
+                                    ? const Color(0xFFFF5D73)
+                                    : const Color(0xFF73808F),
+                              ),
+                              title: Text(
+                                boundary.enabled
+                                    ? boundary.label
+                                    : '${boundary.label} · off',
+                              ),
                               subtitle: Text(
-                                '${boundary.source}${altitude.isEmpty ? '' : ' · $altitude ${boundary.altitudeDatum.name}'}',
-                                maxLines: 2,
+                                '${boundary.source} · $validity · updated $updated${altitude.isEmpty ? '' : '\n$altitude · ${boundary.altitudeDatum.name}'}\n${boundary.limitations}',
+                                maxLines: 4,
                                 overflow: TextOverflow.ellipsis,
                               ),
                               trailing: canEdit
-                                  ? IconButton(
-                                      tooltip: 'Remove boundary',
-                                      icon: const Icon(Icons.delete_outline),
-                                      onPressed: () async {
-                                        await widget.rideController
-                                            .removeOperationalBoundary(
-                                              boundary.id,
-                                            );
-                                        if (sheetContext.mounted) {
-                                          setSheetState(() {});
-                                        }
-                                      },
+                                  ? Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Switch(
+                                          value: boundary.enabled,
+                                          onChanged: (enabled) async {
+                                            await widget.rideController
+                                                .upsertOperationalBoundary(
+                                                  _copyOperationalBoundary(
+                                                    boundary,
+                                                    enabled: enabled,
+                                                  ),
+                                                );
+                                            _syncOperationalBoundaries();
+                                            if (sheetContext.mounted) {
+                                              setSheetState(() {});
+                                            }
+                                          },
+                                        ),
+                                        PopupMenuButton<String>(
+                                          tooltip: 'Boundary actions',
+                                          onSelected: (action) {
+                                            if (action == 'edit') {
+                                              Navigator.pop(sheetContext);
+                                              unawaited(
+                                                _configureOperationalBoundary(
+                                                  boundary.kind,
+                                                  existing: boundary,
+                                                ),
+                                              );
+                                            } else if (action == 'redraw') {
+                                              Navigator.pop(sheetContext);
+                                              _redrawOperationalBoundary(
+                                                boundary,
+                                              );
+                                            } else if (action == 'remove') {
+                                              unawaited(() async {
+                                                await widget.rideController
+                                                    .removeOperationalBoundary(
+                                                      boundary.id,
+                                                    );
+                                                _syncOperationalBoundaries();
+                                                if (sheetContext.mounted) {
+                                                  setSheetState(() {});
+                                                }
+                                              }());
+                                            }
+                                          },
+                                          itemBuilder: (context) => [
+                                            const PopupMenuItem(
+                                              value: 'edit',
+                                              child: Text('Edit details'),
+                                            ),
+                                            if (boundary.kind !=
+                                                OperationalBoundaryKind
+                                                    .altitudeBand)
+                                              const PopupMenuItem(
+                                                value: 'redraw',
+                                                child: Text('Redraw on map'),
+                                              ),
+                                            const PopupMenuItem(
+                                              value: 'remove',
+                                              child: Text('Remove'),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
                                     )
                                   : null,
                             );
@@ -6723,29 +6893,137 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     );
   }
 
+  OperationalBoundary _copyOperationalBoundary(
+    OperationalBoundary boundary, {
+    bool? enabled,
+  }) => OperationalBoundary(
+    id: boundary.id,
+    label: boundary.label,
+    kind: boundary.kind,
+    points: boundary.points,
+    source: boundary.source,
+    updatedAt: DateTime.now(),
+    enabled: enabled ?? boundary.enabled,
+    warningDirection: boundary.warningDirection,
+    effectiveFrom: boundary.effectiveFrom,
+    validUntil: boundary.validUntil,
+    limitations: boundary.limitations,
+    lowerAltitudeMeters: boundary.lowerAltitudeMeters,
+    upperAltitudeMeters: boundary.upperAltitudeMeters,
+    altitudeDatum: boundary.altitudeDatum,
+    altitudeUnit: boundary.altitudeUnit,
+    acceptedAltitudeSources: boundary.acceptedAltitudeSources,
+  );
+
+  static String _formatBoundaryTime(DateTime value) {
+    final local = value.toLocal();
+    String two(int part) => part.toString().padLeft(2, '0');
+    return '${local.year}-${two(local.month)}-${two(local.day)} '
+        '${two(local.hour)}:${two(local.minute)}';
+  }
+
+  _OperationalBoundaryDraft _draftFromBoundary(
+    OperationalBoundary boundary, {
+    bool includePoints = true,
+  }) => _OperationalBoundaryDraft(
+    id: boundary.id,
+    label: boundary.label,
+    kind: boundary.kind,
+    source: boundary.source,
+    enabled: boundary.enabled,
+    warningDirection: boundary.warningDirection,
+    effectiveFrom: boundary.effectiveFrom,
+    validUntil: boundary.validUntil,
+    limitations: boundary.limitations,
+    lowerAltitudeMeters: boundary.lowerAltitudeMeters,
+    upperAltitudeMeters: boundary.upperAltitudeMeters,
+    altitudeDatum: boundary.altitudeDatum,
+    altitudeUnit: boundary.altitudeUnit,
+    acceptedAltitudeSources: boundary.acceptedAltitudeSources,
+    points: includePoints
+        ? [
+            for (final point in boundary.points)
+              route_domain.GeoPoint(
+                latitude: point.latitude,
+                longitude: point.longitude,
+              ),
+          ]
+        : const [],
+  );
+
+  void _redrawOperationalBoundary(OperationalBoundary boundary) {
+    setState(() {
+      _selectedIndex = 0;
+      _selectingLandingZone = false;
+      _operationalBoundaryDraft = _draftFromBoundary(
+        boundary,
+        includePoints: false,
+      );
+    });
+    _syncOperationalBoundaries();
+  }
+
   Future<void> _configureOperationalBoundary(
-    OperationalBoundaryKind kind,
-  ) async {
+    OperationalBoundaryKind kind, {
+    OperationalBoundary? existing,
+  }) async {
     final labelController = TextEditingController(
-      text: switch (kind) {
-        OperationalBoundaryKind.line => 'Advisory boundary line',
-        OperationalBoundaryKind.area => 'Advisory boundary area',
-        OperationalBoundaryKind.altitudeBand => 'Planned altitude band',
-      },
+      text:
+          existing?.label ??
+          switch (kind) {
+            OperationalBoundaryKind.line => 'Advisory boundary line',
+            OperationalBoundaryKind.area => 'Advisory boundary area',
+            OperationalBoundaryKind.altitudeBand => 'Planned altitude band',
+          },
     );
     final sourceController = TextEditingController(
-      text: 'Pilot-entered advisory boundary',
+      text: existing?.source ?? 'Pilot-entered advisory boundary',
     );
-    final lowerController = TextEditingController();
-    final upperController = TextEditingController();
-    var datum = AltitudeDatum.wgs84Geoid;
+    final limitationsController = TextEditingController(
+      text:
+          existing?.limitations ??
+          'Advisory only; verify against current official information.',
+    );
+    var altitudeUnit = existing?.altitudeUnit ?? AltitudeUnit.metres;
+    final lowerController = TextEditingController(
+      text: existing?.lowerAltitudeMeters == null
+          ? ''
+          : altitudeUnit
+                .fromMetres(existing!.lowerAltitudeMeters!)
+                .toStringAsFixed(0),
+    );
+    final upperController = TextEditingController(
+      text: existing?.upperAltitudeMeters == null
+          ? ''
+          : altitudeUnit
+                .fromMetres(existing!.upperAltitudeMeters!)
+                .toStringAsFixed(0),
+    );
+    final effectiveController = TextEditingController(
+      text: existing?.effectiveFrom?.toLocal().toIso8601String() ?? '',
+    );
+    final validUntilController = TextEditingController(
+      text: existing?.validUntil?.toLocal().toIso8601String() ?? '',
+    );
+    var enabled = existing?.enabled ?? true;
+    var direction =
+        existing?.warningDirection ??
+        OperationalBoundaryWarningDirection.either;
+    var datum = existing?.altitudeDatum ?? AltitudeDatum.wgs84Geoid;
+    var acceptGnss =
+        existing?.acceptedAltitudeSources.contains(AltitudeSource.gnss) ?? true;
+    var acceptBarometric =
+        existing?.acceptedAltitudeSources.contains(AltitudeSource.barometric) ??
+        true;
     String? validationMessage;
     final draft = await showDialog<_OperationalBoundaryDraft>(
       context: context,
       builder: (dialogContext) => StatefulBuilder(
         builder: (context, setDialogState) => AlertDialog(
           title: Text(
-            kind == OperationalBoundaryKind.altitudeBand
+            existing != null
+                ? 'Edit operational boundary'
+                : kind == OperationalBoundaryKind.altitudeBand
                 ? 'Add altitude limits'
                 : 'Describe the boundary',
           ),
@@ -6753,6 +7031,15 @@ class _ActiveRideShellState extends State<ActiveRideShell>
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
+                SwitchListTile.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Enabled'),
+                  subtitle: const Text(
+                    'Disabled boundaries stay shared but do not alert.',
+                  ),
+                  value: enabled,
+                  onChanged: (value) => setDialogState(() => enabled = value),
+                ),
                 TextField(
                   controller: labelController,
                   maxLength: 96,
@@ -6766,15 +7053,106 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                     helperText: 'Shown to every crew member',
                   ),
                 ),
+                TextField(
+                  controller: limitationsController,
+                  maxLength: 500,
+                  maxLines: 2,
+                  decoration: const InputDecoration(
+                    labelText: 'Limitations',
+                    helperText: 'State why this advisory may be incomplete',
+                  ),
+                ),
+                if (kind != OperationalBoundaryKind.altitudeBand)
+                  DropdownButtonFormField<OperationalBoundaryWarningDirection>(
+                    initialValue: direction,
+                    decoration: const InputDecoration(labelText: 'Warn when'),
+                    items: const [
+                      DropdownMenuItem(
+                        value: OperationalBoundaryWarningDirection.either,
+                        child: Text('Entering or leaving'),
+                      ),
+                      DropdownMenuItem(
+                        value: OperationalBoundaryWarningDirection.entering,
+                        child: Text('Entering only'),
+                      ),
+                      DropdownMenuItem(
+                        value: OperationalBoundaryWarningDirection.leaving,
+                        child: Text('Leaving only'),
+                      ),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) {
+                        setDialogState(() => direction = value);
+                      }
+                    },
+                  ),
+                TextField(
+                  controller: effectiveController,
+                  keyboardType: TextInputType.datetime,
+                  decoration: const InputDecoration(
+                    labelText: 'Effective from (optional)',
+                    hintText: '2026-08-24T07:00',
+                  ),
+                ),
+                TextField(
+                  controller: validUntilController,
+                  keyboardType: TextInputType.datetime,
+                  decoration: const InputDecoration(
+                    labelText: 'Valid until (optional)',
+                    hintText: '2026-08-24T12:00',
+                  ),
+                ),
                 if (kind == OperationalBoundaryKind.altitudeBand) ...[
+                  DropdownButtonFormField<AltitudeUnit>(
+                    initialValue: altitudeUnit,
+                    decoration: const InputDecoration(
+                      labelText: 'Altitude units',
+                    ),
+                    items: const [
+                      DropdownMenuItem(
+                        value: AltitudeUnit.metres,
+                        child: Text('Metres'),
+                      ),
+                      DropdownMenuItem(
+                        value: AltitudeUnit.feet,
+                        child: Text('Feet'),
+                      ),
+                    ],
+                    onChanged: (value) {
+                      if (value == null || value == altitudeUnit) return;
+                      final lower = double.tryParse(lowerController.text);
+                      final upper = double.tryParse(upperController.text);
+                      double convert(double input) {
+                        final metres = altitudeUnit == AltitudeUnit.metres
+                            ? input
+                            : input / 3.280839895;
+                        return value.fromMetres(metres);
+                      }
+
+                      setDialogState(() {
+                        if (lower != null) {
+                          lowerController.text = convert(
+                            lower,
+                          ).toStringAsFixed(0);
+                        }
+                        if (upper != null) {
+                          upperController.text = convert(
+                            upper,
+                          ).toStringAsFixed(0);
+                        }
+                        altitudeUnit = value;
+                      });
+                    },
+                  ),
                   TextField(
                     controller: lowerController,
                     keyboardType: const TextInputType.numberWithOptions(
                       decimal: true,
                       signed: true,
                     ),
-                    decoration: const InputDecoration(
-                      labelText: 'Minimum altitude in metres (optional)',
+                    decoration: InputDecoration(
+                      labelText:
+                          'Minimum altitude in ${altitudeUnit.label.toLowerCase()} (optional)',
                     ),
                   ),
                   TextField(
@@ -6783,8 +7161,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                       decimal: true,
                       signed: true,
                     ),
-                    decoration: const InputDecoration(
-                      labelText: 'Maximum altitude in metres (optional)',
+                    decoration: InputDecoration(
+                      labelText:
+                          'Maximum altitude in ${altitudeUnit.label.toLowerCase()} (optional)',
                     ),
                   ),
                   const SizedBox(height: 12),
@@ -6811,6 +7190,20 @@ class _ActiveRideShellState extends State<ActiveRideShell>
                       if (value != null) setDialogState(() => datum = value);
                     },
                   ),
+                  CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Accept GNSS altitude'),
+                    value: acceptGnss,
+                    onChanged: (value) =>
+                        setDialogState(() => acceptGnss = value ?? false),
+                  ),
+                  CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Accept barometric altitude'),
+                    value: acceptBarometric,
+                    onChanged: (value) =>
+                        setDialogState(() => acceptBarometric = value ?? false),
+                  ),
                 ],
                 if (validationMessage != null)
                   Padding(
@@ -6832,39 +7225,88 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               onPressed: () {
                 final label = labelController.text.trim();
                 final source = sourceController.text.trim();
-                final lower = lowerController.text.trim().isEmpty
+                final limitations = limitationsController.text.trim();
+                final lowerInput = lowerController.text.trim().isEmpty
                     ? null
                     : double.tryParse(lowerController.text.trim());
-                final upper = upperController.text.trim().isEmpty
+                final upperInput = upperController.text.trim().isEmpty
                     ? null
                     : double.tryParse(upperController.text.trim());
+                final lower = lowerInput == null
+                    ? null
+                    : altitudeUnit == AltitudeUnit.metres
+                    ? lowerInput
+                    : lowerInput / 3.280839895;
+                final upper = upperInput == null
+                    ? null
+                    : altitudeUnit == AltitudeUnit.metres
+                    ? upperInput
+                    : upperInput / 3.280839895;
+                final effectiveText = effectiveController.text.trim();
+                final validUntilText = validUntilController.text.trim();
+                final effective = effectiveText.isEmpty
+                    ? null
+                    : DateTime.tryParse(effectiveText);
+                final validUntil = validUntilText.isEmpty
+                    ? null
+                    : DateTime.tryParse(validUntilText);
                 final altitudeValid =
                     kind != OperationalBoundaryKind.altitudeBand ||
                     ((lower != null || upper != null) &&
-                        (lower == null || upper == null || lower < upper));
-                if (label.isEmpty || source.isEmpty || !altitudeValid) {
+                        (lower == null || upper == null || lower < upper) &&
+                        (acceptGnss || acceptBarometric));
+                final effectiveAt = effective ?? DateTime.now();
+                final timesValid =
+                    (effectiveText.isEmpty || effective != null) &&
+                    (validUntilText.isEmpty || validUntil != null) &&
+                    (validUntil == null || validUntil.isAfter(effectiveAt));
+                if (label.isEmpty ||
+                    source.isEmpty ||
+                    limitations.isEmpty ||
+                    !altitudeValid ||
+                    !timesValid) {
                   setDialogState(() {
-                    validationMessage = label.isEmpty || source.isEmpty
-                        ? 'Add a name and source.'
-                        : 'Add at least one limit, with the minimum below the maximum.';
+                    validationMessage =
+                        label.isEmpty || source.isEmpty || limitations.isEmpty
+                        ? 'Add a name, source and limitations.'
+                        : !timesValid
+                        ? 'Use valid times, with the end after the start.'
+                        : 'Add at least one valid limit and altitude source.';
                   });
                   return;
                 }
                 Navigator.pop(
                   dialogContext,
                   _OperationalBoundaryDraft(
-                    id: 'boundary-${DateTime.now().microsecondsSinceEpoch}',
+                    id:
+                        existing?.id ??
+                        'boundary-${DateTime.now().microsecondsSinceEpoch}',
                     label: label,
                     kind: kind,
                     source: source,
+                    enabled: enabled,
+                    warningDirection: direction,
+                    effectiveFrom: effective,
+                    validUntil: validUntil,
+                    limitations: limitations,
                     lowerAltitudeMeters: lower,
                     upperAltitudeMeters: upper,
                     altitudeDatum: datum,
+                    altitudeUnit: altitudeUnit,
+                    acceptedAltitudeSources: {
+                      if (acceptGnss) AltitudeSource.gnss,
+                      if (acceptBarometric) AltitudeSource.barometric,
+                    },
+                    points: existing == null
+                        ? const []
+                        : _draftFromBoundary(existing).points,
                   ),
                 );
               },
               child: Text(
-                kind == OperationalBoundaryKind.altitudeBand
+                existing != null
+                    ? 'Save changes'
+                    : kind == OperationalBoundaryKind.altitudeBand
                     ? 'Save limits'
                     : 'Choose points on map',
               ),
@@ -6875,23 +7317,17 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     );
     labelController.dispose();
     sourceController.dispose();
+    limitationsController.dispose();
     lowerController.dispose();
     upperController.dispose();
+    effectiveController.dispose();
+    validUntilController.dispose();
     if (draft == null || !mounted) return;
-    if (kind == OperationalBoundaryKind.altitudeBand) {
+    if (kind == OperationalBoundaryKind.altitudeBand || existing != null) {
       await widget.rideController.upsertOperationalBoundary(
-        OperationalBoundary(
-          id: draft.id,
-          label: draft.label,
-          kind: draft.kind,
-          points: const [],
-          source: draft.source,
-          updatedAt: DateTime.now(),
-          lowerAltitudeMeters: draft.lowerAltitudeMeters,
-          upperAltitudeMeters: draft.upperAltitudeMeters,
-          altitudeDatum: draft.altitudeDatum,
-        ),
+        _boundaryFromDraft(draft),
       );
+      _syncOperationalBoundaries();
       return;
     }
     setState(() {

--- a/apps/mobile/lib/features/ride/ride_dashboard.dart
+++ b/apps/mobile/lib/features/ride/ride_dashboard.dart
@@ -1307,6 +1307,8 @@ class _EventRow extends StatelessWidget {
         'Operational boundary updated',
       RideEventType.operationalBoundaryRemoved =>
         'Operational boundary removed',
+      RideEventType.operationalBoundaryAlerted =>
+        event.payload['message'] as String? ?? 'Operational boundary warning',
       RideEventType.chaseGuidanceTargetSelected =>
         '${event.payload['vehicleLabel'] ?? 'Chase vehicle'} now targets '
             '${event.payload['target'] == 'balloon' ? 'the balloon' : 'the intended landing area'}',

--- a/apps/mobile/lib/services/chase_guidance_target.dart
+++ b/apps/mobile/lib/services/chase_guidance_target.dart
@@ -113,6 +113,7 @@ class ChaseGuidanceSelectionReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.operationalBoundaryAlerted:
         case RideEventType.pilotHandoverOffered:
         case RideEventType.pilotHandoverAccepted:
           break;

--- a/apps/mobile/lib/services/craft_roster.dart
+++ b/apps/mobile/lib/services/craft_roster.dart
@@ -174,6 +174,7 @@ class CraftRosterReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.operationalBoundaryAlerted:
         case RideEventType.chaseGuidanceTargetSelected:
         case RideEventType.pilotHandoverOffered:
         case RideEventType.pilotHandoverAccepted:

--- a/apps/mobile/lib/services/craft_track_reducer.dart
+++ b/apps/mobile/lib/services/craft_track_reducer.dart
@@ -119,6 +119,7 @@ class CraftTrackReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.operationalBoundaryAlerted:
         case RideEventType.chaseGuidanceTargetSelected:
         case RideEventType.pilotHandoverOffered:
         case RideEventType.pilotHandoverAccepted:

--- a/apps/mobile/lib/services/device_authority_policy.dart
+++ b/apps/mobile/lib/services/device_authority_policy.dart
@@ -124,6 +124,7 @@ class DeviceAuthorityPolicy {
       RideEventType.deviceAuthorityRevoked => isPilot,
       RideEventType.windContextNoted =>
         isPilot || role == FlightRole.balloonCrew,
+      RideEventType.operationalBoundaryAlerted => role.isAboardBalloon,
       RideEventType.flightStartedByCrew => role.isChasing,
       RideEventType.flightLanded ||
       RideEventType.flightLandingRetracted ||

--- a/apps/mobile/lib/services/flight_replay_archiver.dart
+++ b/apps/mobile/lib/services/flight_replay_archiver.dart
@@ -32,6 +32,7 @@ class FlightReplayArchiver {
     final builders = <String, _TrackBuilder>{};
     final wind = <FlightReplayWindContext>[];
     final landingAreas = <FlightReplayLandingArea>[];
+    final boundaryAlerts = <FlightReplayBoundaryAlert>[];
 
     for (final event in ordered) {
       if (event.createdAt.isBefore(startedAt) ||
@@ -107,6 +108,9 @@ class FlightReplayArchiver {
         case RideEventType.landingAreaNoted:
           final area = _landingArea(event);
           if (area != null) landingAreas.add(area);
+        case RideEventType.operationalBoundaryAlerted:
+          final alert = _boundaryAlert(event);
+          if (alert != null) boundaryAlerts.add(alert);
         case RideEventType.rideCreated:
         case RideEventType.riderJoined:
         case RideEventType.riderLeft:
@@ -173,6 +177,7 @@ class FlightReplayArchiver {
       tracks: List.unmodifiable(tracks),
       windContexts: List.unmodifiable(wind),
       landingAreas: List.unmodifiable(landingAreas),
+      boundaryAlerts: List.unmodifiable(boundaryAlerts),
       peerTracksIncluded: includePeerTracks,
     );
   }
@@ -247,6 +252,46 @@ class FlightReplayArchiver {
       ),
       radiusMeters: radius.toDouble(),
       label: label,
+    );
+  }
+
+  static FlightReplayBoundaryAlert? _boundaryAlert(RideEvent event) {
+    final payload = event.payload;
+    final boundaryId = payload['boundaryId'];
+    final boundaryLabel = payload['boundaryLabel'];
+    final kind = payload['kind'];
+    final assessment = payload['assessment'];
+    final confirmed = payload['confirmed'];
+    final message = payload['message'];
+    if (boundaryId is! String ||
+        boundaryLabel is! String ||
+        kind is! String ||
+        assessment is! String ||
+        confirmed is! bool ||
+        message is! String) {
+      return null;
+    }
+    final observedAtValue = payload['observedAt'];
+    final observedAt = observedAtValue is String
+        ? DateTime.tryParse(observedAtValue)?.toUtc()
+        : null;
+    final latitude = payload['latitude'];
+    final longitude = payload['longitude'];
+    return FlightReplayBoundaryAlert(
+      recordedAt: observedAt ?? event.createdAt,
+      boundaryId: boundaryId,
+      boundaryLabel: boundaryLabel,
+      kind: kind,
+      assessment: assessment,
+      confirmed: confirmed,
+      message: message,
+      position: latitude is num && longitude is num
+          ? GeoPoint(
+              latitude: latitude.toDouble(),
+              longitude: longitude.toDouble(),
+            )
+          : null,
+      altitudeMeters: (payload['altitudeMeters'] as num?)?.toDouble(),
     );
   }
 }

--- a/apps/mobile/lib/services/operational_boundary_monitor.dart
+++ b/apps/mobile/lib/services/operational_boundary_monitor.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import '../domain/altitude.dart';
+import '../domain/altitude_unit.dart';
 import '../domain/geo_point.dart';
 import '../domain/operational_boundary.dart';
 
@@ -12,76 +13,203 @@ enum OperationalBoundaryAlertKind {
   aboveMaximumAltitude,
 }
 
+enum OperationalBoundaryFixAssessment {
+  usable,
+  stale,
+  inaccurate,
+  missing,
+  altitudeSourceMismatch,
+  altitudeDatumMismatch,
+  altitudeInaccurate,
+}
+
 class OperationalBoundaryAlert {
-  const OperationalBoundaryAlert({required this.boundary, required this.kind});
+  const OperationalBoundaryAlert({
+    required this.boundary,
+    required this.kind,
+    required this.observedAt,
+    required this.assessment,
+    this.position,
+    this.altitudeMeters,
+  });
 
   final OperationalBoundary boundary;
   final OperationalBoundaryAlertKind kind;
+  final DateTime observedAt;
+  final OperationalBoundaryFixAssessment assessment;
+  final GeoPoint? position;
+  final double? altitudeMeters;
 
-  String get message => switch (kind) {
-    OperationalBoundaryAlertKind.lineCrossed =>
-      '${boundary.label} boundary crossed',
-    OperationalBoundaryAlertKind.areaEntered => '${boundary.label} entered',
-    OperationalBoundaryAlertKind.areaExited => '${boundary.label} exited',
-    OperationalBoundaryAlertKind.belowMinimumAltitude =>
-      '${boundary.label}: below ${boundary.lowerAltitudeMeters!.round()} m',
-    OperationalBoundaryAlertKind.aboveMaximumAltitude =>
-      '${boundary.label}: above ${boundary.upperAltitudeMeters!.round()} m',
-  };
+  bool get confirmed => assessment == OperationalBoundaryFixAssessment.usable;
+
+  String get message {
+    final description = switch (kind) {
+      OperationalBoundaryAlertKind.lineCrossed =>
+        '${boundary.label} boundary crossed',
+      OperationalBoundaryAlertKind.areaEntered => '${boundary.label} entered',
+      OperationalBoundaryAlertKind.areaExited => '${boundary.label} exited',
+      OperationalBoundaryAlertKind.belowMinimumAltitude =>
+        '${boundary.label}: below ${boundary.altitudeUnit.altitude(boundary.lowerAltitudeMeters!)}',
+      OperationalBoundaryAlertKind.aboveMaximumAltitude =>
+        '${boundary.label}: above ${boundary.altitudeUnit.altitude(boundary.upperAltitudeMeters!)}',
+    };
+    if (confirmed) return description;
+    final quality = switch (assessment) {
+      OperationalBoundaryFixAssessment.stale => 'stale location',
+      OperationalBoundaryFixAssessment.inaccurate => 'low-accuracy location',
+      OperationalBoundaryFixAssessment.missing => 'missing location',
+      OperationalBoundaryFixAssessment.altitudeSourceMismatch =>
+        'unaccepted altitude source',
+      OperationalBoundaryFixAssessment.altitudeDatumMismatch =>
+        'different altitude reference',
+      OperationalBoundaryFixAssessment.altitudeInaccurate =>
+        'low-accuracy altitude',
+      OperationalBoundaryFixAssessment.usable => 'usable location',
+    };
+    return 'Possible $description — $quality; not confirmed';
+  }
 }
 
-/// Detects crossings across any number of shared boundaries.
+/// Detects independent crossings across any number of shared advisories.
+///
+/// Only a fresh, sufficiently accurate sample advances the trusted state. A
+/// poor sample may explain a possible crossing, but it cannot turn uncertainty
+/// into a confirmed warning or prevent the next good fix from doing so.
 class OperationalBoundaryMonitor {
   OperationalBoundaryMonitor({
     this.repeatCooldown = const Duration(minutes: 2),
+    this.maximumFixAge = const Duration(seconds: 30),
+    this.maximumHorizontalAccuracyMeters = 100,
+    this.maximumAltitudeAccuracyMeters = 50,
+    this.horizontalHysteresisMeters = 15,
     this.altitudeHysteresisMeters = 20,
   });
 
   final Duration repeatCooldown;
+  final Duration maximumFixAge;
+  final double maximumHorizontalAccuracyMeters;
+  final double maximumAltitudeAccuracyMeters;
+  final double horizontalHysteresisMeters;
   final double altitudeHysteresisMeters;
-  GeoPoint? _previousPosition;
+
+  final _previousTrustedPositionByBoundary = <String, GeoPoint>{};
   final _insideByBoundary = <String, bool>{};
   final _altitudeStateByBoundary = <String, int>{};
+  final _revisionByBoundary = <String, String>{};
   final _lastAlertAt = <String, DateTime>{};
 
   List<OperationalBoundaryAlert> evaluate({
     required Iterable<OperationalBoundary> boundaries,
-    required GeoPoint position,
+    required GeoPoint? position,
     required DateTime now,
+    DateTime? recordedAt,
+    double? horizontalAccuracyMeters,
     double? altitudeMeters,
+    AltitudeSource altitudeSource = AltitudeSource.unknown,
     AltitudeDatum altitudeDatum = AltitudeDatum.unknown,
+    double? altitudeAccuracyMeters,
   }) {
+    final active = boundaries
+        .where((boundary) => boundary.enabled && boundary.appliesAt(now))
+        .toList(growable: false);
+    final activeIds = active.map((boundary) => boundary.id).toSet();
+    _previousTrustedPositionByBoundary.removeWhere(
+      (id, _) => !activeIds.contains(id),
+    );
+    _insideByBoundary.removeWhere((id, _) => !activeIds.contains(id));
+    _altitudeStateByBoundary.removeWhere((id, _) => !activeIds.contains(id));
+    _revisionByBoundary.removeWhere((id, _) => !activeIds.contains(id));
+    _lastAlertAt.removeWhere(
+      (key, _) => !activeIds.any((id) => key.startsWith('$id:')),
+    );
+    for (final boundary in active) {
+      final revision =
+          '${boundary.kind.name}:'
+          '${boundary.updatedAt.toUtc().toIso8601String()}';
+      if (_revisionByBoundary[boundary.id] == revision) continue;
+      _previousTrustedPositionByBoundary.remove(boundary.id);
+      _insideByBoundary.remove(boundary.id);
+      _altitudeStateByBoundary.remove(boundary.id);
+      _lastAlertAt.removeWhere((key, _) => key.startsWith('${boundary.id}:'));
+      _revisionByBoundary[boundary.id] = revision;
+    }
+    final horizontalAssessment = _horizontalAssessment(
+      position: position,
+      recordedAt: recordedAt ?? now,
+      horizontalAccuracyMeters: horizontalAccuracyMeters,
+      now: now,
+    );
+    if (position == null) return const [];
+
     final alerts = <OperationalBoundaryAlert>[];
-    final previousPosition = _previousPosition;
-    for (final boundary in boundaries) {
+    final horizontalUsable =
+        horizontalAssessment == OperationalBoundaryFixAssessment.usable;
+
+    for (final boundary in active) {
       switch (boundary.kind) {
         case OperationalBoundaryKind.line:
-          if (previousPosition != null &&
-              _crossesLine(previousPosition, position, boundary.points) &&
-              _canAlert('${boundary.id}:line', now)) {
-            alerts.add(
-              OperationalBoundaryAlert(
-                boundary: boundary,
-                kind: OperationalBoundaryAlertKind.lineCrossed,
-              ),
+          final previous = _previousTrustedPositionByBoundary[boundary.id];
+          if (previous != null) {
+            final crossing = _lineCrossing(
+              previous,
+              position,
+              boundary.points,
+              horizontalHysteresisMeters,
             );
+            if (crossing != null &&
+                _allowsDirection(boundary.warningDirection, crossing) &&
+                _canAlert(
+                  '${boundary.id}:line:${crossing.name}:${horizontalUsable ? 'confirmed' : 'possible'}',
+                  now,
+                )) {
+              alerts.add(
+                OperationalBoundaryAlert(
+                  boundary: boundary,
+                  kind: OperationalBoundaryAlertKind.lineCrossed,
+                  observedAt: recordedAt ?? now,
+                  assessment: horizontalAssessment,
+                  position: position,
+                ),
+              );
+            }
+          }
+          if (horizontalUsable &&
+              _distanceToPolylineMeters(position, boundary.points) >=
+                  horizontalHysteresisMeters) {
+            _previousTrustedPositionByBoundary[boundary.id] = position;
           }
         case OperationalBoundaryKind.area:
           final inside = _insidePolygon(position, boundary.points);
           final previousInside = _insideByBoundary[boundary.id];
+          final farEnough =
+              _distanceToPolylineMeters(position, [
+                ...boundary.points,
+                boundary.points.first,
+              ]) >=
+              horizontalHysteresisMeters;
           if (previousInside != null &&
               previousInside != inside &&
-              _canAlert('${boundary.id}:area', now)) {
+              farEnough &&
+              _allowsAreaDirection(boundary.warningDirection, inside) &&
+              _canAlert(
+                '${boundary.id}:area:$inside:${horizontalUsable ? 'confirmed' : 'possible'}',
+                now,
+              )) {
             alerts.add(
               OperationalBoundaryAlert(
                 boundary: boundary,
                 kind: inside
                     ? OperationalBoundaryAlertKind.areaEntered
                     : OperationalBoundaryAlertKind.areaExited,
+                observedAt: recordedAt ?? now,
+                assessment: horizontalAssessment,
+                position: position,
               ),
             );
           }
-          _insideByBoundary[boundary.id] = inside;
+          if (horizontalUsable && (previousInside == null || farEnough)) {
+            _insideByBoundary[boundary.id] = inside;
+          }
         case OperationalBoundaryKind.altitudeBand:
           break;
       }
@@ -92,14 +220,29 @@ class OperationalBoundaryMonitor {
           _insideByBoundary[boundary.id] == true;
       if (!horizontalApplies ||
           !boundary.hasAltitudeBand ||
-          altitudeMeters == null ||
-          altitudeDatum != boundary.altitudeDatum) {
+          altitudeMeters == null) {
         continue;
       }
+      final altitudeQuality = _altitudeAssessment(
+        boundary: boundary,
+        altitudeSource: altitudeSource,
+        altitudeDatum: altitudeDatum,
+        altitudeAccuracyMeters: altitudeAccuracyMeters,
+      );
+      if (altitudeQuality ==
+              OperationalBoundaryFixAssessment.altitudeSourceMismatch ||
+          altitudeQuality ==
+              OperationalBoundaryFixAssessment.altitudeDatumMismatch) {
+        continue;
+      }
+      final altitudeAssessment = horizontalUsable
+          ? altitudeQuality
+          : horizontalAssessment;
       final previousState = _altitudeStateByBoundary[boundary.id] ?? 0;
       final nextState = _altitudeState(boundary, altitudeMeters, previousState);
       if (nextState != previousState && nextState != 0) {
-        final key = '${boundary.id}:altitude:$nextState';
+        final key =
+            '${boundary.id}:altitude:$nextState:${altitudeAssessment == OperationalBoundaryFixAssessment.usable ? 'confirmed' : 'possible'}';
         if (_canAlert(key, now)) {
           alerts.add(
             OperationalBoundaryAlert(
@@ -107,14 +250,62 @@ class OperationalBoundaryMonitor {
               kind: nextState < 0
                   ? OperationalBoundaryAlertKind.belowMinimumAltitude
                   : OperationalBoundaryAlertKind.aboveMaximumAltitude,
+              observedAt: recordedAt ?? now,
+              assessment: altitudeAssessment,
+              position: position,
+              altitudeMeters: altitudeMeters,
             ),
           );
         }
       }
-      _altitudeStateByBoundary[boundary.id] = nextState;
+      if (horizontalUsable &&
+          altitudeAssessment == OperationalBoundaryFixAssessment.usable) {
+        _altitudeStateByBoundary[boundary.id] = nextState;
+      }
     }
-    _previousPosition = position;
+
     return alerts;
+  }
+
+  OperationalBoundaryFixAssessment _horizontalAssessment({
+    required GeoPoint? position,
+    required DateTime recordedAt,
+    required double? horizontalAccuracyMeters,
+    required DateTime now,
+  }) {
+    if (position == null) return OperationalBoundaryFixAssessment.missing;
+    final age = now.difference(recordedAt);
+    if (age.isNegative || age > maximumFixAge) {
+      return OperationalBoundaryFixAssessment.stale;
+    }
+    if (horizontalAccuracyMeters != null &&
+        (!horizontalAccuracyMeters.isFinite ||
+            horizontalAccuracyMeters < 0 ||
+            horizontalAccuracyMeters > maximumHorizontalAccuracyMeters)) {
+      return OperationalBoundaryFixAssessment.inaccurate;
+    }
+    return OperationalBoundaryFixAssessment.usable;
+  }
+
+  OperationalBoundaryFixAssessment _altitudeAssessment({
+    required OperationalBoundary boundary,
+    required AltitudeSource altitudeSource,
+    required AltitudeDatum altitudeDatum,
+    required double? altitudeAccuracyMeters,
+  }) {
+    if (!boundary.acceptedAltitudeSources.contains(altitudeSource)) {
+      return OperationalBoundaryFixAssessment.altitudeSourceMismatch;
+    }
+    if (altitudeDatum != boundary.altitudeDatum) {
+      return OperationalBoundaryFixAssessment.altitudeDatumMismatch;
+    }
+    if (altitudeAccuracyMeters != null &&
+        (!altitudeAccuracyMeters.isFinite ||
+            altitudeAccuracyMeters < 0 ||
+            altitudeAccuracyMeters > maximumAltitudeAccuracyMeters)) {
+      return OperationalBoundaryFixAssessment.altitudeInaccurate;
+    }
+    return OperationalBoundaryFixAssessment.usable;
   }
 
   int _altitudeState(
@@ -148,63 +339,152 @@ class OperationalBoundaryMonitor {
     return true;
   }
 
-  static bool _crossesLine(GeoPoint from, GeoPoint to, List<GeoPoint> line) {
-    for (var index = 0; index < line.length - 1; index++) {
-      if (_segmentsIntersect(from, to, line[index], line[index + 1])) {
-        return true;
-      }
+  static bool _allowsAreaDirection(
+    OperationalBoundaryWarningDirection direction,
+    bool nowInside,
+  ) =>
+      direction == OperationalBoundaryWarningDirection.either ||
+      (direction == OperationalBoundaryWarningDirection.entering &&
+          nowInside) ||
+      (direction == OperationalBoundaryWarningDirection.leaving && !nowInside);
+
+  static bool _allowsDirection(
+    OperationalBoundaryWarningDirection configured,
+    OperationalBoundaryWarningDirection observed,
+  ) =>
+      configured == OperationalBoundaryWarningDirection.either ||
+      configured == observed;
+
+  static OperationalBoundaryWarningDirection? _lineCrossing(
+    GeoPoint from,
+    GeoPoint to,
+    List<GeoPoint> line,
+    double hysteresisMeters,
+  ) {
+    if (_distanceToPolylineMeters(from, line) < hysteresisMeters ||
+        _distanceToPolylineMeters(to, line) < hysteresisMeters) {
+      return null;
     }
-    return false;
+    for (var index = 0; index < line.length - 1; index++) {
+      final start = line[index];
+      final end = line[index + 1];
+      final projected = _projectTogether([from, to, start, end]);
+      if (!_segmentsIntersect(
+        projected[0],
+        projected[1],
+        projected[2],
+        projected[3],
+      )) {
+        continue;
+      }
+      final before = _side(projected[2], projected[3], projected[0]);
+      final after = _side(projected[2], projected[3], projected[1]);
+      if (before == 0 || after == 0 || before.sign == after.sign) continue;
+      return before < after
+          ? OperationalBoundaryWarningDirection.entering
+          : OperationalBoundaryWarningDirection.leaving;
+    }
+    return null;
   }
 
-  static bool _segmentsIntersect(
-    GeoPoint a,
-    GeoPoint b,
-    GeoPoint c,
-    GeoPoint d,
-  ) {
-    double orientation(GeoPoint p, GeoPoint q, GeoPoint r) =>
-        (q.longitude - p.longitude) * (r.latitude - p.latitude) -
-        (q.latitude - p.latitude) * (r.longitude - p.longitude);
-    const epsilon = 1e-12;
-    bool opposite(double first, double second) =>
-        (first > epsilon && second < -epsilon) ||
-        (first < -epsilon && second > epsilon);
-    bool onSegment(GeoPoint start, GeoPoint point, GeoPoint end) =>
-        point.longitude >= math.min(start.longitude, end.longitude) - epsilon &&
-        point.longitude <= math.max(start.longitude, end.longitude) + epsilon &&
-        point.latitude >= math.min(start.latitude, end.latitude) - epsilon &&
-        point.latitude <= math.max(start.latitude, end.latitude) + epsilon;
+  static double _side(_XY a, _XY b, _XY point) =>
+      (b.x - a.x) * (point.y - a.y) - (b.y - a.y) * (point.x - a.x);
 
-    final first = orientation(a, b, c);
-    final second = orientation(a, b, d);
-    final third = orientation(c, d, a);
-    final fourth = orientation(c, d, b);
-    if (opposite(first, second) && opposite(third, fourth)) return true;
-    if (first.abs() <= epsilon && onSegment(a, c, b)) return true;
-    if (second.abs() <= epsilon && onSegment(a, d, b)) return true;
-    if (third.abs() <= epsilon && onSegment(c, a, d)) return true;
-    return fourth.abs() <= epsilon && onSegment(c, b, d);
+  static bool _segmentsIntersect(_XY a, _XY b, _XY c, _XY d) {
+    final first = _side(a, b, c);
+    final second = _side(a, b, d);
+    final third = _side(c, d, a);
+    final fourth = _side(c, d, b);
+    const epsilon = 1e-6;
+    return ((first > epsilon && second < -epsilon) ||
+            (first < -epsilon && second > epsilon)) &&
+        ((third > epsilon && fourth < -epsilon) ||
+            (third < -epsilon && fourth > epsilon));
+  }
+
+  static double _distanceToPolylineMeters(GeoPoint point, List<GeoPoint> line) {
+    var best = double.infinity;
+    for (var index = 0; index < line.length - 1; index++) {
+      final projected = _projectTogether([point, line[index], line[index + 1]]);
+      best = math.min(
+        best,
+        _distanceToSegment(projected[0], projected[1], projected[2]),
+      );
+    }
+    return best;
+  }
+
+  static double _distanceToSegment(_XY point, _XY start, _XY end) {
+    final dx = end.x - start.x;
+    final dy = end.y - start.y;
+    final lengthSquared = dx * dx + dy * dy;
+    if (lengthSquared == 0) {
+      return math.sqrt(
+        math.pow(point.x - start.x, 2) + math.pow(point.y - start.y, 2),
+      );
+    }
+    final fraction =
+        (((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSquared)
+            .clamp(0.0, 1.0);
+    final x = start.x + fraction * dx;
+    final y = start.y + fraction * dy;
+    return math.sqrt(math.pow(point.x - x, 2) + math.pow(point.y - y, 2));
+  }
+
+  static List<_XY> _projectTogether(List<GeoPoint> points) {
+    const earthRadiusMeters = 6371008.8;
+    final latitudeOrigin =
+        points.map((point) => point.latitude).reduce((a, b) => a + b) /
+        points.length;
+    final longitudeOrigin = points.first.longitude;
+    final latitudeScale = math.pi / 180 * earthRadiusMeters;
+    final longitudeScale =
+        latitudeScale * math.cos(latitudeOrigin * math.pi / 180);
+    return [
+      for (final point in points)
+        _XY(
+          _normaliseLongitude(point.longitude - longitudeOrigin) *
+              longitudeScale,
+          (point.latitude - latitudeOrigin) * latitudeScale,
+        ),
+    ];
+  }
+
+  static double _normaliseLongitude(double value) {
+    var result = value;
+    while (result > 180) {
+      result -= 360;
+    }
+    while (result < -180) {
+      result += 360;
+    }
+    return result;
   }
 
   static bool _insidePolygon(GeoPoint point, List<GeoPoint> polygon) {
+    final projected = _projectTogether([point, ...polygon]);
+    final target = projected.first;
+    final shape = projected.skip(1).toList(growable: false);
     var inside = false;
     for (
-      var first = 0, second = polygon.length - 1;
-      first < polygon.length;
+      var first = 0, second = shape.length - 1;
+      first < shape.length;
       second = first++
     ) {
-      final a = polygon[first];
-      final b = polygon[second];
+      final a = shape[first];
+      final b = shape[second];
       final intersects =
-          ((a.latitude > point.latitude) != (b.latitude > point.latitude)) &&
-          (point.longitude <
-              (b.longitude - a.longitude) *
-                      (point.latitude - a.latitude) /
-                      (b.latitude - a.latitude) +
-                  a.longitude);
+          ((a.y > target.y) != (b.y > target.y)) &&
+          (target.x < (b.x - a.x) * (target.y - a.y) / (b.y - a.y) + a.x);
       if (intersects) inside = !inside;
     }
     return inside;
   }
+}
+
+class _XY {
+  const _XY(this.x, this.y);
+
+  final double x;
+  final double y;
 }

--- a/apps/mobile/lib/services/ride_lifecycle.dart
+++ b/apps/mobile/lib/services/ride_lifecycle.dart
@@ -106,6 +106,7 @@ class RideLifecycleReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.operationalBoundaryAlerted:
         case RideEventType.chaseGuidanceTargetSelected:
         case RideEventType.pilotHandoverOffered:
         case RideEventType.pilotHandoverAccepted:

--- a/apps/mobile/lib/services/ride_route_reducer.dart
+++ b/apps/mobile/lib/services/ride_route_reducer.dart
@@ -166,6 +166,7 @@ class RideRouteReducer {
         case RideEventType.windContextNoted:
         case RideEventType.operationalBoundaryUpserted:
         case RideEventType.operationalBoundaryRemoved:
+        case RideEventType.operationalBoundaryAlerted:
         case RideEventType.chaseGuidanceTargetSelected:
         case RideEventType.pilotHandoverOffered:
         case RideEventType.pilotHandoverAccepted:

--- a/apps/mobile/test/domain/operational_boundary_test.dart
+++ b/apps/mobile/test/domain/operational_boundary_test.dart
@@ -1,4 +1,5 @@
 import 'package:balloon_crumbs/domain/altitude.dart';
+import 'package:balloon_crumbs/domain/altitude_unit.dart';
 import 'package:balloon_crumbs/domain/geo_point.dart';
 import 'package:balloon_crumbs/domain/operational_boundary.dart';
 import 'package:balloon_crumbs/domain/ride_event.dart';
@@ -86,16 +87,154 @@ void main() {
         createdAt: start,
         payload: const {'role': 'rider'},
       ),
+      _upsert(
+        'pilot-boundary',
+        boundary,
+        start.add(const Duration(minutes: 1)),
+      ),
       _event(
         id: 'forged',
         deviceId: 'chaser',
         type: RideEventType.operationalBoundaryUpserted,
-        createdAt: start.add(const Duration(minutes: 1)),
-        payload: boundary.toEventPayload(leaderRiderId: 'chaser'),
+        createdAt: start.add(const Duration(minutes: 2)),
+        payload: OperationalBoundary(
+          id: boundary.id,
+          label: 'Forged edit',
+          kind: boundary.kind,
+          points: boundary.points,
+          source: boundary.source,
+          updatedAt: start.add(const Duration(minutes: 2)),
+        ).toEventPayload(leaderRiderId: 'chaser'),
+      ),
+      _event(
+        id: 'forged-remove',
+        deviceId: 'chaser',
+        type: RideEventType.operationalBoundaryRemoved,
+        createdAt: start.add(const Duration(minutes: 3)),
+        payload: const {'leaderRiderId': 'chaser', 'boundaryId': 'area'},
       ),
     ]);
 
-    expect(result, isEmpty);
+    expect(result, hasLength(1));
+    expect(result.single.label, 'Keep clear');
+  });
+
+  test('configuration round-trips with units, validity and source rules', () {
+    final boundary = OperationalBoundary(
+      id: 'configured-band',
+      label: 'Briefed operating band',
+      kind: OperationalBoundaryKind.altitudeBand,
+      points: const [],
+      source: 'Morning flight briefing',
+      updatedAt: start,
+      enabled: false,
+      effectiveFrom: start.add(const Duration(minutes: 10)),
+      validUntil: start.add(const Duration(hours: 2)),
+      limitations: 'Forecast advisory; confirm before flight.',
+      lowerAltitudeMeters: 152.4,
+      upperAltitudeMeters: 914.4,
+      altitudeDatum: AltitudeDatum.wgs84Geoid,
+      altitudeUnit: AltitudeUnit.feet,
+      acceptedAltitudeSources: const {AltitudeSource.barometric},
+    );
+
+    final restored = OperationalBoundary.fromJson(boundary.toJson());
+
+    expect(restored.isValid, isTrue);
+    expect(restored.enabled, isFalse);
+    expect(restored.altitudeUnit, AltitudeUnit.feet);
+    expect(restored.acceptedAltitudeSources, {AltitudeSource.barometric});
+    expect(restored.limitations, contains('Forecast'));
+    expect(restored.appliesAt(start), isFalse);
+    expect(restored.appliesAt(start.add(const Duration(hours: 1))), isTrue);
+    expect(restored.appliesAt(start.add(const Duration(hours: 3))), isFalse);
+  });
+
+  test('offline event order converges for three edited boundaries', () {
+    final line = OperationalBoundary(
+      id: 'line',
+      label: 'Boundary line',
+      kind: OperationalBoundaryKind.line,
+      points: const [
+        GeoPoint(latitude: 51, longitude: -2.1),
+        GeoPoint(latitude: 51.1, longitude: -2),
+      ],
+      source: 'Pilot briefing',
+      updatedAt: start,
+    );
+    final area = OperationalBoundary(
+      id: 'area',
+      label: 'Boundary area',
+      kind: OperationalBoundaryKind.area,
+      points: const [
+        GeoPoint(latitude: 51, longitude: -2.1),
+        GeoPoint(latitude: 51.1, longitude: -2.1),
+        GeoPoint(latitude: 51.1, longitude: -2),
+      ],
+      source: 'Pilot briefing',
+      updatedAt: start,
+    );
+    final altitude = OperationalBoundary(
+      id: 'altitude',
+      label: 'Altitude limits',
+      kind: OperationalBoundaryKind.altitudeBand,
+      points: const [],
+      source: 'Pilot briefing',
+      updatedAt: start,
+      upperAltitudeMeters: 900,
+    );
+    final editTime = start.add(const Duration(minutes: 2));
+    final events = [
+      _event(
+        id: 'created',
+        type: RideEventType.rideCreated,
+        createdAt: start,
+        payload: const {'role': 'lead'},
+      ),
+      _upsert('line', line, start.add(const Duration(minutes: 1))),
+      _upsert('area', area, start.add(const Duration(minutes: 1))),
+      _upsert('altitude', altitude, start.add(const Duration(minutes: 1))),
+      _upsert(
+        'area-edit-a',
+        OperationalBoundary(
+          id: area.id,
+          label: area.label,
+          kind: area.kind,
+          points: area.points,
+          source: area.source,
+          updatedAt: editTime,
+          enabled: true,
+        ),
+        editTime,
+      ),
+      _upsert(
+        'area-edit-z',
+        OperationalBoundary(
+          id: area.id,
+          label: area.label,
+          kind: area.kind,
+          points: area.points,
+          source: area.source,
+          updatedAt: editTime,
+          enabled: false,
+        ),
+        editTime,
+      ),
+    ];
+
+    final reducer = const OperationalBoundaryReducer();
+    final forward = reducer.fromEvents(events);
+    final reverse = reducer.fromEvents(events.reversed);
+
+    expect(
+      forward.map((boundary) => boundary.toJson()),
+      reverse.map((boundary) => boundary.toJson()),
+    );
+    expect(forward, hasLength(3));
+    expect(
+      forward.singleWhere((boundary) => boundary.id == 'area').enabled,
+      isFalse,
+    );
   });
 }
 

--- a/apps/mobile/test/services/device_authority_policy_test.dart
+++ b/apps/mobile/test/services/device_authority_policy_test.dart
@@ -143,4 +143,64 @@ void main() {
     ]);
     expect(policy.revokedDeviceIds, contains(crew.deviceId));
   });
+
+  test('only a balloon-side identity can publish a boundary warning', () async {
+    final policy = DeviceAuthorityPolicy(session);
+    expect(
+      policy.accept(
+        await signed(
+          identity: root,
+          type: RideEventType.rideCreated,
+          payload: const {'role': 'lead', 'flightRole': 'pilot'},
+          minute: 0,
+        ),
+      ),
+      isTrue,
+    );
+    expect(
+      policy.accept(
+        await signed(
+          identity: crew,
+          type: RideEventType.riderJoined,
+          payload: const {
+            'displayName': 'Chaser',
+            'role': 'rider',
+            'flightRole': 'chaseCrew',
+          },
+          minute: 1,
+        ),
+      ),
+      isTrue,
+    );
+    const warning = {
+      'boundaryId': 'edge',
+      'boundaryLabel': 'Restricted edge',
+      'kind': 'lineCrossed',
+      'assessment': 'usable',
+      'confirmed': true,
+      'message': 'Restricted edge boundary crossed',
+    };
+    expect(
+      policy.accept(
+        await signed(
+          identity: crew,
+          type: RideEventType.operationalBoundaryAlerted,
+          payload: warning,
+          minute: 2,
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      policy.accept(
+        await signed(
+          identity: root,
+          type: RideEventType.operationalBoundaryAlerted,
+          payload: warning,
+          minute: 3,
+        ),
+      ),
+      isTrue,
+    );
+  });
 }

--- a/apps/mobile/test/services/flight_replay_archiver_test.dart
+++ b/apps/mobile/test/services/flight_replay_archiver_test.dart
@@ -29,6 +29,8 @@ void main() {
     expect(replay.windContexts, hasLength(1));
     expect(replay.windContexts.single.isForecast, isTrue);
     expect(replay.landingAreas.single.label, 'North field');
+    expect(replay.boundaryAlerts.single.boundaryLabel, 'Restricted edge');
+    expect(replay.boundaryAlerts.single.confirmed, isTrue);
     expect(replay.peerTracksIncluded, isFalse);
     expect(replay.canReplay, isTrue);
   });
@@ -130,6 +132,24 @@ List<RideEvent> _events(DateTime start) => [
       'vectors': [
         {'altitudeMetersMsl': 100, 'fromDegrees': 240, 'speedKmh': 12},
       ],
+    },
+  ),
+  _event(
+    'boundary-alert',
+    'pilot-device',
+    RideEventType.operationalBoundaryAlerted,
+    start.add(const Duration(minutes: 6)),
+    {
+      'boundaryId': 'restricted-edge',
+      'boundaryLabel': 'Restricted edge',
+      'kind': 'lineCrossed',
+      'assessment': 'usable',
+      'confirmed': true,
+      'message': 'Restricted edge boundary crossed',
+      'observedAt': start.add(const Duration(minutes: 6)).toIso8601String(),
+      'latitude': 51.47,
+      'longitude': -2.58,
+      'altitudeMeters': 420,
     },
   ),
 ];

--- a/apps/mobile/test/services/operational_boundary_monitor_test.dart
+++ b/apps/mobile/test/services/operational_boundary_monitor_test.dart
@@ -71,6 +71,7 @@ void main() {
         position: const GeoPoint(latitude: 51, longitude: -2),
         now: start,
         altitudeMeters: 190,
+        altitudeSource: AltitudeSource.gnss,
         altitudeDatum: AltitudeDatum.wgs84Ellipsoid,
       ),
       isEmpty,
@@ -80,6 +81,7 @@ void main() {
       position: const GeoPoint(latitude: 51, longitude: -2),
       now: start.add(const Duration(seconds: 5)),
       altitudeMeters: 190,
+      altitudeSource: AltitudeSource.gnss,
       altitudeDatum: AltitudeDatum.wgs84Geoid,
     );
     final stillBelow = monitor.evaluate(
@@ -87,6 +89,7 @@ void main() {
       position: const GeoPoint(latitude: 51, longitude: -2),
       now: start.add(const Duration(seconds: 10)),
       altitudeMeters: 205,
+      altitudeSource: AltitudeSource.gnss,
       altitudeDatum: AltitudeDatum.wgs84Geoid,
     );
     final recovered = monitor.evaluate(
@@ -94,6 +97,7 @@ void main() {
       position: const GeoPoint(latitude: 51, longitude: -2),
       now: start.add(const Duration(seconds: 15)),
       altitudeMeters: 225,
+      altitudeSource: AltitudeSource.gnss,
       altitudeDatum: AltitudeDatum.wgs84Geoid,
     );
 
@@ -129,7 +133,384 @@ void main() {
 
     expect(alerts, isEmpty);
   });
+
+  test('line direction and GPS hysteresis suppress wrong-way jitter', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final boundary = _boundary(
+      id: 'oriented-line',
+      kind: OperationalBoundaryKind.line,
+      warningDirection: OperationalBoundaryWarningDirection.entering,
+      points: const [
+        GeoPoint(latitude: 51.0, longitude: -2.0),
+        GeoPoint(latitude: 51.1, longitude: -2.0),
+      ],
+    );
+    monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -1.99),
+      now: start,
+    );
+    expect(
+      monitor.evaluate(
+        boundaries: [boundary],
+        position: const GeoPoint(latitude: 51.05, longitude: -2.0001),
+        now: start.add(const Duration(seconds: 1)),
+      ),
+      isEmpty,
+    );
+    final entering = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -2.01),
+      now: start.add(const Duration(seconds: 2)),
+    );
+    expect(entering.single.confirmed, isTrue);
+
+    final wrongWay = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -1.99),
+      now: start.add(const Duration(seconds: 3)),
+    );
+    expect(wrongWay, isEmpty);
+  });
+
+  test('stale crossing is possible then a fresh fix confirms it', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final boundary = _boundary(
+      id: 'freshness',
+      kind: OperationalBoundaryKind.line,
+      points: const [
+        GeoPoint(latitude: 51, longitude: -2),
+        GeoPoint(latitude: 51.1, longitude: -2),
+      ],
+    );
+    monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -2.01),
+      recordedAt: start,
+      now: start,
+    );
+    final stale = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -1.99),
+      recordedAt: start,
+      now: start.add(const Duration(minutes: 1)),
+    );
+    expect(stale.single.confirmed, isFalse);
+    expect(stale.single.message, contains('not confirmed'));
+
+    final fresh = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -1.99),
+      recordedAt: start.add(const Duration(minutes: 1, seconds: 1)),
+      now: start.add(const Duration(minutes: 1, seconds: 1)),
+    );
+    expect(fresh.single.confirmed, isTrue);
+  });
+
+  test('a missing fix does not advance or erase trusted line state', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final boundary = _boundary(
+      id: 'missing-fix',
+      kind: OperationalBoundaryKind.line,
+      points: const [
+        GeoPoint(latitude: 51, longitude: -2),
+        GeoPoint(latitude: 51.1, longitude: -2),
+      ],
+    );
+    monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -2.01),
+      now: start,
+    );
+    expect(
+      monitor.evaluate(
+        boundaries: [boundary],
+        position: null,
+        now: start.add(const Duration(seconds: 1)),
+      ),
+      isEmpty,
+    );
+
+    final fresh = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51.05, longitude: -1.99),
+      now: start.add(const Duration(seconds: 2)),
+    );
+
+    expect(fresh.single.kind, OperationalBoundaryAlertKind.lineCrossed);
+    expect(fresh.single.confirmed, isTrue);
+  });
+
+  test('disabled and out-of-window boundaries are ignored', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final boundaries = [
+      _boundary(
+        id: 'disabled',
+        kind: OperationalBoundaryKind.area,
+        enabled: false,
+        points: _square,
+      ),
+      _boundary(
+        id: 'expired',
+        kind: OperationalBoundaryKind.area,
+        validUntil: start.subtract(const Duration(seconds: 1)),
+        points: _square,
+      ),
+    ];
+    monitor.evaluate(
+      boundaries: boundaries,
+      position: const GeoPoint(latitude: 50.9, longitude: -2.2),
+      now: start,
+    );
+    expect(
+      monitor.evaluate(
+        boundaries: boundaries,
+        position: const GeoPoint(latitude: 51.05, longitude: -2.05),
+        now: start.add(const Duration(seconds: 1)),
+      ),
+      isEmpty,
+    );
+  });
+
+  test('overlapping named areas alert independently', () {
+    final monitor = OperationalBoundaryMonitor();
+    final boundaries = [
+      _boundary(id: 'one', kind: OperationalBoundaryKind.area, points: _square),
+      _boundary(id: 'two', kind: OperationalBoundaryKind.area, points: _square),
+    ];
+    monitor.evaluate(
+      boundaries: boundaries,
+      position: const GeoPoint(latitude: 50.9, longitude: -2.2),
+      now: start,
+    );
+    final alerts = monitor.evaluate(
+      boundaries: boundaries,
+      position: const GeoPoint(latitude: 51.05, longitude: -2.05),
+      now: start.add(const Duration(seconds: 1)),
+    );
+    expect(alerts.map((alert) => alert.boundary.id), {'one', 'two'});
+  });
+
+  test('proximity to one line does not freeze another line state', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final boundaries = [
+      _boundary(
+        id: 'nearby-line',
+        kind: OperationalBoundaryKind.line,
+        points: const [
+          GeoPoint(latitude: 51.0, longitude: -2.0),
+          GeoPoint(latitude: 51.1, longitude: -2.0),
+        ],
+      ),
+      _boundary(
+        id: 'crossed-line',
+        kind: OperationalBoundaryKind.line,
+        points: const [
+          GeoPoint(latitude: 51.05, longitude: -2.2),
+          GeoPoint(latitude: 51.05, longitude: -1.8),
+        ],
+      ),
+    ];
+    monitor.evaluate(
+      boundaries: boundaries,
+      position: const GeoPoint(latitude: 51.04, longitude: -2.0001),
+      now: start,
+    );
+    monitor.evaluate(
+      boundaries: boundaries,
+      position: const GeoPoint(latitude: 51.0499, longitude: -2.0001),
+      now: start.add(const Duration(seconds: 1)),
+    );
+
+    final crossed = monitor.evaluate(
+      boundaries: boundaries,
+      position: const GeoPoint(latitude: 51.06, longitude: -2.0001),
+      now: start.add(const Duration(seconds: 2)),
+    );
+
+    expect(crossed, hasLength(1));
+    expect(crossed.single.boundary.id, 'crossed-line');
+  });
+
+  test('area crossing works across the antimeridian', () {
+    final monitor = OperationalBoundaryMonitor();
+    final boundary = _boundary(
+      id: 'date-line',
+      kind: OperationalBoundaryKind.area,
+      points: const [
+        GeoPoint(latitude: -1, longitude: 179.5),
+        GeoPoint(latitude: 1, longitude: 179.5),
+        GeoPoint(latitude: 1, longitude: -179.5),
+        GeoPoint(latitude: -1, longitude: -179.5),
+      ],
+    );
+    monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 0, longitude: 178),
+      now: start,
+    );
+    final alerts = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 0, longitude: -179.8),
+      now: start.add(const Duration(seconds: 1)),
+    );
+    expect(alerts.single.kind, OperationalBoundaryAlertKind.areaEntered);
+  });
+
+  test('altitude source and accuracy cannot create a confirmed warning', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final boundary = _boundary(
+      id: 'altitude-quality',
+      kind: OperationalBoundaryKind.altitudeBand,
+      lower: 200,
+      upper: 800,
+    );
+    expect(
+      monitor.evaluate(
+        boundaries: [boundary],
+        position: const GeoPoint(latitude: 51, longitude: -2),
+        now: start,
+        altitudeMeters: 900,
+        altitudeSource: AltitudeSource.unknown,
+        altitudeDatum: AltitudeDatum.wgs84Geoid,
+      ),
+      isEmpty,
+    );
+    final inaccurate = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51, longitude: -2),
+      now: start.add(const Duration(seconds: 1)),
+      altitudeMeters: 900,
+      altitudeSource: AltitudeSource.gnss,
+      altitudeDatum: AltitudeDatum.wgs84Geoid,
+      altitudeAccuracyMeters: 100,
+    );
+    expect(inaccurate.single.confirmed, isFalse);
+
+    final accurate = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51, longitude: -2),
+      now: start.add(const Duration(seconds: 2)),
+      altitudeMeters: 900,
+      altitudeSource: AltitudeSource.gnss,
+      altitudeDatum: AltitudeDatum.wgs84Geoid,
+      altitudeAccuracyMeters: 5,
+    );
+    expect(accurate.single.confirmed, isTrue);
+  });
+
+  test('a stale horizontal fix cannot confirm an altitude warning', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final boundary = _boundary(
+      id: 'stale-altitude',
+      kind: OperationalBoundaryKind.altitudeBand,
+      upper: 800,
+    );
+
+    final stale = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51, longitude: -2),
+      recordedAt: start,
+      now: start.add(const Duration(minutes: 1)),
+      altitudeMeters: 900,
+      altitudeSource: AltitudeSource.gnss,
+      altitudeDatum: AltitudeDatum.wgs84Geoid,
+      altitudeAccuracyMeters: 5,
+    );
+    expect(stale.single.confirmed, isFalse);
+    expect(stale.single.assessment, OperationalBoundaryFixAssessment.stale);
+
+    final fresh = monitor.evaluate(
+      boundaries: [boundary],
+      position: const GeoPoint(latitude: 51, longitude: -2),
+      recordedAt: start.add(const Duration(minutes: 1, seconds: 1)),
+      now: start.add(const Duration(minutes: 1, seconds: 1)),
+      altitudeMeters: 900,
+      altitudeSource: AltitudeSource.gnss,
+      altitudeDatum: AltitudeDatum.wgs84Geoid,
+      altitudeAccuracyMeters: 5,
+    );
+    expect(fresh.single.confirmed, isTrue);
+  });
+
+  test('disabling a boundary clears its trusted transition state', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final enabled = _boundary(
+      id: 're-enabled-area',
+      kind: OperationalBoundaryKind.area,
+      points: _square,
+    );
+    final disabled = _boundary(
+      id: enabled.id,
+      kind: enabled.kind,
+      enabled: false,
+      points: enabled.points,
+    );
+    monitor.evaluate(
+      boundaries: [enabled],
+      position: const GeoPoint(latitude: 50.9, longitude: -2.2),
+      now: start,
+    );
+    monitor.evaluate(
+      boundaries: [disabled],
+      position: const GeoPoint(latitude: 51.05, longitude: -2.05),
+      now: start.add(const Duration(seconds: 1)),
+    );
+
+    final firstFixAfterReEnable = monitor.evaluate(
+      boundaries: [enabled],
+      position: const GeoPoint(latitude: 51.05, longitude: -2.05),
+      now: start.add(const Duration(seconds: 2)),
+    );
+    expect(firstFixAfterReEnable, isEmpty);
+
+    final exit = monitor.evaluate(
+      boundaries: [enabled],
+      position: const GeoPoint(latitude: 50.9, longitude: -2.2),
+      now: start.add(const Duration(seconds: 3)),
+    );
+    expect(exit.single.kind, OperationalBoundaryAlertKind.areaExited);
+  });
+
+  test('editing a boundary resets state before evaluating new geometry', () {
+    final monitor = OperationalBoundaryMonitor(repeatCooldown: Duration.zero);
+    final original = _boundary(
+      id: 'edited-area',
+      kind: OperationalBoundaryKind.area,
+      points: _square,
+    );
+    const position = GeoPoint(latitude: 51.05, longitude: -2.05);
+    monitor.evaluate(boundaries: [original], position: position, now: start);
+    final edited = OperationalBoundary(
+      id: original.id,
+      label: original.label,
+      kind: original.kind,
+      points: const [
+        GeoPoint(latitude: 52, longitude: -3.1),
+        GeoPoint(latitude: 52.1, longitude: -3.1),
+        GeoPoint(latitude: 52.1, longitude: -3),
+        GeoPoint(latitude: 52, longitude: -3),
+      ],
+      source: original.source,
+      updatedAt: original.updatedAt.add(const Duration(minutes: 1)),
+    );
+
+    final firstEditedFix = monitor.evaluate(
+      boundaries: [edited],
+      position: position,
+      now: start.add(const Duration(minutes: 1)),
+    );
+
+    expect(firstEditedFix, isEmpty);
+  });
 }
+
+const _square = [
+  GeoPoint(latitude: 51, longitude: -2.1),
+  GeoPoint(latitude: 51.1, longitude: -2.1),
+  GeoPoint(latitude: 51.1, longitude: -2),
+  GeoPoint(latitude: 51, longitude: -2),
+];
 
 OperationalBoundary _boundary({
   required String id,
@@ -137,6 +518,10 @@ OperationalBoundary _boundary({
   List<GeoPoint> points = const [],
   double? lower,
   double? upper,
+  bool enabled = true,
+  DateTime? validUntil,
+  OperationalBoundaryWarningDirection warningDirection =
+      OperationalBoundaryWarningDirection.either,
 }) => OperationalBoundary(
   id: id,
   label: id,
@@ -144,6 +529,9 @@ OperationalBoundary _boundary({
   points: points,
   source: 'Test advisory',
   updatedAt: DateTime.utc(2026, 8, 22),
+  enabled: enabled,
+  validUntil: validUntil,
+  warningDirection: warningDirection,
   lowerAltitudeMeters: lower,
   upperAltitudeMeters: upper,
   altitudeDatum: AltitudeDatum.wgs84Geoid,

--- a/apps/planner/app.js
+++ b/apps/planner/app.js
@@ -30,12 +30,23 @@ const elements = Object.fromEntries(
     "airspace-toggle",
     "add-altitude-boundary",
     "boundary-altitude-datum",
+    "boundary-altitude-unit",
+    "boundary-effective-from",
+    "boundary-enabled",
     "boundary-list",
+    "boundary-limitations",
     "boundary-lower-altitude",
+    "boundary-lower-unit",
     "boundary-name",
     "boundary-source",
+    "boundary-source-barometric",
+    "boundary-source-gnss",
     "boundary-status",
     "boundary-upper-altitude",
+    "boundary-upper-unit",
+    "boundary-valid-until",
+    "boundary-warning-direction",
+    "cancel-boundary-edit",
     "cancel-boundary",
     "clock",
     "code-result",
@@ -82,6 +93,7 @@ const elements = Object.fromEntries(
     "profile-window",
     "retry-map",
     "route-status",
+    "save-boundary-details",
     "set-landing",
     "set-launch",
     "theme-label",
@@ -115,6 +127,7 @@ const state = {
   mapTileFailures: 0,
   operationalBoundaries: [],
   operationalBoundaryDraft: null,
+  operationalBoundaryEditId: null,
 };
 
 function setStatus(element, message, kind = "") {
@@ -1090,11 +1103,26 @@ function boundaryId() {
 
 function boundaryDescription(boundary) {
   const geometry = boundary.kind === "line" ? "Line" : boundary.kind === "area" ? "Area" : "Altitude";
+  const unit = boundary.altitudeUnit === "feet" ? "ft" : "m";
+  const scale = boundary.altitudeUnit === "feet" ? 3.280839895 : 1;
   const limits = [
-    boundary.lowerAltitudeMeters === null ? null : `min ${boundary.lowerAltitudeMeters} m`,
-    boundary.upperAltitudeMeters === null ? null : `max ${boundary.upperAltitudeMeters} m`,
+    boundary.lowerAltitudeMeters === null
+      ? null
+      : `min ${Math.round(boundary.lowerAltitudeMeters * scale)} ${unit}`,
+    boundary.upperAltitudeMeters === null
+      ? null
+      : `max ${Math.round(boundary.upperAltitudeMeters * scale)} ${unit}`,
   ].filter(Boolean);
-  return `${geometry}${limits.length ? ` · ${limits.join(" · ")} · ${boundary.altitudeDatum}` : ""} · ${boundary.source}`;
+  const validity = boundary.validUntil
+    ? ` · until ${new Date(boundary.validUntil).toLocaleString()}`
+    : "";
+  const effective = boundary.effectiveFrom
+    ? ` · from ${new Date(boundary.effectiveFrom).toLocaleString()}`
+    : "";
+  const updated = boundary.updatedAt
+    ? ` · updated ${new Date(boundary.updatedAt).toLocaleString()}`
+    : "";
+  return `${boundary.enabled ? geometry : `${geometry} · off`} · ${boundary.warningDirection}${limits.length ? ` · ${limits.join(" · ")} · ${boundary.altitudeDatum}` : ""} · ${boundary.source}${effective}${validity}${updated} · ${boundary.limitations}`;
 }
 
 function persistOperationalBoundaries() {
@@ -1119,9 +1147,33 @@ function renderOperationalBoundaries() {
     const copy = document.createElement("div");
     const title = document.createElement("strong");
     const detail = document.createElement("small");
+    const actions = document.createElement("div");
+    const toggle = document.createElement("button");
+    const edit = document.createElement("button");
     const remove = document.createElement("button");
     title.textContent = boundary.label;
     detail.textContent = boundaryDescription(boundary);
+    toggle.type = "button";
+    toggle.textContent = boundary.enabled ? "Disable" : "Enable";
+    toggle.setAttribute("aria-label", `${toggle.textContent} ${boundary.label}`);
+    toggle.addEventListener("click", () => {
+      state.operationalBoundaries = state.operationalBoundaries.map((candidate) =>
+        candidate.id === boundary.id
+          ? normaliseOperationalBoundary({
+              ...candidate,
+              enabled: !candidate.enabled,
+              updatedAt: new Date().toISOString(),
+            })
+          : candidate,
+      );
+      persistOperationalBoundaries();
+      renderOperationalBoundaries();
+      updateSources();
+    });
+    edit.type = "button";
+    edit.textContent = "Edit";
+    edit.setAttribute("aria-label", `Edit ${boundary.label}`);
+    edit.addEventListener("click", () => editOperationalBoundary(boundary));
     remove.type = "button";
     remove.textContent = "Remove";
     remove.setAttribute("aria-label", `Remove ${boundary.label}`);
@@ -1135,7 +1187,8 @@ function renderOperationalBoundaries() {
       setStatus(elements.boundary_status, `${boundary.label} removed.`);
     });
     copy.append(title, detail);
-    item.append(copy, remove);
+    actions.append(toggle, edit, remove);
+    item.append(copy, actions);
     elements.boundary_list.append(item);
   }
 }
@@ -1158,17 +1211,158 @@ function loadOperationalBoundaries() {
   renderOperationalBoundaries();
 }
 
-function boundaryLabelAndSource() {
+function optionalIsoTime(element, label) {
+  if (!element.value) return null;
+  const parsed = new Date(element.value);
+  if (!Number.isFinite(parsed.getTime())) throw new Error(`${label} is invalid.`);
+  return parsed.toISOString();
+}
+
+function altitudeInputMetres(element) {
+  const value = optionalNumber(element);
+  if (value === null) return null;
+  return elements.boundary_altitude_unit.value === "feet" ? value / 3.280839895 : value;
+}
+
+function boundaryConfiguration() {
   const label = elements.boundary_name.value.trim();
   const source = elements.boundary_source.value.trim();
-  if (!label || !source) throw new Error("Add a boundary name and source first.");
-  return { label, source };
+  const limitations = elements.boundary_limitations.value.trim();
+  if (!label || !source || !limitations) {
+    throw new Error("Add a boundary name, source and limitations first.");
+  }
+  const effectiveFrom = optionalIsoTime(elements.boundary_effective_from, "Effective time");
+  const validUntil = optionalIsoTime(elements.boundary_valid_until, "Expiry time");
+  if (effectiveFrom && validUntil && new Date(validUntil) <= new Date(effectiveFrom)) {
+    throw new Error("Expiry must be after the effective time.");
+  }
+  return {
+    label,
+    source,
+    enabled: elements.boundary_enabled.checked,
+    warningDirection: elements.boundary_warning_direction.value,
+    effectiveFrom,
+    validUntil,
+    limitations,
+    lowerAltitudeMeters: altitudeInputMetres(elements.boundary_lower_altitude),
+    upperAltitudeMeters: altitudeInputMetres(elements.boundary_upper_altitude),
+    altitudeDatum: elements.boundary_altitude_datum.value,
+    altitudeUnit: elements.boundary_altitude_unit.value,
+    acceptedAltitudeSources: [
+      ...(elements.boundary_source_gnss.checked ? ["gnss"] : []),
+      ...(elements.boundary_source_barometric.checked ? ["barometric"] : []),
+    ],
+  };
+}
+
+function localDateTimeValue(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+function setBoundaryEditMode(boundaryId) {
+  state.operationalBoundaryEditId = boundaryId;
+  elements.save_boundary_details.disabled = !boundaryId;
+  elements.cancel_boundary_edit.disabled = !boundaryId;
+}
+
+function editOperationalBoundary(boundary) {
+  setBoundaryEditMode(boundary.id);
+  elements.boundary_name.value = boundary.label;
+  elements.boundary_source.value = boundary.source;
+  elements.boundary_enabled.checked = boundary.enabled;
+  elements.boundary_warning_direction.value = boundary.warningDirection;
+  elements.boundary_limitations.value = boundary.limitations;
+  elements.boundary_effective_from.value = localDateTimeValue(boundary.effectiveFrom);
+  elements.boundary_valid_until.value = localDateTimeValue(boundary.validUntil);
+  elements.boundary_altitude_unit.value = boundary.altitudeUnit;
+  elements.boundary_altitude_unit.dataset.previous = boundary.altitudeUnit;
+  const scale = boundary.altitudeUnit === "feet" ? 3.280839895 : 1;
+  elements.boundary_lower_altitude.value =
+    boundary.lowerAltitudeMeters === null
+      ? ""
+      : String(Math.round(boundary.lowerAltitudeMeters * scale));
+  elements.boundary_upper_altitude.value =
+    boundary.upperAltitudeMeters === null
+      ? ""
+      : String(Math.round(boundary.upperAltitudeMeters * scale));
+  elements.boundary_altitude_datum.value = boundary.altitudeDatum;
+  elements.boundary_source_gnss.checked = boundary.acceptedAltitudeSources.includes("gnss");
+  elements.boundary_source_barometric.checked =
+    boundary.acceptedAltitudeSources.includes("barometric");
+  syncBoundaryAltitudeUnit({ convert: false });
+  setStatus(
+    elements.boundary_status,
+    `Editing ${boundary.label}. Save details or redraw the same kind to replace its geometry.`,
+    "good",
+  );
+}
+
+function cancelOperationalBoundaryEdit() {
+  setBoundaryEditMode(null);
+  setStatus(elements.boundary_status, "Boundary edit cancelled.");
+}
+
+function saveOperationalBoundaryDetails() {
+  const boundary = state.operationalBoundaries.find(
+    (candidate) => candidate.id === state.operationalBoundaryEditId,
+  );
+  if (!boundary) return cancelOperationalBoundaryEdit();
+  try {
+    const updated = normaliseOperationalBoundary({
+      ...boundary,
+      ...boundaryConfiguration(),
+      warningDirection:
+        boundary.kind === "altitudeBand"
+          ? "either"
+          : elements.boundary_warning_direction.value,
+      updatedAt: new Date().toISOString(),
+    });
+    state.operationalBoundaries = state.operationalBoundaries.map((candidate) =>
+      candidate.id === updated.id ? updated : candidate,
+    );
+    persistOperationalBoundaries();
+    renderOperationalBoundaries();
+    updateSources();
+    setBoundaryEditMode(null);
+    setStatus(elements.boundary_status, `${updated.label} updated.`, "good");
+  } catch (error) {
+    setStatus(elements.boundary_status, error.message, "error");
+  }
+}
+
+function syncBoundaryAltitudeUnit({ convert = true } = {}) {
+  const next = elements.boundary_altitude_unit.value;
+  const previous = elements.boundary_altitude_unit.dataset.previous ?? next;
+  if (convert && previous !== next) {
+    for (const input of [elements.boundary_lower_altitude, elements.boundary_upper_altitude]) {
+      const value = Number(input.value);
+      if (!Number.isFinite(value)) continue;
+      const metres = previous === "feet" ? value / 3.280839895 : value;
+      input.value = String(Math.round(next === "feet" ? metres * 3.280839895 : metres));
+    }
+  }
+  elements.boundary_altitude_unit.dataset.previous = next;
+  const symbol = next === "feet" ? "ft" : "m";
+  elements.boundary_lower_unit.textContent = symbol;
+  elements.boundary_upper_unit.textContent = symbol;
 }
 
 function beginOperationalBoundary(kind) {
   try {
-    const { label, source } = boundaryLabelAndSource();
-    state.operationalBoundaryDraft = { id: boundaryId(), label, source, kind, points: [] };
+    const configuration = boundaryConfiguration();
+    const existing = state.operationalBoundaries.find(
+      (candidate) => candidate.id === state.operationalBoundaryEditId,
+    );
+    state.operationalBoundaryDraft = {
+      ...configuration,
+      id: existing?.kind === kind ? existing.id : boundaryId(),
+      kind,
+      points: [],
+      updatedAt: new Date().toISOString(),
+    };
     state.mode = "boundary";
     elements.finish_boundary.disabled = true;
     elements.cancel_boundary.disabled = false;
@@ -1198,16 +1392,17 @@ function finishOperationalBoundary() {
   try {
     const boundary = normaliseOperationalBoundary({
       ...draft,
-      lowerAltitudeMeters: null,
-      upperAltitudeMeters: null,
-      altitudeDatum: "wgs84Geoid",
     });
-    state.operationalBoundaries = [...state.operationalBoundaries, boundary];
+    state.operationalBoundaries = [
+      ...state.operationalBoundaries.filter((candidate) => candidate.id !== boundary.id),
+      boundary,
+    ];
     state.operationalBoundaryDraft = null;
     state.mode = null;
     elements.finish_boundary.disabled = true;
     elements.cancel_boundary.disabled = true;
     elements.map_prompt.hidden = true;
+    setBoundaryEditMode(null);
     persistOperationalBoundaries();
     renderOperationalBoundaries();
     updateSources();
@@ -1254,18 +1449,23 @@ function windFieldDigest(field) {
 
 function addAltitudeBoundary() {
   try {
-    const { label, source } = boundaryLabelAndSource();
+    const configuration = boundaryConfiguration();
+    const existing = state.operationalBoundaries.find(
+      (candidate) => candidate.id === state.operationalBoundaryEditId,
+    );
     const boundary = normaliseOperationalBoundary({
-      id: boundaryId(),
-      label,
-      source,
+      ...configuration,
+      id: existing?.kind === "altitudeBand" ? existing.id : boundaryId(),
       kind: "altitudeBand",
       points: [],
-      lowerAltitudeMeters: optionalNumber(elements.boundary_lower_altitude),
-      upperAltitudeMeters: optionalNumber(elements.boundary_upper_altitude),
-      altitudeDatum: elements.boundary_altitude_datum.value,
+      warningDirection: "either",
+      updatedAt: new Date().toISOString(),
     });
-    state.operationalBoundaries = [...state.operationalBoundaries, boundary];
+    state.operationalBoundaries = [
+      ...state.operationalBoundaries.filter((candidate) => candidate.id !== boundary.id),
+      boundary,
+    ];
+    setBoundaryEditMode(null);
     persistOperationalBoundaries();
     renderOperationalBoundaries();
     updateSources();
@@ -1404,6 +1604,9 @@ function bindControls() {
   elements.draw_boundary_area.addEventListener("click", () => beginOperationalBoundary("area"));
   elements.finish_boundary.addEventListener("click", finishOperationalBoundary);
   elements.cancel_boundary.addEventListener("click", cancelOperationalBoundary);
+  elements.save_boundary_details.addEventListener("click", saveOperationalBoundaryDetails);
+  elements.cancel_boundary_edit.addEventListener("click", cancelOperationalBoundaryEdit);
+  elements.boundary_altitude_unit.addEventListener("change", syncBoundaryAltitudeUnit);
   elements.add_altitude_boundary.addEventListener("click", addAltitudeBoundary);
 }
 
@@ -1413,6 +1616,7 @@ async function start() {
   configureDepartureInput();
   syncMaxAltitudeControl();
   syncVerticalRateControls();
+  syncBoundaryAltitudeUnit({ convert: false });
   updateClock();
   window.setInterval(updateClock, 1_000);
   bindControls();

--- a/apps/planner/planner-core.mjs
+++ b/apps/planner/planner-core.mjs
@@ -1464,9 +1464,20 @@ export function normaliseOperationalBoundary(input) {
   const id = String(input.id ?? "").trim().slice(0, 96);
   const label = String(input.label ?? "").trim().slice(0, 96);
   const source = String(input.source ?? "").trim().slice(0, 160);
+  const limitations = String(
+    input.limitations ?? "Advisory only; verify against current official information.",
+  )
+    .trim()
+    .slice(0, 500);
   const kind = String(input.kind ?? "");
-  if (!id || !label || !source || !["line", "area", "altitudeBand"].includes(kind)) {
-    throw new TypeError("Boundary name, kind and source are required.");
+  if (
+    !id ||
+    !label ||
+    !source ||
+    !limitations ||
+    !["line", "area", "altitudeBand"].includes(kind)
+  ) {
+    throw new TypeError("Boundary name, kind, source and limitations are required.");
   }
   const points = Array.isArray(input.points)
     ? input.points.map((point) => validPoint(point, "boundary point"))
@@ -1504,15 +1515,58 @@ export function normaliseOperationalBoundary(input) {
   )
     ? input.altitudeDatum
     : "wgs84Geoid";
+  const altitudeUnit = ["metres", "feet"].includes(input.altitudeUnit)
+    ? input.altitudeUnit
+    : "metres";
+  const warningDirection = ["entering", "leaving", "either"].includes(
+    input.warningDirection,
+  )
+    ? input.warningDirection
+    : "either";
+  if (kind === "altitudeBand" && warningDirection !== "either") {
+    throw new RangeError("Altitude bands must warn at either limit.");
+  }
+  const acceptedAltitudeSources = Array.isArray(input.acceptedAltitudeSources)
+    ? [...new Set(input.acceptedAltitudeSources.filter((value) => ["gnss", "barometric"].includes(value)))]
+    : ["gnss", "barometric"];
+  if (
+    (kind === "altitudeBand" ||
+      lowerAltitudeMeters !== null ||
+      upperAltitudeMeters !== null) &&
+    acceptedAltitudeSources.length === 0
+  ) {
+    throw new RangeError("Choose at least one accepted altitude source.");
+  }
+  const optionalTime = (value, label) => {
+    if (value === null || value === undefined || value === "") return null;
+    const parsed = new Date(value);
+    if (!Number.isFinite(parsed.getTime())) throw new TypeError(`${label} is invalid.`);
+    return parsed.toISOString();
+  };
+  const updatedAt = optionalTime(input.updatedAt, "Boundary update time");
+  const effectiveFrom = optionalTime(input.effectiveFrom, "Boundary effective time");
+  const validUntil = optionalTime(input.validUntil, "Boundary expiry time");
+  const start = effectiveFrom ?? updatedAt;
+  if (start && validUntil && new Date(validUntil) <= new Date(start)) {
+    throw new RangeError("Boundary expiry must be after its effective time.");
+  }
   return Object.freeze({
     id,
     label,
     kind,
     points: Object.freeze(points.map((point) => Object.freeze(point))),
     source,
+    enabled: input.enabled !== false,
+    warningDirection,
+    effectiveFrom,
+    validUntil,
+    limitations,
     lowerAltitudeMeters,
     upperAltitudeMeters,
     altitudeDatum,
+    altitudeUnit,
+    acceptedAltitudeSources: Object.freeze(acceptedAltitudeSources),
+    ...(updatedAt ? { updatedAt } : {}),
   });
 }
 
@@ -1520,7 +1574,7 @@ export function operationalBoundariesGeoJson(boundaries, draft = null) {
   const features = [];
   for (const boundary of boundaries ?? []) {
     const value = normaliseOperationalBoundary(boundary);
-    if (value.kind === "altitudeBand") continue;
+    if (!value.enabled || value.kind === "altitudeBand") continue;
     const coordinates = value.points.map((point) => [point.longitude, point.latitude]);
     features.push({
       type: "Feature",

--- a/apps/planner/planner-core.test.mjs
+++ b/apps/planner/planner-core.test.mjs
@@ -619,12 +619,20 @@ test("operational boundaries validate several lines, areas and altitude limits",
     lowerAltitudeMeters: 200,
     upperAltitudeMeters: 900,
     altitudeDatum: "wgs84Geoid",
+    altitudeUnit: "feet",
+    acceptedAltitudeSources: ["barometric"],
+    limitations: "Briefing snapshot; verify before launch.",
+    effectiveFrom: "2026-08-22T07:00:00Z",
+    validUntil: "2026-08-22T12:00:00Z",
   });
   const geoJson = operationalBoundariesGeoJson([line, area, altitude]);
 
   assert.equal(geoJson.features.length, 2);
   assert.equal(geoJson.features[0].geometry.type, "LineString");
   assert.equal(geoJson.features[1].geometry.type, "Polygon");
+  assert.equal(altitude.altitudeUnit, "feet");
+  assert.deepEqual(altitude.acceptedAltitudeSources, ["barometric"]);
+  assert.equal(altitude.effectiveFrom, "2026-08-22T07:00:00.000Z");
   assert.deepEqual(
     geoJson.features[1].geometry.coordinates[0][0],
     geoJson.features[1].geometry.coordinates[0].at(-1),
@@ -633,4 +641,36 @@ test("operational boundaries validate several lines, areas and altitude limits",
     () => normaliseOperationalBoundary({ ...altitude, lowerAltitudeMeters: 1000 }),
     /below maximum/,
   );
+  assert.throws(
+    () =>
+      normaliseOperationalBoundary({
+        ...altitude,
+        acceptedAltitudeSources: [],
+      }),
+    /altitude source/,
+  );
+  assert.throws(
+    () =>
+      normaliseOperationalBoundary({
+        ...altitude,
+        validUntil: "2026-08-22T06:00:00Z",
+      }),
+    /after its effective time/,
+  );
+  assert.equal(
+    operationalBoundariesGeoJson([{ ...line, enabled: false }, area]).features.length,
+    1,
+  );
+  const edited = [line, area, altitude].map((boundary, index) =>
+    normaliseOperationalBoundary({
+      ...boundary,
+      label: `${boundary.label} edit ${index + 1}`,
+      enabled: index !== 1,
+      updatedAt: `2026-08-22T${String(8 + index).padStart(2, "0")}:00:00Z`,
+    }),
+  );
+  assert.equal(edited.length, 3);
+  assert.equal(edited[0].label, "Restricted edge edit 1");
+  assert.equal(edited[1].enabled, false);
+  assert.equal(edited[2].updatedAt, "2026-08-22T10:00:00.000Z");
 });

--- a/apps/planner/planner.css
+++ b/apps/planner/planner.css
@@ -109,6 +109,7 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .boundary-list li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.5rem; align-items: center; border: 1px solid var(--line); border-radius: 0.65rem; padding: 0.55rem 0.65rem; background: var(--panel-raised); }
 .boundary-list strong, .boundary-list small { display: block; }
 .boundary-list small { margin-top: 0.12rem; color: var(--muted); font-size: 0.68rem; }
+.boundary-list li > div:last-child { display: flex; gap: 0.3rem; flex-wrap: wrap; justify-content: end; }
 .boundary-list button { padding: 0.35rem 0.5rem; font-size: 0.7rem; }
 .place-search { display: grid; gap: 0.36rem; margin-bottom: 0.2rem; }
 .place-search > label { color: var(--muted); font-size: 0.78rem; font-weight: 700; }
@@ -130,11 +131,14 @@ button.primary:hover:not(:disabled) { background: #8be4f2; }
 .field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
 .compact-fields { margin-top: 0.1rem; }
 .compact-fields .field { margin-top: 0.65rem; }
+.full-width-field { grid-column: 1 / -1; }
+.checkbox-field { align-content: center; }
+.checkbox-field > span { display: flex; align-items: center; gap: 0.35rem; }
 .ceiling-field { margin-top: 0.7rem; padding-top: 0.65rem; border-top: 1px solid var(--line); }
 .vertical-rate-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
 .vertical-rate-fields .range-field > span { display: grid; gap: 0.08rem; }
 .vertical-rate-fields .range-field strong { font-variant-numeric: tabular-nums; }
-input[type="text"], input[type="search"], input[type="number"], input[type="date"], select {
+input[type="text"], input[type="search"], input[type="number"], input[type="date"], input[type="datetime-local"], select, textarea {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--line);
@@ -143,6 +147,7 @@ input[type="text"], input[type="search"], input[type="number"], input[type="date
   background: #11151c;
   color: var(--ink);
 }
+textarea { resize: vertical; font: inherit; }
 .input-with-unit { display: grid; grid-template-columns: 1fr auto; align-items: center; border: 1px solid var(--line); border-radius: 0.6rem; background: #11151c; }
 .input-with-unit input { border: 0; background: transparent; }
 .input-with-unit i { font-style: normal; padding-right: 0.7rem; color: #8e97a7; font-weight: 650; white-space: nowrap; }

--- a/apps/planner/planner.html
+++ b/apps/planner/planner.html
@@ -164,6 +164,10 @@
             </div>
           </div>
           <div class="field-grid compact-fields">
+            <label class="field checkbox-field">
+              <span>Enabled</span>
+              <input type="checkbox" id="boundary-enabled" checked />
+            </label>
             <label class="field">
               <span>Name</span>
               <input type="text" id="boundary-name" maxlength="96" value="Advisory boundary" />
@@ -172,21 +176,50 @@
               <span>Source or briefing reference</span>
               <input type="text" id="boundary-source" maxlength="160" value="Pilot-entered advisory" />
             </label>
+            <label class="field">
+              <span>Warn when</span>
+              <select id="boundary-warning-direction">
+                <option value="either">Entering or leaving</option>
+                <option value="entering">Entering only</option>
+                <option value="leaving">Leaving only</option>
+              </select>
+            </label>
+            <label class="field full-width-field">
+              <span>Limitations</span>
+              <textarea id="boundary-limitations" maxlength="500" rows="2">Advisory only; verify against current official information.</textarea>
+            </label>
+            <label class="field">
+              <span>Effective from (optional)</span>
+              <input type="datetime-local" id="boundary-effective-from" />
+            </label>
+            <label class="field">
+              <span>Valid until (optional)</span>
+              <input type="datetime-local" id="boundary-valid-until" />
+            </label>
           </div>
           <div class="button-row">
             <button type="button" id="draw-boundary-line">Draw line</button>
             <button type="button" id="draw-boundary-area">Draw area</button>
             <button type="button" id="finish-boundary" disabled>Finish area</button>
             <button type="button" id="cancel-boundary" disabled>Cancel drawing</button>
+            <button type="button" id="save-boundary-details" disabled>Save edited details</button>
+            <button type="button" id="cancel-boundary-edit" disabled>Cancel edit</button>
           </div>
           <div class="field-grid compact-fields altitude-boundary-fields">
             <label class="field">
+              <span>Altitude units</span>
+              <select id="boundary-altitude-unit">
+                <option value="metres">Metres</option>
+                <option value="feet">Feet</option>
+              </select>
+            </label>
+            <label class="field">
               <span>Minimum altitude (optional)</span>
-              <span class="input-with-unit"><input type="number" id="boundary-lower-altitude" step="10" /><i>m</i></span>
+              <span class="input-with-unit"><input type="number" id="boundary-lower-altitude" step="10" /><i id="boundary-lower-unit">m</i></span>
             </label>
             <label class="field">
               <span>Maximum altitude (optional)</span>
-              <span class="input-with-unit"><input type="number" id="boundary-upper-altitude" step="10" /><i>m</i></span>
+              <span class="input-with-unit"><input type="number" id="boundary-upper-altitude" step="10" /><i id="boundary-upper-unit">m</i></span>
             </label>
             <label class="field">
               <span>Altitude reference</span>
@@ -196,11 +229,16 @@
                 <option value="relativeToLaunch">Relative to launch</option>
               </select>
             </label>
+            <label class="field checkbox-field">
+              <span>Accepted altitude sources</span>
+              <span><input type="checkbox" id="boundary-source-gnss" checked /> GNSS</span>
+              <span><input type="checkbox" id="boundary-source-barometric" checked /> Barometric</span>
+            </label>
             <button type="button" id="add-altitude-boundary">Add altitude limits</button>
           </div>
           <p class="status" id="boundary-status" role="status">Boundaries are saved in this browser. Confirm every source before flight.</p>
           <ul class="boundary-list" id="boundary-list" aria-label="Operational boundaries"></ul>
-          <p class="small muted">Planner boundaries are advisory planning aids and currently stay in this browser. Recreate or update them in the live flight so every crew device receives the alert definition.</p>
+          <p class="small muted">Boundaries stay in this browser until you generate a plan code. Importing that plan as the balloon pilot publishes them to the flight; review and update them live before takeoff.</p>
         </section>
 
         <details class="panel-section generate-section share-disclosure">

--- a/apps/server/src/balloon_crumbs_server/schemas.py
+++ b/apps/server/src/balloon_crumbs_server/schemas.py
@@ -454,9 +454,23 @@ class ForecastPlanBoundary(BaseModel):
     points: list[ForecastPlanPoint] = Field(default_factory=list, max_length=512)
     source: str = Field(min_length=1, max_length=160)
     updatedAt: datetime
+    enabled: bool = True
+    warningDirection: Literal["entering", "leaving", "either"] = "either"
+    effectiveFrom: datetime | None = None
+    validUntil: datetime | None = None
+    limitations: str = Field(
+        default="Advisory only; verify against current official information.",
+        min_length=1,
+        max_length=500,
+    )
     lowerAltitudeMeters: float | None = Field(default=None, ge=-500, le=20_000)
     upperAltitudeMeters: float | None = Field(default=None, ge=-500, le=20_000)
     altitudeDatum: str = Field(min_length=1, max_length=64)
+    altitudeUnit: Literal["metres", "feet"] = "metres"
+    acceptedAltitudeSources: list[Literal["gnss", "barometric"]] = Field(
+        default_factory=lambda: ["gnss", "barometric"],
+        max_length=2,
+    )
 
     @model_validator(mode="after")
     def geometry_matches_kind(self) -> ForecastPlanBoundary:
@@ -466,6 +480,23 @@ class ForecastPlanBoundary(BaseModel):
             raise ValueError("A boundary area needs three points")
         if self.kind == "altitudeBand" and self.points:
             raise ValueError("An altitude band cannot contain points")
+        if (
+            self.kind == "altitudeBand"
+            and self.lowerAltitudeMeters is None
+            and self.upperAltitudeMeters is None
+        ):
+            raise ValueError("An altitude band needs at least one altitude limit")
+        if self.kind == "altitudeBand" and self.warningDirection != "either":
+            raise ValueError("An altitude band must warn at either limit")
+        if (
+            self.kind == "altitudeBand"
+            or self.lowerAltitudeMeters is not None
+            or self.upperAltitudeMeters is not None
+        ) and not self.acceptedAltitudeSources:
+            raise ValueError("An altitude boundary needs an accepted altitude source")
+        effective = self.effectiveFrom or self.updatedAt
+        if self.validUntil is not None and self.validUntil <= effective:
+            raise ValueError("Boundary expiry must follow its effective time")
         if (
             self.lowerAltitudeMeters is not None
             and self.upperAltitudeMeters is not None

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -84,6 +84,7 @@ EVENT_TYPES = {
     "windContextNoted",
     "operationalBoundaryUpserted",
     "operationalBoundaryRemoved",
+    "operationalBoundaryAlerted",
     # One shared navigation target per chase vehicle. The relay carries the
     # choice; each vehicle still computes and validates its own road route.
     "chaseGuidanceTargetSelected",
@@ -1718,6 +1719,7 @@ class RelayService:
             "windContextNoted": timedelta(hours=72),
             "operationalBoundaryUpserted": timedelta(hours=72),
             "operationalBoundaryRemoved": timedelta(hours=72),
+            "operationalBoundaryAlerted": timedelta(hours=2),
             "chaseGuidanceTargetSelected": timedelta(hours=72),
             "pilotHandoverOffered": timedelta(hours=72),
             "pilotHandoverAccepted": timedelta(hours=72),

--- a/apps/server/tests/test_additive_event_types.py
+++ b/apps/server/tests/test_additive_event_types.py
@@ -54,6 +54,7 @@ def test_retention_table_matches_the_documented_bands() -> None:
     assert retention("flightLandingRetracted") == timedelta(hours=72)
     assert retention("deviceAuthorityRevoked") == timedelta(hours=72)
     assert retention("deviceAuthorityRotated") == timedelta(hours=72)
+    assert retention("operationalBoundaryAlerted") == timedelta(hours=2)
 
 
 def test_ground_crew_start_is_accepted_and_relayed(client, synchronize, make_event) -> None:
@@ -389,6 +390,22 @@ def test_balloon_flight_context_is_accepted_and_relayed(client, synchronize, mak
             "boundary-remove",
             event_type="operationalBoundaryRemoved",
             payload={"leaderRiderId": "device-a", "boundaryId": "restricted-edge"},
+        ),
+        make_event(
+            ride_id,
+            "boundary-alert",
+            event_type="operationalBoundaryAlerted",
+            payload={
+                "boundaryId": "restricted-edge",
+                "boundaryLabel": "Restricted airspace edge",
+                "kind": "lineCrossed",
+                "assessment": "usable",
+                "confirmed": True,
+                "message": "Restricted airspace edge boundary crossed",
+                "observedAt": "2026-08-22T06:05:00Z",
+                "latitude": 51.46,
+                "longitude": -2.61,
+            },
         ),
     ]
 

--- a/apps/server/tests/test_plans.py
+++ b/apps/server/tests/test_plans.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from balloon_crumbs_server.app import create_app
 from balloon_crumbs_server.gpx import GpxValidationError, validate_gpx
 from balloon_crumbs_server.models import RidePlan
+from balloon_crumbs_server.schemas import ForecastPlanBoundary
 from balloon_crumbs_server.service import PLAN_CODE_ALPHABET, PLAN_CODE_LENGTH, purge_expired
 
 GPX_TWO_POINTS = """<?xml version="1.0" encoding="UTF-8"?>
@@ -214,6 +215,28 @@ def test_structured_plan_rejects_unknown_schema_and_mismatched_fallback(client) 
     response = _create(client, forecast_plan=mismatched)
     assert response.status_code == 400
     assert "fallback" in response.json()["error"].lower()
+
+
+def test_structured_plan_rejects_empty_altitude_boundary(client) -> None:
+    forecast_plan = _forecast_plan()
+    boundary = {
+        "id": "empty-altitude-band",
+        "label": "Missing limits",
+        "kind": "altitudeBand",
+        "points": [],
+        "source": "Pilot briefing",
+        "updatedAt": "2026-08-23T06:00:00Z",
+        "altitudeDatum": "wgs84Geoid",
+    }
+    forecast_plan["operationalBoundaries"] = [boundary]
+
+    with pytest.raises(ValueError, match="at least one altitude limit"):
+        ForecastPlanBoundary.model_validate(boundary)
+
+    response = _create(client, forecast_plan=forecast_plan)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "Malformed plan request"
 
 
 def test_unknown_plan_code_is_not_found(client) -> None:


### PR DESCRIPTION
## Summary
- add editable, enabled, time-bounded line, area and altitude advisories to the planner and mobile app
- evaluate balloon-side crossings with per-boundary state, direction, age/accuracy checks, hysteresis, datum/source rules and antimeridian-safe geometry
- relay voice-first named warnings to chasers and retain bounded replay evidence
- preserve deterministic offline convergence and reject unauthorised edits

## Verification
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` — 1,830 passed, 24 skipped
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -q`
- `node --check app.js` and `planner-core.mjs`
- planner/Pages tests — 37 passed

Refs #60. The issue intentionally remains open until its required physical foreground/background alert-delivery evidence is recorded; this PR does not make that reliability claim.