### PR TITLE
Secure observer sharing and flight-data exports

### DIFF
--- a/apps/mobile/lib/controllers/observer_access_controller.dart
+++ b/apps/mobile/lib/controllers/observer_access_controller.dart
@@ -7,18 +7,25 @@ import '../domain/ride_session.dart';
 import '../internet/internet_relay_client.dart';
 import '../internet/observer_access_client.dart';
 
+typedef ObserverGroupAuthorizer =
+    Future<ObserverPilotAuthorization> Function(
+      ObserverGroupAuthorizationRequest request,
+    );
+
 class ObserverAccessController extends ChangeNotifier {
   ObserverAccessController(
     this._api,
     this._store, {
     DateTime Function()? clock,
     this.publishInterval = const Duration(seconds: 10),
+    this.groupAuthorizer,
   }) : _clock = clock ?? DateTime.now;
 
   final ObserverAccessApi _api;
   final ObserverGrantStore _store;
   final DateTime Function() _clock;
   final Duration publishInterval;
+  final ObserverGroupAuthorizer? groupAuthorizer;
   RideSession? _session;
   List<ObserverGrantCredentials> _credentials = const [];
   ObserverInvite? _latestInvite;
@@ -125,15 +132,26 @@ class ObserverAccessController extends ChangeNotifier {
     required String label,
     required Duration duration,
     ObserverAccessScope scope = ObserverAccessScope.rider,
+    ObserverPositionPrecision precision = ObserverPositionPrecision.reduced,
   }) async {
     final session = _session;
     if (session == null || _busy) return;
     await _run(() async {
+      final pilotAuthorization = scope == ObserverAccessScope.group
+          ? await _groupAuthorization(
+              session,
+              label: label,
+              duration: duration,
+              precision: precision,
+            )
+          : null;
       final credentials = await _api.create(
         session,
         label: label,
         duration: duration,
         scope: scope,
+        precision: precision,
+        pilotAuthorization: pilotAuthorization,
       );
       try {
         await _serializeGrantMutation(() async {
@@ -167,6 +185,28 @@ class ObserverAccessController extends ChangeNotifier {
         shareUri: _api.shareUri(credentials),
       );
     });
+  }
+
+  Future<ObserverPilotAuthorization> _groupAuthorization(
+    RideSession session, {
+    required String label,
+    required Duration duration,
+    required ObserverPositionPrecision precision,
+  }) {
+    final authorizer = groupAuthorizer;
+    if (authorizer == null) {
+      throw const InternetRelayException(
+        'Only the current pilot can create a whole-group watcher link.',
+      );
+    }
+    return authorizer(
+      ObserverGroupAuthorizationRequest(
+        session: session,
+        label: label,
+        duration: duration,
+        precision: precision,
+      ),
+    );
   }
 
   Future<void> revoke(String grantId) async {

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -40,6 +40,7 @@ import '../features/map/craft_icon.dart';
 import '../relay/live_presence.dart';
 import '../services/nearby_bridge.dart';
 import '../services/operational_boundary_monitor.dart';
+import '../services/observer_group_authorization.dart';
 import '../services/pilot_handover.dart';
 import '../services/presence_authenticator.dart';
 import '../services/completed_ride_archiver.dart';
@@ -51,6 +52,7 @@ import '../services/received_quick_message.dart';
 import '../services/ride_route_reducer.dart';
 import '../services/rider_contact_share.dart';
 import '../internet/internet_relay_client.dart';
+import '../internet/observer_access_client.dart';
 import '../internet/crew_room_directory.dart';
 import '../relay/relay_presence.dart';
 
@@ -1408,6 +1410,36 @@ class RideController extends ChangeNotifier {
         payload: {'role': role.name},
       );
     });
+  }
+
+  Future<ObserverPilotAuthorization> authorizeGroupObserver(
+    ObserverGroupAuthorizationRequest request,
+  ) async {
+    final session = _requireSession();
+    final manager = _deviceIdentityManager;
+    if (request.session.rideId != session.rideId ||
+        !session.usesDeviceAuthority ||
+        manager == null ||
+        !hasFlightAuthority ||
+        pilotAuthority.pilotDeviceId != session.localRiderId) {
+      throw const FormatException(
+        'Only the current pilot can authorize a whole-group watcher link.',
+      );
+    }
+    final identity = (await manager.loadOrCreate(
+      session.rideId,
+    )).boundToDeviceId(session.localRiderId);
+    if (identity.publicKey != session.localDevicePublicKey) {
+      throw StateError('This device no longer holds the pilot signing key.');
+    }
+    return ObserverGroupAuthorization.sign(
+      session: session,
+      identity: identity,
+      label: request.label,
+      duration: request.duration,
+      precision: request.precision,
+      signedAt: _clock(),
+    );
   }
 
   /// Changes this device's non-authority role without moving it to another

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -118,6 +118,7 @@ import '../situational_awareness/situational_awareness_screen.dart';
 import '../simulation/ride_simulation_screen.dart';
 import 'end_ride_confirmation.dart';
 import 'ended_ride_screen.dart';
+import 'flight_export_consent.dart';
 import 'observer_access_sheet.dart';
 import 'ride_dashboard.dart';
 import 'ride_roster_sheet.dart';
@@ -2080,6 +2081,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               client: http.Client(),
             ),
             const SecureObserverGrantStore(),
+            groupAuthorizer: widget.rideController.authorizeGroupObserver,
           );
           await _observerAccessController!.attach(session);
           if (_observerAccessController!.hasActiveGrants) {
@@ -7349,6 +7351,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
   Future<void> _shareCurrentRideSummary() async {
     final session = widget.rideController.session;
     if (session == null) return;
+    final choice = await chooseFlightSummaryShare(context);
+    if (choice == null || !mounted) return;
     try {
       final renderObject = context.findRenderObject();
       final origin = renderObject is RenderBox && renderObject.hasSize
@@ -7362,6 +7366,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         // Attached only when an instrumented build was recording, and only ever
         // to a recipient the rider picks in the share sheet (#419).
         diagnostics: _renderedDiagnostics,
+        includeExactTrack: choice == FlightSummaryShareChoice.exactFlightData,
       );
     } on Object catch (error) {
       if (!mounted) return;

--- a/apps/mobile/lib/features/ride/ended_ride_screen.dart
+++ b/apps/mobile/lib/features/ride/ended_ride_screen.dart
@@ -8,6 +8,7 @@ import '../../services/basemap_configuration.dart';
 import '../../services/ride_summary_exporter.dart';
 import '../internet/internet_relay_status_card.dart';
 import '../nearby/relay_status_card.dart';
+import 'flight_export_consent.dart';
 import 'ride_recap_screen.dart';
 
 class EndedRideScreen extends StatefulWidget {
@@ -324,6 +325,8 @@ class _EndedRideScreenState extends State<EndedRideScreen> {
   );
 
   Future<void> _shareSummary(BuildContext context) async {
+    final choice = await chooseFlightSummaryShare(context);
+    if (choice == null || !context.mounted) return;
     final renderObject = context.findRenderObject();
     final origin = renderObject is RenderBox && renderObject.hasSize
         ? renderObject.localToGlobal(Offset.zero) & renderObject.size
@@ -338,6 +341,7 @@ class _EndedRideScreenState extends State<EndedRideScreen> {
         diagnostics: diagnostics == null || diagnostics.isEmpty
             ? null
             : diagnostics,
+        includeExactTrack: choice == FlightSummaryShareChoice.exactFlightData,
       );
     } on Object catch (error) {
       if (!context.mounted) return;

--- a/apps/mobile/lib/features/ride/flight_export_consent.dart
+++ b/apps/mobile/lib/features/ride/flight_export_consent.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+enum FlightSummaryShareChoice { summaryOnly, exactFlightData }
+
+Future<FlightSummaryShareChoice?> chooseFlightSummaryShare(
+  BuildContext context,
+) => showDialog<FlightSummaryShareChoice>(
+  context: context,
+  builder: (dialogContext) => AlertDialog(
+    title: const Text('Include exact flight data?'),
+    content: const Text(
+      'The summary does not contain a location trail. Exact flight data adds '
+      'the recorded positions, timestamps and altitude as GPX, KML and CSV '
+      'files. An instrumented tester build may also add its opted-in diagnostic '
+      'log. Anyone you send those files to can retain them.',
+    ),
+    actions: [
+      TextButton(
+        key: const Key('cancel-flight-summary-share'),
+        onPressed: () => Navigator.pop(dialogContext),
+        child: const Text('Cancel'),
+      ),
+      TextButton(
+        key: const Key('share-summary-without-track'),
+        onPressed: () =>
+            Navigator.pop(dialogContext, FlightSummaryShareChoice.summaryOnly),
+        child: const Text('Summary only'),
+      ),
+      FilledButton(
+        key: const Key('share-exact-flight-data'),
+        onPressed: () => Navigator.pop(
+          dialogContext,
+          FlightSummaryShareChoice.exactFlightData,
+        ),
+        child: const Text('Include exact data'),
+      ),
+    ],
+  ),
+);
+
+Future<bool> confirmExactFlightDataExport(BuildContext context) async =>
+    await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Export exact flight data?'),
+        content: const Text(
+          'This exports precise recorded positions, timestamps and altitude. '
+          'The files may reveal launch, landing and recovery locations. Only '
+          'share them with someone you trust.',
+        ),
+        actions: [
+          TextButton(
+            key: const Key('cancel-exact-flight-export'),
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const Key('confirm-exact-flight-export'),
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Export exact data'),
+          ),
+        ],
+      ),
+    ) ??
+    false;

--- a/apps/mobile/lib/features/ride/observer_access_sheet.dart
+++ b/apps/mobile/lib/features/ride/observer_access_sheet.dart
@@ -44,6 +44,7 @@ class _ObserverAccessSheetState extends State<ObserverAccessSheet> {
   final _labelController = TextEditingController(text: 'Safety contact');
   Duration _duration = const Duration(hours: 4);
   ObserverAccessScope _scope = ObserverAccessScope.rider;
+  ObserverPositionPrecision _precision = ObserverPositionPrecision.reduced;
   bool _consent = false;
 
   @override
@@ -185,6 +186,35 @@ class _ObserverAccessSheetState extends State<ObserverAccessSheet> {
                   ? null
                   : (value) => setState(() => _duration = value ?? _duration),
             ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<ObserverPositionPrecision>(
+              key: const Key('observer-precision'),
+              initialValue: _precision,
+              decoration: const InputDecoration(labelText: 'Position detail'),
+              items: const [
+                DropdownMenuItem(
+                  value: ObserverPositionPrecision.reduced,
+                  child: Text('Approximate area (recommended)'),
+                ),
+                DropdownMenuItem(
+                  value: ObserverPositionPrecision.exact,
+                  child: Text('Exact last-known position'),
+                ),
+              ],
+              onChanged: widget.controller.busy
+                  ? null
+                  : (value) => setState(() {
+                      _precision = value ?? _precision;
+                      _consent = false;
+                    }),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              _precision == ObserverPositionPrecision.reduced
+                  ? 'Coordinates are rounded to an area about 1 km across before the watcher can read them.'
+                  : 'Exact coordinates can reveal the field, property or road you are on. Trails and altitude still remain private.',
+              style: const TextStyle(color: Color(0xFFA9B4C2)),
+            ),
             CheckboxListTile(
               key: const Key('observer-consent'),
               value: _consent,
@@ -192,9 +222,9 @@ class _ObserverAccessSheetState extends State<ObserverAccessSheet> {
               title: Text(
                 _scope == ObserverAccessScope.group
                     ? 'I have told the group and choose to share this '
-                          'read-only group view for the selected time.'
-                    : 'I choose to share this information for the selected '
-                          'time.',
+                          '${_precision == ObserverPositionPrecision.exact ? 'exact' : 'approximate'} read-only group view for the selected time.'
+                    : 'I choose to share this '
+                          '${_precision == ObserverPositionPrecision.exact ? 'exact' : 'approximate'} information for the selected time.',
               ),
               onChanged: widget.controller.busy
                   ? null
@@ -208,6 +238,7 @@ class _ObserverAccessSheetState extends State<ObserverAccessSheet> {
                       label: _labelController.text,
                       duration: _duration,
                       scope: _scope,
+                      precision: _precision,
                     ),
               icon: widget.controller.busy
                   ? const SizedBox.square(
@@ -275,7 +306,9 @@ class _ObserverAccessSheetState extends State<ObserverAccessSheet> {
                       : Icons.visibility_off_outlined,
                 ),
                 title: Text(grant.label),
-                subtitle: Text('${grant.scope.label} · ${_grantStatus(grant)}'),
+                subtitle: Text(
+                  '${grant.scope.label} · ${grant.precision.label} · ${_grantStatus(grant)}',
+                ),
                 trailing: grant.isActiveAt(DateTime.now())
                     ? TextButton(
                         onPressed: widget.controller.busy

--- a/apps/mobile/lib/features/ride/previous_rides_screen.dart
+++ b/apps/mobile/lib/features/ride/previous_rides_screen.dart
@@ -24,6 +24,7 @@ import '../map/resolved_route_map_preview.dart'
     show embeddedMapGestureRecognizers;
 import '../map/stored_route_picker.dart';
 import '../replay/flight_replay_screen.dart';
+import 'flight_export_consent.dart';
 import 'ride_recap_screen.dart';
 
 class PreviousRidesScreen extends StatelessWidget {
@@ -151,10 +152,10 @@ class _RideTile extends StatelessWidget {
       subtitle: Text(
         '${_date(ride.startedAt)} · $distance · ${ride.riderCount} crew\n'
         '${ride.traveledRoute == null
-            ? 'No GPX trail recorded'
+            ? 'No flight trail recorded'
             : ride.hasRecordingGaps
             ? 'Recorded trail has location gaps'
-            : 'GPX ready'}',
+            : 'Flight data ready'}',
       ),
       isThreeLine: true,
       trailing: const Icon(Icons.chevron_right),
@@ -291,12 +292,12 @@ class _PreviousRideDetailScreenState extends State<PreviousRideDetailScreen> {
             key: const Key('archived-ride-export-gpx'),
             onPressed: _sharing || ride.traveledRoute == null
                 ? null
-                : _exportGpx,
+                : _exportFlightData,
             icon: const Icon(Icons.file_upload_outlined),
             label: Text(
               ride.traveledRoute == null
-                  ? 'No recorded GPX trail'
-                  : 'Export GPX',
+                  ? 'No recorded flight trail'
+                  : 'Export flight data',
             ),
           ),
           const SizedBox(height: 10),
@@ -309,7 +310,7 @@ class _PreviousRideDetailScreenState extends State<PreviousRideDetailScreen> {
           const Text(
             'Flight history is stored locally on this phone. Balloon Crumbs '
             'does not upload a permanent copy. The native share destination '
-            'determines where an exported GPX is saved.',
+            'determines where exported GPX, KML and CSV files are saved.',
             style: TextStyle(color: Color(0xFF8994A2), fontSize: 12),
           ),
         ],
@@ -414,12 +415,15 @@ class _PreviousRideDetailScreenState extends State<PreviousRideDetailScreen> {
     }
   }
 
-  Future<void> _exportGpx() => _runShare(
-    () => widget.sharer.exportGpx(
-      widget.ride,
-      sharePositionOrigin: _shareOrigin(),
-    ),
-  );
+  Future<void> _exportFlightData() async {
+    if (!await confirmExactFlightDataExport(context) || !mounted) return;
+    await _runShare(
+      () => widget.sharer.exportFlightData(
+        widget.ride,
+        sharePositionOrigin: _shareOrigin(),
+      ),
+    );
+  }
 
   Future<void> _runShare(Future<void> Function() action) async {
     setState(() => _sharing = true);

--- a/apps/mobile/lib/internet/observer_access_client.dart
+++ b/apps/mobile/lib/internet/observer_access_client.dart
@@ -22,6 +22,56 @@ enum ObserverAccessScope {
       : ObserverAccessScope.rider;
 }
 
+enum ObserverPositionPrecision {
+  reduced,
+  exact;
+
+  String get label => switch (this) {
+    ObserverPositionPrecision.reduced => 'Approximate area',
+    ObserverPositionPrecision.exact => 'Exact position',
+  };
+
+  static ObserverPositionPrecision fromName(Object? name) =>
+      name == ObserverPositionPrecision.exact.name
+      ? ObserverPositionPrecision.exact
+      : ObserverPositionPrecision.reduced;
+}
+
+class ObserverGroupAuthorizationRequest {
+  const ObserverGroupAuthorizationRequest({
+    required this.session,
+    required this.label,
+    required this.duration,
+    required this.precision,
+  });
+
+  final RideSession session;
+  final String label;
+  final Duration duration;
+  final ObserverPositionPrecision precision;
+}
+
+class ObserverPilotAuthorization {
+  const ObserverPilotAuthorization({
+    required this.deviceId,
+    required this.devicePublicKey,
+    required this.signedAtMilliseconds,
+    required this.signature,
+  });
+
+  final String deviceId;
+  final String devicePublicKey;
+  final int signedAtMilliseconds;
+  final String signature;
+
+  Map<String, Object?> toJson() => {
+    'deviceId': deviceId,
+    'devicePublicKey': devicePublicKey,
+    'signedAtMilliseconds': signedAtMilliseconds,
+    'signature': signature,
+  };
+}
+
 class ObserverAccessConfiguration {
   const ObserverAccessConfiguration({
     required this.relay,
@@ -72,12 +122,14 @@ class ObserverGrant {
     required this.createdAt,
     required this.expiresAt,
     this.scope = ObserverAccessScope.rider,
+    this.precision = ObserverPositionPrecision.reduced,
     this.revokedAt,
   });
 
   final String id;
   final String label;
   final ObserverAccessScope scope;
+  final ObserverPositionPrecision precision;
   final DateTime createdAt;
   final DateTime expiresAt;
   final DateTime? revokedAt;
@@ -88,6 +140,7 @@ class ObserverGrant {
     'id': id,
     'label': label,
     'scope': scope.name,
+    'precision': precision.name,
     'createdAt': createdAt.toUtc().toIso8601String(),
     'expiresAt': expiresAt.toUtc().toIso8601String(),
     'revokedAt': revokedAt?.toUtc().toIso8601String(),
@@ -97,6 +150,7 @@ class ObserverGrant {
     id: json['id']! as String,
     label: json['label']! as String,
     scope: ObserverAccessScope.fromName(json['scope']),
+    precision: ObserverPositionPrecision.fromName(json['precision']),
     createdAt: DateTime.parse(json['createdAt']! as String).toLocal(),
     expiresAt: DateTime.parse(json['expiresAt']! as String).toLocal(),
     revokedAt: switch (json['revokedAt']) {
@@ -324,6 +378,8 @@ abstract interface class ObserverAccessApi {
     required String label,
     required Duration duration,
     ObserverAccessScope scope = ObserverAccessScope.rider,
+    ObserverPositionPrecision precision = ObserverPositionPrecision.reduced,
+    ObserverPilotAuthorization? pilotAuthorization,
   });
 
   Future<ObserverGrant> inspect(ObserverGrantCredentials credentials);
@@ -358,6 +414,8 @@ class HttpObserverAccessClient implements ObserverAccessApi {
     required String label,
     required Duration duration,
     ObserverAccessScope scope = ObserverAccessScope.rider,
+    ObserverPositionPrecision precision = ObserverPositionPrecision.reduced,
+    ObserverPilotAuthorization? pilotAuthorization,
   }) async {
     final minutes = duration.inMinutes;
     if (label.trim().isEmpty || label.trim().length > 80) {
@@ -370,15 +428,22 @@ class HttpObserverAccessClient implements ObserverAccessApi {
         'Observer access must last between 30 minutes and 24 hours.',
       );
     }
+    if (scope == ObserverAccessScope.group && pilotAuthorization == null) {
+      throw const InternetRelayException(
+        'Only the current pilot can authorize a whole-group watcher link.',
+      );
+    }
     final request = http.Request('POST', _rideGrantsUri(session.rideId))
       ..headers['content-type'] = 'application/json'
       ..body = jsonEncode({
         'label': label.trim(),
         'durationMinutes': minutes,
         'consentConfirmed': true,
+        'precision': precision.name,
         if (scope == ObserverAccessScope.group) ...{
           'scope': scope.name,
           'groupDisclosureConfirmed': true,
+          'pilotAuthorization': pilotAuthorization!.toJson(),
         },
       });
     final response = await _send(request, bearer: _rideBearer(session));

--- a/apps/mobile/lib/services/completed_ride_sharer.dart
+++ b/apps/mobile/lib/services/completed_ride_sharer.dart
@@ -7,6 +7,7 @@ import 'package:share_plus/share_plus.dart';
 import '../domain/completed_ride.dart';
 import '../domain/distance_unit.dart';
 import '../domain/ride_role.dart';
+import 'flight_data_exporter.dart';
 import 'gpx_exporter.dart';
 import 'measurement_formatter.dart';
 
@@ -17,13 +18,20 @@ abstract interface class CompletedRideSharer {
     Rect? sharePositionOrigin,
   });
 
-  Future<void> exportGpx(CompletedRide ride, {Rect? sharePositionOrigin});
+  Future<void> exportFlightData(
+    CompletedRide ride, {
+    Rect? sharePositionOrigin,
+  });
 }
 
 class SystemCompletedRideSharer implements CompletedRideSharer {
-  const SystemCompletedRideSharer({this.gpxExporter = const GpxExporter()});
+  const SystemCompletedRideSharer({
+    this.gpxExporter = const GpxExporter(),
+    this.flightDataExporter = const FlightDataExporter(),
+  });
 
   final GpxExporter gpxExporter;
+  final FlightDataExporter flightDataExporter;
 
   @override
   Future<void> shareSummary(
@@ -54,7 +62,7 @@ class SystemCompletedRideSharer implements CompletedRideSharer {
   }
 
   @override
-  Future<void> exportGpx(
+  Future<void> exportFlightData(
     CompletedRide ride, {
     Rect? sharePositionOrigin,
   }) async {
@@ -62,22 +70,49 @@ class SystemCompletedRideSharer implements CompletedRideSharer {
     if (route == null) {
       throw StateError('This flight has no recorded local trail to export.');
     }
-    final fileName = gpxExporter.fileName(route);
-    final bytes = Uint8List.fromList(utf8.encode(gpxExporter.export(route)));
+    final gpxFileName = gpxExporter.fileName(route);
+    final csvFileName = flightDataExporter.csvFileName(ride.rideCode);
+    final kmlFileName = flightDataExporter.kmlFileName(ride.rideCode);
     await SharePlus.instance.share(
       ShareParams(
         title: 'Export ${ride.title}',
-        subject: 'Balloon Crumbs GPX: ${ride.title}',
+        subject: 'Balloon Crumbs flight data: ${ride.title}',
         text:
-            'Choose Files, Downloads or a GPX-compatible app in the share sheet.',
+            'Exact recorded positions, timestamps and altitude are attached. '
+            'The CSV labels measured, calculated, missing and rejected data.',
         files: [
           XFile.fromData(
-            bytes,
+            Uint8List.fromList(utf8.encode(gpxExporter.export(route))),
             mimeType: 'application/gpx+xml',
-            name: fileName,
+            name: gpxFileName,
+          ),
+          XFile.fromData(
+            Uint8List.fromList(
+              utf8.encode(
+                flightDataExporter.archivedTelemetryCsv(
+                  traveledRoute: route,
+                  plannedRoute: ride.plannedRoute,
+                ),
+              ),
+            ),
+            mimeType: 'text/csv',
+            name: csvFileName,
+          ),
+          XFile.fromData(
+            Uint8List.fromList(
+              utf8.encode(
+                flightDataExporter.kml(
+                  name: ride.title,
+                  traveledRoute: route,
+                  plannedRoute: ride.plannedRoute,
+                ),
+              ),
+            ),
+            mimeType: 'application/vnd.google-earth.kml+xml',
+            name: kmlFileName,
           ),
         ],
-        fileNameOverrides: [fileName],
+        fileNameOverrides: [gpxFileName, csvFileName, kmlFileName],
         sharePositionOrigin: sharePositionOrigin,
       ),
     );

--- a/apps/mobile/lib/services/flight_data_exporter.dart
+++ b/apps/mobile/lib/services/flight_data_exporter.dart
@@ -1,0 +1,484 @@
+import 'package:xml/xml.dart';
+
+import '../domain/altitude.dart';
+import '../domain/imported_route.dart';
+import '../domain/ride_event.dart';
+import '../domain/ride_session.dart';
+
+enum TelemetryQuality { measured, calculated, missing, rejected }
+
+/// Writes precise flight data without pretending every value has equal quality.
+///
+/// The CSV is the audit-friendly form: every value says whether it was measured,
+/// calculated, missing, or rejected. GPX remains the interoperable geometry
+/// format and KML is the convenient map-viewing format.
+class FlightDataExporter {
+  const FlightDataExporter();
+
+  static const maximumContinuousTrailGap = Duration(minutes: 2);
+
+  String telemetryCsv({
+    required RideSession session,
+    required Iterable<RideEvent> events,
+    ImportedRoute? plannedRoute,
+  }) {
+    final rows = <_TelemetryRow>[
+      ..._recordedRows(session, events),
+      if (plannedRoute != null)
+        ..._routeRows(
+          plannedRoute,
+          dataset: 'planned_route',
+          quality: TelemetryQuality.calculated,
+        ),
+    ];
+    final csv = <List<Object?>>[
+      const [
+        'dataset',
+        'segment',
+        'point',
+        'recorded_at_utc',
+        'latitude',
+        'longitude',
+        'altitude_meters',
+        'position_quality',
+        'altitude_quality',
+        'altitude_source',
+        'altitude_datum',
+        'altitude_accuracy_meters',
+        'note',
+      ],
+      ...rows.map((row) => row.cells),
+    ].map(_csvRow).join('\r\n');
+    return '$csv\r\n';
+  }
+
+  String archivedTelemetryCsv({
+    required ImportedRoute traveledRoute,
+    ImportedRoute? plannedRoute,
+  }) {
+    final rows = <_TelemetryRow>[
+      ..._routeRows(
+        traveledRoute,
+        dataset: 'recorded_track',
+        quality: TelemetryQuality.measured,
+        markSegmentGaps: true,
+      ),
+      if (plannedRoute != null)
+        ..._routeRows(
+          plannedRoute,
+          dataset: 'planned_route',
+          quality: TelemetryQuality.calculated,
+        ),
+    ];
+    final csv = <List<Object?>>[
+      const [
+        'dataset',
+        'segment',
+        'point',
+        'recorded_at_utc',
+        'latitude',
+        'longitude',
+        'altitude_meters',
+        'position_quality',
+        'altitude_quality',
+        'altitude_source',
+        'altitude_datum',
+        'altitude_accuracy_meters',
+        'note',
+      ],
+      ...rows.map((row) => row.cells),
+    ].map(_csvRow).join('\r\n');
+    return '$csv\r\n';
+  }
+
+  String kml({
+    required String name,
+    ImportedRoute? traveledRoute,
+    ImportedRoute? plannedRoute,
+  }) {
+    final builder = XmlBuilder();
+    builder.processing('xml', 'version="1.0" encoding="UTF-8"');
+    builder.element(
+      'kml',
+      attributes: {'xmlns': 'http://www.opengis.net/kml/2.2'},
+      nest: () => builder.element(
+        'Document',
+        nest: () {
+          builder.element('name', nest: name);
+          _writeKmlStyle(builder, 'recorded', 'ff00aaff');
+          _writeKmlStyle(builder, 'calculated', 'ffffaa00');
+          if (traveledRoute != null) {
+            _writeKmlRoute(
+              builder,
+              traveledRoute,
+              folderName: 'Recorded track',
+              styleId: 'recorded',
+              quality: TelemetryQuality.measured,
+            );
+          }
+          if (plannedRoute != null) {
+            _writeKmlRoute(
+              builder,
+              plannedRoute,
+              folderName: 'Planned or forecast route',
+              styleId: 'calculated',
+              quality: TelemetryQuality.calculated,
+            );
+          }
+        },
+      ),
+    );
+    return '${builder.buildDocument().toXmlString(pretty: true)}\n';
+  }
+
+  String csvFileName(String rideCode) =>
+      'balloon-crumbs-${_slug(rideCode)}-telemetry.csv';
+
+  String kmlFileName(String rideCode) =>
+      'balloon-crumbs-${_slug(rideCode)}-flight.kml';
+
+  static Iterable<_TelemetryRow> _recordedRows(
+    RideSession session,
+    Iterable<RideEvent> events,
+  ) sync* {
+    final ordered =
+        events
+            .where(
+              (event) =>
+                  event.type == RideEventType.riderLocationUpdated &&
+                  event.deviceId == session.localRiderId,
+            )
+            .toList(growable: false)
+          ..sort((left, right) {
+            final time = left.createdAt.compareTo(right.createdAt);
+            return time != 0 ? time : left.id.compareTo(right.id);
+          });
+    DateTime? previousRecordedAt;
+    var segment = 1;
+    var point = 0;
+    for (final event in ordered) {
+      final location = event.payload['location'];
+      final sample = location is Map ? location['sample'] : null;
+      if (sample is! Map) {
+        yield _TelemetryRow.rejected(
+          event.createdAt,
+          'Malformed location sample',
+        );
+        continue;
+      }
+      final position = sample['position'];
+      final latitude = position is Map ? position['latitude'] : null;
+      final longitude = position is Map ? position['longitude'] : null;
+      final positionIsValid =
+          latitude is num &&
+          latitude.isFinite &&
+          latitude >= -90 &&
+          latitude <= 90 &&
+          longitude is num &&
+          longitude.isFinite &&
+          longitude >= -180 &&
+          longitude <= 180;
+      final rawRecordedAt = sample['recordedAt'];
+      final parsedRecordedAt = rawRecordedAt is String
+          ? DateTime.tryParse(rawRecordedAt)?.toUtc()
+          : null;
+      final recordedAt = parsedRecordedAt ?? event.createdAt.toUtc();
+      final notes = <String>[
+        if (rawRecordedAt != null && parsedRecordedAt == null)
+          'Rejected recordedAt; event time used',
+      ];
+      final rawAltitude = sample['altitudeMeters'];
+      final altitudeIsValid =
+          rawAltitude is num &&
+          rawAltitude.isFinite &&
+          rawAltitude >= -1000 &&
+          rawAltitude <= 30000;
+      final altitudeQuality = rawAltitude == null
+          ? TelemetryQuality.missing
+          : altitudeIsValid
+          ? TelemetryQuality.measured
+          : TelemetryQuality.rejected;
+      if (rawAltitude != null && !altitudeIsValid) {
+        notes.add('Rejected altitude outside the supported numeric range');
+      }
+      if (!positionIsValid) {
+        yield _TelemetryRow(
+          dataset: 'recorded_track',
+          segment: segment,
+          point: point,
+          recordedAt: recordedAt,
+          positionQuality: TelemetryQuality.rejected,
+          altitudeQuality: altitudeQuality,
+          note: [...notes, 'Rejected invalid or missing position'].join('; '),
+        );
+        continue;
+      }
+      if (previousRecordedAt case final previous?
+          when recordedAt.difference(previous) > maximumContinuousTrailGap ||
+              recordedAt.isBefore(previous)) {
+        segment += 1;
+        point = 0;
+        final movedBackwards = recordedAt.isBefore(previous);
+        yield _TelemetryRow(
+          dataset: 'recording_gap',
+          segment: segment,
+          point: point,
+          recordedAt: recordedAt,
+          positionQuality: TelemetryQuality.missing,
+          altitudeQuality: TelemetryQuality.missing,
+          note: movedBackwards
+              ? 'Recorded time moved backwards; continuity was rejected'
+              : 'No continuous position record for more than 120 seconds',
+        );
+      }
+      previousRecordedAt = recordedAt;
+      point += 1;
+      final rawAltitudeAccuracy = sample['altitudeAccuracyMeters'];
+      yield _TelemetryRow(
+        dataset: 'recorded_track',
+        segment: segment,
+        point: point,
+        recordedAt: recordedAt,
+        latitude: latitude.toDouble(),
+        longitude: longitude.toDouble(),
+        altitudeMeters: altitudeIsValid ? rawAltitude.toDouble() : null,
+        positionQuality: TelemetryQuality.measured,
+        altitudeQuality: altitudeQuality,
+        altitudeSource: altitudeIsValid
+            ? _enumValue(
+                AltitudeSource.values,
+                sample['altitudeSource'],
+                AltitudeSource.unknown,
+              )
+            : AltitudeSource.unknown,
+        altitudeDatum: altitudeIsValid
+            ? _enumValue(
+                AltitudeDatum.values,
+                sample['altitudeDatum'],
+                AltitudeDatum.unknown,
+              )
+            : AltitudeDatum.unknown,
+        altitudeAccuracyMeters:
+            altitudeIsValid &&
+                rawAltitudeAccuracy is num &&
+                rawAltitudeAccuracy.isFinite &&
+                rawAltitudeAccuracy >= 0 &&
+                rawAltitudeAccuracy <= 10000
+            ? rawAltitudeAccuracy.toDouble()
+            : null,
+        note: notes.join('; '),
+      );
+    }
+  }
+
+  static Iterable<_TelemetryRow> _routeRows(
+    ImportedRoute route, {
+    required String dataset,
+    required TelemetryQuality quality,
+    bool markSegmentGaps = false,
+  }) sync* {
+    var segment = 0;
+    for (final path in route.paths) {
+      segment += 1;
+      if (markSegmentGaps && segment > 1) {
+        yield _TelemetryRow(
+          dataset: 'recording_gap',
+          segment: segment,
+          point: 0,
+          positionQuality: TelemetryQuality.missing,
+          altitudeQuality: TelemetryQuality.missing,
+          note: 'Recorded track resumes in a new segment',
+        );
+      }
+      for (final (index, point) in path.points.indexed) {
+        yield _TelemetryRow(
+          dataset: dataset,
+          segment: segment,
+          point: index + 1,
+          recordedAt: point.recordedAt,
+          latitude: point.latitude,
+          longitude: point.longitude,
+          altitudeMeters: point.elevationMeters,
+          positionQuality: quality,
+          altitudeQuality: point.elevationMeters == null
+              ? TelemetryQuality.missing
+              : quality,
+          altitudeSource: point.altitudeSource,
+          altitudeDatum: point.altitudeDatum,
+          altitudeAccuracyMeters: point.altitudeAccuracyMeters,
+        );
+      }
+    }
+  }
+
+  static void _writeKmlStyle(XmlBuilder builder, String id, String color) {
+    builder.element(
+      'Style',
+      attributes: {'id': id},
+      nest: () => builder.element(
+        'LineStyle',
+        nest: () {
+          builder.element('color', nest: color);
+          builder.element('width', nest: '5');
+        },
+      ),
+    );
+  }
+
+  static void _writeKmlRoute(
+    XmlBuilder builder,
+    ImportedRoute route, {
+    required String folderName,
+    required String styleId,
+    required TelemetryQuality quality,
+  }) {
+    builder.element(
+      'Folder',
+      nest: () {
+        builder.element('name', nest: folderName);
+        for (final (index, path) in route.paths.indexed) {
+          if (path.points.length < 2) continue;
+          final hasKmlAbsoluteAltitude = path.points.every(
+            (point) =>
+                point.elevationMeters != null &&
+                point.altitudeDatum == AltitudeDatum.wgs84Geoid,
+          );
+          builder.element(
+            'Placemark',
+            nest: () {
+              builder.element(
+                'name',
+                nest: path.name ?? '$folderName ${index + 1}',
+              );
+              builder.element('styleUrl', nest: '#$styleId');
+              builder.element(
+                'ExtendedData',
+                nest: () {
+                  _writeKmlData(builder, 'position_quality', quality.name);
+                  _writeKmlData(
+                    builder,
+                    'altitude_quality',
+                    hasKmlAbsoluteAltitude ? quality.name : 'missing_or_mixed',
+                  );
+                  _writeKmlData(builder, 'altitude_unit', 'metres');
+                  _writeKmlData(
+                    builder,
+                    'altitude_datum',
+                    hasKmlAbsoluteAltitude
+                        ? AltitudeDatum.wgs84Geoid.name
+                        : 'omitted_from_kml_use_csv',
+                  );
+                },
+              );
+              builder.element(
+                'LineString',
+                nest: () {
+                  builder.element('tessellate', nest: '1');
+                  if (hasKmlAbsoluteAltitude) {
+                    builder.element('altitudeMode', nest: 'absolute');
+                  }
+                  builder.element(
+                    'coordinates',
+                    nest: path.points
+                        .map(
+                          (point) => hasKmlAbsoluteAltitude
+                              ? '${point.longitude},${point.latitude},${point.elevationMeters}'
+                              : '${point.longitude},${point.latitude}',
+                        )
+                        .join(' '),
+                  );
+                },
+              );
+            },
+          );
+        }
+      },
+    );
+  }
+
+  static void _writeKmlData(XmlBuilder builder, String name, String value) {
+    builder.element(
+      'Data',
+      attributes: {'name': name},
+      nest: () => builder.element('value', nest: value),
+    );
+  }
+
+  static T _enumValue<T extends Enum>(
+    List<T> values,
+    Object? name,
+    T fallback,
+  ) => values.where((value) => value.name == name).firstOrNull ?? fallback;
+
+  static String _csvRow(List<Object?> values) =>
+      values.map((value) => _csvCell(value?.toString() ?? '')).join(',');
+
+  static String _csvCell(String value) => '"${value.replaceAll('"', '""')}"';
+
+  static String _slug(String value) {
+    final slug = value
+        .toLowerCase()
+        .replaceAll(RegExp('[^a-z0-9]+'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    return slug.isEmpty ? 'flight' : slug;
+  }
+}
+
+class _TelemetryRow {
+  const _TelemetryRow({
+    required this.dataset,
+    required this.segment,
+    required this.point,
+    required this.positionQuality,
+    required this.altitudeQuality,
+    this.recordedAt,
+    this.latitude,
+    this.longitude,
+    this.altitudeMeters,
+    this.altitudeSource = AltitudeSource.unknown,
+    this.altitudeDatum = AltitudeDatum.unknown,
+    this.altitudeAccuracyMeters,
+    this.note = '',
+  });
+
+  factory _TelemetryRow.rejected(DateTime recordedAt, String note) =>
+      _TelemetryRow(
+        dataset: 'recorded_track',
+        segment: 0,
+        point: 0,
+        recordedAt: recordedAt,
+        positionQuality: TelemetryQuality.rejected,
+        altitudeQuality: TelemetryQuality.rejected,
+        note: note,
+      );
+
+  final String dataset;
+  final int segment;
+  final int point;
+  final DateTime? recordedAt;
+  final double? latitude;
+  final double? longitude;
+  final double? altitudeMeters;
+  final TelemetryQuality positionQuality;
+  final TelemetryQuality altitudeQuality;
+  final AltitudeSource altitudeSource;
+  final AltitudeDatum altitudeDatum;
+  final double? altitudeAccuracyMeters;
+  final String note;
+
+  List<Object?> get cells => [
+    dataset,
+    segment,
+    point,
+    recordedAt?.toUtc().toIso8601String(),
+    latitude,
+    longitude,
+    altitudeMeters,
+    positionQuality.name,
+    altitudeQuality.name,
+    altitudeSource.name,
+    altitudeDatum.name,
+    altitudeAccuracyMeters,
+    note,
+  ];
+}

--- a/apps/mobile/lib/services/observer_group_authorization.dart
+++ b/apps/mobile/lib/services/observer_group_authorization.dart
@@ -1,0 +1,65 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:cryptography/cryptography.dart';
+
+import '../domain/ride_session.dart';
+import '../internet/observer_access_client.dart';
+import 'device_identity.dart';
+
+class ObserverGroupAuthorization {
+  const ObserverGroupAuthorization._();
+
+  static Future<ObserverPilotAuthorization> sign({
+    required RideSession session,
+    required DeviceIdentity identity,
+    required String label,
+    required Duration duration,
+    required ObserverPositionPrecision precision,
+    required DateTime signedAt,
+  }) async {
+    final signedAtMilliseconds = signedAt.toUtc().millisecondsSinceEpoch;
+    final challenge = buildChallenge(
+      rideId: session.rideId,
+      deviceId: session.localRiderId,
+      devicePublicKey: identity.publicKey,
+      signedAtMilliseconds: signedAtMilliseconds,
+      label: label,
+      durationMinutes: duration.inMinutes,
+      precision: precision,
+    );
+    final keyPair = await Ed25519().newKeyPairFromSeed(identity.privateSeed);
+    final signature = await Ed25519().sign(
+      utf8.encode(challenge),
+      keyPair: keyPair,
+    );
+    return ObserverPilotAuthorization(
+      deviceId: session.localRiderId,
+      devicePublicKey: identity.publicKey,
+      signedAtMilliseconds: signedAtMilliseconds,
+      signature: base64Url.encode(signature.bytes).replaceAll('=', ''),
+    );
+  }
+
+  static String buildChallenge({
+    required String rideId,
+    required String deviceId,
+    required String devicePublicKey,
+    required int signedAtMilliseconds,
+    required String label,
+    required int durationMinutes,
+    required ObserverPositionPrecision precision,
+  }) {
+    final body = SplayTreeMap<String, Object?>.from({
+      'deviceId': deviceId,
+      'devicePublicKey': devicePublicKey,
+      'durationMinutes': durationMinutes,
+      'label': label.trim().replaceAll(RegExp(r'\s+'), ' '),
+      'precision': precision.name,
+      'rideId': rideId,
+      'scope': ObserverAccessScope.group.name,
+      'signedAtMilliseconds': signedAtMilliseconds,
+    });
+    return 'balloon-crumbs-observer-group-grant-v1\n${jsonEncode(body)}';
+  }
+}

--- a/apps/mobile/lib/services/ride_summary_exporter.dart
+++ b/apps/mobile/lib/services/ride_summary_exporter.dart
@@ -11,9 +11,11 @@ import '../domain/imported_route.dart';
 import '../domain/ride_event.dart';
 import '../domain/ride_session.dart';
 import 'geo_calculations.dart';
+import 'flight_data_exporter.dart';
 import 'gpx_exporter.dart';
 import 'measurement_formatter.dart';
 import 'ride_lifecycle.dart';
+import 'ride_route_reducer.dart';
 
 typedef _TrailPoint = ({
   double latitude,
@@ -240,13 +242,26 @@ class RideSummaryExporter {
     if (position is! Map) return null;
     final latitude = position['latitude'];
     final longitude = position['longitude'];
-    if (latitude is! num || longitude is! num) return null;
+    if (latitude is! num ||
+        !latitude.isFinite ||
+        latitude < -90 ||
+        latitude > 90 ||
+        longitude is! num ||
+        !longitude.isFinite ||
+        longitude < -180 ||
+        longitude > 180) {
+      return null;
+    }
     final recordedAt = sample['recordedAt'];
     // Read defensively like the rest of this walk: a relayed fix is untrusted,
     // and a malformed altitude must cost that point its height rather than the
     // whole export.
     final altitude = sample['altitudeMeters'];
-    final hasAltitude = altitude is num && altitude.isFinite;
+    final hasAltitude =
+        altitude is num &&
+        altitude.isFinite &&
+        altitude >= -1000 &&
+        altitude <= 30000;
     final altitudeAccuracy = sample['altitudeAccuracyMeters'];
     return (
       latitude: latitude.toDouble(),
@@ -273,7 +288,8 @@ class RideSummaryExporter {
           hasAltitude &&
               altitudeAccuracy is num &&
               altitudeAccuracy.isFinite &&
-              altitudeAccuracy >= 0
+              altitudeAccuracy >= 0 &&
+              altitudeAccuracy <= 10000
           ? altitudeAccuracy.toDouble()
           : null,
     );
@@ -313,7 +329,7 @@ class RideSummaryExporter {
     ];
     for (final point in trail.skip(1)) {
       final gap = point.recordedAt.difference(segments.last.last.recordedAt);
-      if (gap > maximumContinuousTrailGap) {
+      if (gap > maximumContinuousTrailGap || gap.isNegative) {
         segments.add(<_TrailPoint>[]);
       }
       segments.last.add(point);
@@ -346,6 +362,7 @@ abstract interface class RideSummarySharer {
     DistanceUnit distanceUnit = DistanceUnit.kilometres,
     Rect? sharePositionOrigin,
     String? diagnostics,
+    bool includeExactTrack = false,
   });
 }
 
@@ -364,20 +381,32 @@ class SystemRideSummarySharer implements RideSummarySharer {
     // attachment on the share a rider already does, rather than a second flow
     // and a second decision at the end of a ride.
     String? diagnostics,
+    bool includeExactTrack = false,
   }) async {
+    final exportedEvents = events.toList(growable: false);
     final generatedAt = DateTime.now();
     final summary = exporter.summarize(
       session,
-      events,
+      exportedEvents,
       generatedAt: generatedAt,
     );
     final route = exporter.traveledRoute(
       session,
-      events,
+      exportedEvents,
       generatedAt: generatedAt,
     );
+    final plannedRoute = const RideRouteReducer()
+        .fromEvents(
+          rideId: session.rideId,
+          inviteSecret: session.inviteSecret,
+          events: exportedEvents,
+        )
+        .route;
+    const flightDataExporter = FlightDataExporter();
     final csvFileName = exporter.fileName(summary);
     final gpxFileName = exporter.trailFileName(summary);
+    final telemetryFileName = flightDataExporter.csvFileName(summary.rideCode);
+    final kmlFileName = flightDataExporter.kmlFileName(summary.rideCode);
     final diagnosticsFileName =
         'balloon-crumbs-diagnostics-'
         '${summary.rideCode}.txt';
@@ -392,7 +421,7 @@ class SystemRideSummarySharer implements RideSummarySharer {
             mimeType: 'text/csv',
             name: csvFileName,
           ),
-          if (route != null)
+          if (includeExactTrack && route != null) ...[
             XFile.fromData(
               Uint8List.fromList(
                 utf8.encode(const GpxExporter().export(route)),
@@ -400,7 +429,34 @@ class SystemRideSummarySharer implements RideSummarySharer {
               mimeType: 'application/gpx+xml',
               name: gpxFileName,
             ),
-          if (diagnostics != null)
+            XFile.fromData(
+              Uint8List.fromList(
+                utf8.encode(
+                  flightDataExporter.telemetryCsv(
+                    session: session,
+                    events: exportedEvents,
+                    plannedRoute: plannedRoute,
+                  ),
+                ),
+              ),
+              mimeType: 'text/csv',
+              name: telemetryFileName,
+            ),
+            XFile.fromData(
+              Uint8List.fromList(
+                utf8.encode(
+                  flightDataExporter.kml(
+                    name: session.rideName ?? 'Flight ${session.rideCode}',
+                    traveledRoute: route,
+                    plannedRoute: plannedRoute,
+                  ),
+                ),
+              ),
+              mimeType: 'application/vnd.google-earth.kml+xml',
+              name: kmlFileName,
+            ),
+          ],
+          if (includeExactTrack && diagnostics != null)
             XFile.fromData(
               Uint8List.fromList(utf8.encode(diagnostics)),
               mimeType: 'text/plain',
@@ -409,8 +465,12 @@ class SystemRideSummarySharer implements RideSummarySharer {
         ],
         fileNameOverrides: [
           csvFileName,
-          if (route != null) gpxFileName,
-          if (diagnostics != null) diagnosticsFileName,
+          if (includeExactTrack && route != null) ...[
+            gpxFileName,
+            telemetryFileName,
+            kmlFileName,
+          ],
+          if (includeExactTrack && diagnostics != null) diagnosticsFileName,
         ],
         sharePositionOrigin: sharePositionOrigin,
       ),

--- a/apps/mobile/test/controllers/observer_access_controller_test.dart
+++ b/apps/mobile/test/controllers/observer_access_controller_test.dart
@@ -32,6 +32,36 @@ void main() {
   });
 
   test(
+    'expired credentials are removed from local retention on attach',
+    () async {
+      final store = _MemoryObserverGrantStore();
+      store.saved[_session.rideId] = [
+        ObserverGrantCredentials(
+          grant: ObserverGrant(
+            id: 'expired-grant',
+            label: 'Expired contact',
+            createdAt: _clock().subtract(const Duration(hours: 2)),
+            expiresAt: _clock().subtract(const Duration(minutes: 1)),
+          ),
+          managementToken: 'om1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          publisherToken: 'op1_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          observerToken: 'ro1_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        ),
+      ];
+      final controller = ObserverAccessController(
+        _FakeObserverApi(),
+        store,
+        clock: _clock,
+      );
+
+      await controller.attach(_session);
+
+      expect(controller.grants, isEmpty);
+      expect(store.saved[_session.rideId] ?? const [], isEmpty);
+    },
+  );
+
+  test(
     'rapid locations coalesce to one in-flight and one latest snapshot',
     () async {
       final store = _MemoryObserverGrantStore();
@@ -211,6 +241,7 @@ void main() {
         _MemoryObserverGrantStore(),
         clock: _clock,
         publishInterval: Duration.zero,
+        groupAuthorizer: _authorizeGroup,
       );
       await controller.attach(_session);
       await controller.create(
@@ -248,6 +279,16 @@ void main() {
     },
   );
 }
+
+Future<ObserverPilotAuthorization> _authorizeGroup(
+  ObserverGroupAuthorizationRequest request,
+) async => const ObserverPilotAuthorization(
+  deviceId: 'pilot-device',
+  devicePublicKey: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  signedAtMilliseconds: 1,
+  signature:
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+);
 
 DateTime _clock() => DateTime.utc(2026, 7, 24, 13);
 
@@ -347,6 +388,8 @@ class _FakeObserverApi implements ObserverAccessApi {
     required String label,
     required Duration duration,
     ObserverAccessScope scope = ObserverAccessScope.rider,
+    ObserverPositionPrecision precision = ObserverPositionPrecision.reduced,
+    ObserverPilotAuthorization? pilotAuthorization,
   }) async {
     _nextGrant += 1;
     return ObserverGrantCredentials(
@@ -356,6 +399,7 @@ class _FakeObserverApi implements ObserverAccessApi {
         createdAt: _clock(),
         expiresAt: _clock().add(duration),
         scope: scope,
+        precision: precision,
       ),
       managementToken: 'om1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       publisherToken: 'op1_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',

--- a/apps/mobile/test/data/secure_observer_grant_store_test.dart
+++ b/apps/mobile/test/data/secure_observer_grant_store_test.dart
@@ -12,6 +12,7 @@ void main() {
       grant: ObserverGrant(
         id: 'grant-a',
         label: 'Home',
+        precision: ObserverPositionPrecision.exact,
         createdAt: DateTime.utc(2026, 7, 24, 12),
         expiresAt: DateTime.utc(2026, 7, 24, 16),
       ),
@@ -26,6 +27,7 @@ void main() {
     expect(reloaded.single.managementToken, credentials.managementToken);
     expect(reloaded.single.publisherToken, credentials.publisherToken);
     expect(reloaded.single.observerToken, credentials.observerToken);
+    expect(reloaded.single.grant.precision, ObserverPositionPrecision.exact);
     await store.delete('ride-a');
     expect(await store.load('ride-a'), isEmpty);
   });

--- a/apps/mobile/test/features/ended_ride_screen_test.dart
+++ b/apps/mobile/test/features/ended_ride_screen_test.dart
@@ -16,10 +16,13 @@ import 'package:balloon_crumbs/controllers/ride_controller.dart';
 import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/completed_ride_store.dart';
+import 'package:balloon_crumbs/domain/distance_unit.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
 import 'package:balloon_crumbs/features/ride/ended_ride_screen.dart';
 import 'package:balloon_crumbs/internet/internet_relay_client.dart';
 import 'package:balloon_crumbs/services/nearby_bridge.dart';
+import 'package:balloon_crumbs/services/ride_summary_exporter.dart';
 
 void main() {
   late InMemoryEventStore events;
@@ -81,6 +84,35 @@ void main() {
       reason: 'the ride is archived, so nothing may describe it as destroyed',
     );
     expect(find.text('Finish and file in Previous flights'), findsOneWidget);
+  });
+
+  testWidgets('precise track attachments follow the explicit share choice', (
+    tester,
+  ) async {
+    final sharer = _RecordingSummarySharer();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EndedRideScreen(
+          controller: controller,
+          distanceUnits: DistanceUnitController.forLocale(
+            const Locale('en', 'GB'),
+          ),
+          summarySharer: sharer,
+        ),
+      ),
+    );
+    await tester.ensureVisible(find.text('Share flight summary'));
+    await tester.tap(find.text('Share flight summary'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-summary-without-track')));
+    await tester.pumpAndSettle();
+    expect(sharer.exactChoices, [false]);
+
+    await tester.tap(find.text('Share flight summary'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-exact-flight-data')));
+    await tester.pumpAndSettle();
+    expect(sharer.exactChoices, [false, true]);
   });
 
   // #206/#207: the tester was stranded here by an automatic end she did not
@@ -206,4 +238,20 @@ class _OfflineRideCodeDirectory implements RideCodeDirectory {
 
   @override
   void close() {}
+}
+
+class _RecordingSummarySharer implements RideSummarySharer {
+  final exactChoices = <bool>[];
+
+  @override
+  Future<void> share(
+    RideSession session,
+    Iterable<RideEvent> events, {
+    DistanceUnit distanceUnit = DistanceUnit.kilometres,
+    Rect? sharePositionOrigin,
+    String? diagnostics,
+    bool includeExactTrack = false,
+  }) async {
+    exactChoices.add(includeExactTrack);
+  }
 }

--- a/apps/mobile/test/features/ride/flight_export_consent_test.dart
+++ b/apps/mobile/test/features/ride/flight_export_consent_test.dart
@@ -1,0 +1,63 @@
+import 'package:balloon_crumbs/features/ride/flight_export_consent.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('summary sharing does not imply consent to an exact track', (
+    tester,
+  ) async {
+    FlightSummaryShareChoice? choice;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () async {
+              choice = await chooseFlightSummaryShare(context);
+            },
+            child: const Text('Share'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Share'));
+    await tester.pumpAndSettle();
+    expect(find.text('Include exact flight data?'), findsOneWidget);
+    expect(
+      find.textContaining('positions, timestamps and altitude'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('share-summary-without-track')));
+    await tester.pumpAndSettle();
+    expect(choice, FlightSummaryShareChoice.summaryOnly);
+  });
+
+  testWidgets('exact export requires its own affirmative action', (
+    tester,
+  ) async {
+    bool? confirmed;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () async {
+              confirmed = await confirmExactFlightDataExport(context);
+            },
+            child: const Text('Export'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Export'));
+    await tester.pumpAndSettle();
+    expect(find.text('Export exact flight data?'), findsOneWidget);
+    expect(find.textContaining('launch, landing and recovery'), findsOneWidget);
+    expect(confirmed, isNull);
+
+    await tester.tap(find.byKey(const Key('confirm-exact-flight-export')));
+    await tester.pumpAndSettle();
+    expect(confirmed, isTrue);
+  });
+}

--- a/apps/mobile/test/features/ride/observer_access_sheet_test.dart
+++ b/apps/mobile/test/features/ride/observer_access_sheet_test.dart
@@ -13,7 +13,11 @@ void main() {
     tester,
   ) async {
     final api = _FakeObserverApi();
-    final controller = ObserverAccessController(api, _MemoryStore());
+    final controller = ObserverAccessController(
+      api,
+      _MemoryStore(),
+      groupAuthorizer: _authorizeGroup,
+    );
     await controller.attach(_session);
     addTearDown(controller.dispose);
 
@@ -55,7 +59,11 @@ void main() {
     tester,
   ) async {
     final api = _FakeObserverApi();
-    final controller = ObserverAccessController(api, _MemoryStore());
+    final controller = ObserverAccessController(
+      api,
+      _MemoryStore(),
+      groupAuthorizer: _authorizeGroup,
+    );
     await controller.attach(_session);
     addTearDown(controller.dispose);
 
@@ -88,6 +96,44 @@ void main() {
     expect(find.text('Share group watcher link'), findsOneWidget);
     expect(find.textContaining('Whole group ·'), findsOneWidget);
   });
+
+  testWidgets(
+    'exact position needs renewed consent and is labelled on the grant',
+    (tester) async {
+      final api = _FakeObserverApi();
+      final controller = ObserverAccessController(api, _MemoryStore());
+      await controller.attach(_session);
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(),
+          home: Scaffold(body: ObserverAccessSheet(controller: controller)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('observer-consent')));
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('observer-precision')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Exact last-known position').last);
+      await tester.pumpAndSettle();
+      expect(find.textContaining('reveal the field'), findsOneWidget);
+      FilledButton createButton = tester.widget(
+        find.byKey(const Key('create-observer-link')),
+      );
+      expect(createButton.onPressed, isNull);
+
+      await tester.tap(find.byKey(const Key('observer-consent')));
+      await tester.pump();
+      await tester.ensureVisible(find.byKey(const Key('create-observer-link')));
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('create-observer-link')));
+      await tester.pumpAndSettle();
+      expect(api.lastPrecision, ObserverPositionPrecision.exact);
+      expect(find.textContaining('Exact position'), findsOneWidget);
+    },
+  );
 
   // A rider reported being unable to leave this screen after sharing a link, at
   // the kerbside while trying to set off (#304). The body is a scroll view, which
@@ -182,6 +228,7 @@ final _session = RideSession(
 class _FakeObserverApi implements ObserverAccessApi {
   int createCount = 0;
   ObserverAccessScope? lastScope;
+  ObserverPositionPrecision? lastPrecision;
 
   @override
   final configuration = ObserverAccessConfiguration(
@@ -197,9 +244,12 @@ class _FakeObserverApi implements ObserverAccessApi {
     required String label,
     required Duration duration,
     ObserverAccessScope scope = ObserverAccessScope.rider,
+    ObserverPositionPrecision precision = ObserverPositionPrecision.reduced,
+    ObserverPilotAuthorization? pilotAuthorization,
   }) async {
     createCount += 1;
     lastScope = scope;
+    lastPrecision = precision;
     return ObserverGrantCredentials(
       grant: ObserverGrant(
         id: 'grant-a',
@@ -207,6 +257,7 @@ class _FakeObserverApi implements ObserverAccessApi {
         createdAt: DateTime.now(),
         expiresAt: DateTime.now().add(duration),
         scope: scope,
+        precision: precision,
       ),
       managementToken: 'om1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       publisherToken: 'op1_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
@@ -236,6 +287,16 @@ class _FakeObserverApi implements ObserverAccessApi {
   @override
   void close() {}
 }
+
+Future<ObserverPilotAuthorization> _authorizeGroup(
+  ObserverGroupAuthorizationRequest request,
+) async => const ObserverPilotAuthorization(
+  deviceId: 'pilot-device',
+  devicePublicKey: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  signedAtMilliseconds: 1,
+  signature:
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+);
 
 class _MemoryStore implements ObserverGrantStore {
   List<ObserverGrantCredentials> values = const [];

--- a/apps/mobile/test/internet/observer_access_client_test.dart
+++ b/apps/mobile/test/internet/observer_access_client_test.dart
@@ -79,6 +79,7 @@ void main() {
       'label': 'Home contact',
       'durationMinutes': 240,
       'consentConfirmed': true,
+      'precision': 'reduced',
     });
     expect(shareUri.query, isEmpty);
     expect(shareUri.fragment, '${credentials.grant.id}.$observerToken');
@@ -114,7 +115,11 @@ void main() {
       client: MockClient((request) async {
         captured = request;
         return http.Response(
-          jsonEncode({..._grantJson(includeTokens: true), 'scope': 'group'}),
+          jsonEncode({
+            ..._grantJson(includeTokens: true),
+            'scope': 'group',
+            'precision': 'exact',
+          }),
           201,
           headers: {'content-type': 'application/json'},
         );
@@ -126,16 +131,33 @@ void main() {
       label: 'Ride watcher',
       duration: const Duration(hours: 1),
       scope: ObserverAccessScope.group,
+      precision: ObserverPositionPrecision.exact,
+      pilotAuthorization: const ObserverPilotAuthorization(
+        deviceId: 'pilot-device',
+        devicePublicKey: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        signedAtMilliseconds: 1234,
+        signature:
+            'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      ),
     );
 
     expect(jsonDecode(captured.body), {
       'label': 'Ride watcher',
       'durationMinutes': 60,
       'consentConfirmed': true,
+      'precision': 'exact',
       'scope': 'group',
       'groupDisclosureConfirmed': true,
+      'pilotAuthorization': {
+        'deviceId': 'pilot-device',
+        'devicePublicKey': 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        'signedAtMilliseconds': 1234,
+        'signature':
+            'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      },
     });
     expect(credentials.grant.scope, ObserverAccessScope.group);
+    expect(credentials.grant.precision, ObserverPositionPrecision.exact);
   });
 
   test('uses a different credential for inspect, publish and revoke', () async {

--- a/apps/mobile/test/services/flight_data_exporter_test.dart
+++ b/apps/mobile/test/services/flight_data_exporter_test.dart
@@ -1,0 +1,130 @@
+import 'package:balloon_crumbs/domain/altitude.dart';
+import 'package:balloon_crumbs/domain/imported_route.dart';
+import 'package:balloon_crumbs/domain/ride_event.dart';
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/services/flight_data_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final start = DateTime.utc(2026, 8, 24, 6);
+  final session = RideSession(
+    rideId: 'flight-1',
+    rideCode: 'TUCKER',
+    inviteSecret: 'invite-secret-long-enough',
+    joinToken: 'join-token-0123456789',
+    localRiderId: 'pilot',
+    displayName: 'Pilot',
+    role: RideRole.lead,
+    joinedAt: start,
+  );
+
+  RideEvent fix(
+    String id,
+    int seconds, {
+    Object? latitude = 51.303,
+    Object? altitude = 120,
+  }) => RideEvent(
+    id: id,
+    rideId: session.rideId,
+    deviceId: session.localRiderId,
+    type: RideEventType.riderLocationUpdated,
+    priority: EventPriority.routine,
+    signature: 'test',
+    createdAt: start.add(Duration(seconds: seconds)),
+    payload: {
+      'location': {
+        'sample': {
+          'position': {'latitude': latitude, 'longitude': -2.409},
+          'recordedAt': start.add(Duration(seconds: seconds)).toIso8601String(),
+          if (altitude != null) ...{
+            'altitudeMeters': altitude,
+            'altitudeSource': 'gnss',
+            'altitudeDatum': 'wgs84Geoid',
+            'altitudeAccuracyMeters': 6,
+          },
+        },
+      },
+    },
+  );
+
+  ImportedRoute plan() => ImportedRoute(
+    id: 'plan',
+    name: 'Forecast flight',
+    importedAt: start,
+    sourceFileName: 'plan.json',
+    purpose: ImportedRoutePurpose.balloonForecast,
+    paths: const [
+      RoutePath(
+        kind: RoutePathKind.track,
+        points: [
+          GeoPoint(latitude: 51.3, longitude: -2.4, elevationMeters: 150),
+          GeoPoint(latitude: 51.4, longitude: -2.3),
+        ],
+      ),
+    ],
+    waypoints: const [],
+  );
+
+  test('CSV labels measured, calculated, missing and rejected telemetry', () {
+    final csv = const FlightDataExporter().telemetryCsv(
+      session: session,
+      events: [
+        fix('measured', 0),
+        fix('missing-altitude', 30, altitude: null),
+        fix('rejected-altitude', 60, altitude: 'bad'),
+        fix('rejected-position', 90, latitude: 500),
+        fix('after-gap', 300),
+      ],
+      plannedRoute: plan(),
+    );
+
+    expect(csv, contains('"position_quality","altitude_quality"'));
+    expect(csv, contains('"measured","measured","gnss","wgs84Geoid"'));
+    expect(csv, contains('"measured","missing","unknown","unknown"'));
+    expect(csv, contains('"measured","rejected","unknown","unknown"'));
+    expect(csv, contains('"rejected"'));
+    expect(csv, contains('"recording_gap"'));
+    expect(csv, contains('"calculated","calculated"'));
+    expect(csv, contains('"calculated","missing"'));
+    expect(csv, isNot(contains('"pilot"')));
+  });
+
+  test('KML separates the measured track from the calculated plan', () {
+    final route = ImportedRoute(
+      id: 'track',
+      name: 'Recorded flight',
+      importedAt: start,
+      sourceFileName: 'track.gpx',
+      paths: const [
+        RoutePath(
+          kind: RoutePathKind.track,
+          points: [
+            GeoPoint(
+              latitude: 51.303,
+              longitude: -2.409,
+              elevationMeters: 120,
+              altitudeSource: AltitudeSource.gnss,
+              altitudeDatum: AltitudeDatum.wgs84Geoid,
+            ),
+            GeoPoint(latitude: 51.304, longitude: -2.408),
+          ],
+        ),
+      ],
+      waypoints: const [],
+    );
+
+    final kml = const FlightDataExporter().kml(
+      name: 'Tucker flight',
+      traveledRoute: route,
+      plannedRoute: plan(),
+    );
+
+    expect(kml, contains('Recorded track'));
+    expect(kml, contains('Planned or forecast route'));
+    expect(kml, contains('<value>measured</value>'));
+    expect(kml, contains('<value>calculated</value>'));
+    expect(kml, contains('-2.408,51.304'));
+    expect(kml, isNot(contains('-2.408,51.304,0')));
+  });
+}

--- a/apps/mobile/test/services/observer_group_authorization_test.dart
+++ b/apps/mobile/test/services/observer_group_authorization_test.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:balloon_crumbs/domain/ride_role.dart';
+import 'package:balloon_crumbs/domain/ride_session.dart';
+import 'package:balloon_crumbs/internet/observer_access_client.dart';
+import 'package:balloon_crumbs/services/device_identity.dart';
+import 'package:balloon_crumbs/services/observer_group_authorization.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'builds the relay canonical challenge and signs it with the pilot key',
+    () async {
+      final identity = await DeviceIdentity.fromSeed(
+        rideId: 'flight-1',
+        seed: List<int>.generate(32, (index) => index),
+      );
+      final session = RideSession(
+        rideId: 'flight-1',
+        rideCode: 'TUCKER',
+        inviteSecret: 'invite-secret-long-enough',
+        joinToken: 'join-token-0123456789',
+        localRiderId: identity.deviceId,
+        displayName: 'Pilot',
+        role: RideRole.lead,
+        joinedAt: DateTime.utc(2026, 8, 24, 6),
+      );
+      final signedAt = DateTime.utc(2026, 8, 24, 6, 30);
+
+      final proof = await ObserverGroupAuthorization.sign(
+        session: session,
+        identity: identity,
+        label: '  Home   contact ',
+        duration: const Duration(minutes: 60),
+        precision: ObserverPositionPrecision.reduced,
+        signedAt: signedAt,
+      );
+      final challenge = ObserverGroupAuthorization.buildChallenge(
+        rideId: session.rideId,
+        deviceId: identity.deviceId,
+        devicePublicKey: identity.publicKey,
+        signedAtMilliseconds: signedAt.millisecondsSinceEpoch,
+        label: '  Home   contact ',
+        durationMinutes: 60,
+        precision: ObserverPositionPrecision.reduced,
+      );
+
+      expect(
+        challenge,
+        'balloon-crumbs-observer-group-grant-v1\n'
+        '{"deviceId":"${identity.deviceId}",'
+        '"devicePublicKey":"${identity.publicKey}",'
+        '"durationMinutes":60,"label":"Home contact",'
+        '"precision":"reduced","rideId":"flight-1","scope":"group",'
+        '"signedAtMilliseconds":1787553000000}',
+      );
+      final signature = Signature(
+        base64Url.decode(base64Url.normalize(proof.signature)),
+        publicKey: SimplePublicKey(
+          base64Url.decode(base64Url.normalize(identity.publicKey)),
+          type: KeyPairType.ed25519,
+        ),
+      );
+      expect(
+        await Ed25519().verify(utf8.encode(challenge), signature: signature),
+        isTrue,
+      );
+    },
+  );
+}

--- a/apps/server/alembic/versions/0013_observer_precision_and_authority.py
+++ b/apps/server/alembic/versions/0013_observer_precision_and_authority.py
@@ -1,0 +1,38 @@
+"""Bind group observers to pilot authority and store disclosure precision.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-08-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0013"
+down_revision: str | None = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "rides",
+        sa.Column("authority_root_public_key", sa.String(length=43), nullable=True),
+    )
+    op.add_column(
+        "observer_grants",
+        sa.Column(
+            "precision",
+            sa.String(length=16),
+            nullable=False,
+            server_default="reduced",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("observer_grants", "precision")
+    op.drop_column("rides", "authority_root_public_key")

--- a/apps/server/src/balloon_crumbs_server/app.py
+++ b/apps/server/src/balloon_crumbs_server/app.py
@@ -855,6 +855,7 @@ def create_app(
         grant, management_token, publisher_token, observer_token = create_observer_grant(
             session,
             settings=settings,
+            cipher=cipher,
             ride_id=ride_id,
             bearer_token=bearer_token,
             request=payload,

--- a/apps/server/src/balloon_crumbs_server/models.py
+++ b/apps/server/src/balloon_crumbs_server/models.py
@@ -36,6 +36,10 @@ class Ride(Base):
         nullable=False,
         default=True,
     )
+    # Public, operation-scoped Ed25519 root. It is not a join credential; it
+    # binds authority-only relay actions to the creator instead of the shared
+    # ride bearer that every crew member holds.
+    authority_root_public_key: Mapped[str | None] = mapped_column(String(43))
 
     events: Mapped[list[StoredEvent]] = relationship(
         back_populates="ride",
@@ -335,6 +339,12 @@ class ObserverGrant(Base):
         nullable=False,
         default="rider",
         server_default="rider",
+    )
+    precision: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default="reduced",
+        server_default="reduced",
     )
     management_token_hash: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)
     publisher_token_hash: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)

--- a/apps/server/src/balloon_crumbs_server/observer.py
+++ b/apps/server/src/balloon_crumbs_server/observer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import base64
 import hmac
+import json
 import re
 import secrets
 import threading
@@ -9,12 +11,14 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
 from .config import Settings
 from .crypto import DataCipher, base64url, token_hash
-from .models import ObserverGrant, Ride
+from .models import ObserverGrant, Ride, StoredEvent
 from .schemas import CreateObserverGrantRequest, PublishObserverSnapshotRequest
 from .service import RelayServiceError
 
@@ -30,6 +34,7 @@ def create_observer_grant(
     session: Session,
     *,
     settings: Settings,
+    cipher: DataCipher,
     ride_id: str,
     bearer_token: str,
     request: CreateObserverGrantRequest,
@@ -48,6 +53,14 @@ def create_observer_grant(
                 bearer_token,
                 lock_for_update=True,
             )
+            if request.scope == "group":
+                _verify_group_pilot_authorization(
+                    session,
+                    cipher=cipher,
+                    ride=ride,
+                    request=request,
+                    now=now,
+                )
             active_count = (
                 session.scalar(
                     select(func.count(ObserverGrant.id)).where(
@@ -72,6 +85,7 @@ def create_observer_grant(
                 ride_id=ride_id,
                 label=label,
                 scope=request.scope,
+                precision=request.precision,
                 management_token_hash=token_hash(management_token),
                 publisher_token_hash=token_hash(publisher_token),
                 observer_token_hash=token_hash(observer_token),
@@ -197,6 +211,8 @@ def publish_observer_snapshot(
             current = decrypted
 
         incoming = request.model_dump(mode="json")
+        if grant.precision == "reduced":
+            incoming = _reduce_snapshot_precision(incoming)
         merged = {
             "scope": grant.scope,
             "subjectName": incoming["subjectName"],
@@ -356,6 +372,7 @@ def observer_snapshot(
         return {
             "protocolVersion": 2 if scope == "group" else 1,
             "scope": scope,
+            "precision": grant.precision if grant.precision in {"reduced", "exact"} else "reduced",
             "label": grant.label,
             "subjectName": snapshot.get("subjectName"),
             "rideStatus": snapshot.get("rideStatus", "waiting"),
@@ -375,6 +392,7 @@ def grant_json(grant: ObserverGrant) -> dict[str, Any]:
         "id": grant.id,
         "label": grant.label,
         "scope": grant.scope if grant.scope in {"rider", "group"} else "rider",
+        "precision": grant.precision if grant.precision in {"reduced", "exact"} else "reduced",
         "createdAt": _as_utc(grant.created_at),
         "expiresAt": _as_utc(grant.expires_at),
         "revokedAt": _as_utc(grant.revoked_at) if grant.revoked_at else None,
@@ -401,6 +419,302 @@ def _authenticated_ride(
     if not hmac.compare_digest(ride.token_hash, token_hash(bearer_token)):
         raise RelayServiceError(403, "Ride credential rejected")
     return ride
+
+
+def _verify_group_pilot_authorization(
+    session: Session,
+    *,
+    cipher: DataCipher,
+    ride: Ride,
+    request: CreateObserverGrantRequest,
+    now: datetime,
+) -> None:
+    proof = request.pilotAuthorization
+    if proof is None or ride.authority_root_public_key is None:
+        raise RelayServiceError(403, "Pilot authorization is required")
+    signed_at = datetime.fromtimestamp(proof.signedAtMilliseconds / 1000, tz=UTC)
+    if signed_at < now - timedelta(minutes=5) or signed_at > now + timedelta(minutes=2):
+        raise RelayServiceError(400, "Pilot authorization is outside its time window")
+    pilot = _current_pilot_authority(
+        session,
+        cipher=cipher,
+        ride_id=ride.id,
+        root_public_key=ride.authority_root_public_key,
+    )
+    if pilot != (proof.deviceId, proof.devicePublicKey):
+        raise RelayServiceError(403, "Pilot authorization was rejected")
+    challenge = _group_grant_challenge(
+        ride_id=ride.id,
+        device_id=proof.deviceId,
+        public_key=proof.devicePublicKey,
+        signed_at_milliseconds=proof.signedAtMilliseconds,
+        label=" ".join(request.label.split()),
+        duration_minutes=request.durationMinutes,
+        precision=request.precision,
+    )
+    if not _verify_signature(proof.devicePublicKey, proof.signature, challenge):
+        raise RelayServiceError(403, "Pilot authorization was rejected")
+
+
+def _current_pilot_authority(
+    session: Session,
+    *,
+    cipher: DataCipher,
+    ride_id: str,
+    root_public_key: str,
+) -> tuple[str, str] | None:
+    rows = session.scalars(
+        select(StoredEvent)
+        .where(
+            StoredEvent.ride_id == ride_id,
+            StoredEvent.event_type.in_(
+                [
+                    "rideCreated",
+                    "riderJoined",
+                    "pilotHandoverOffered",
+                    "pilotHandoverAccepted",
+                    "deviceAuthorityRotated",
+                    "deviceAuthorityRevoked",
+                ]
+            ),
+        )
+        .order_by(StoredEvent.sequence)
+    ).all()
+    device_keys: dict[str, str] = {}
+    revoked: set[str] = set()
+    pilot_device_id: str | None = None
+    offers: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        try:
+            body = cipher.decrypt_json(
+                row.body_ciphertext,
+                associated_data=f"event:{ride_id}:{row.event_id}".encode(),
+            )
+        except ValueError:
+            continue
+        if not isinstance(body, dict) or body.get("schemaVersion") != 2:
+            continue
+        device_id = body.get("deviceId")
+        public_key = body.get("devicePublicKey")
+        event_type = body.get("type")
+        payload = body.get("payload")
+        if (
+            not isinstance(device_id, str)
+            or not isinstance(public_key, str)
+            or not isinstance(payload, dict)
+            or not _verify_event_signature(body)
+        ):
+            continue
+        known_key = device_keys.get(device_id)
+        if event_type in {"rideCreated", "riderJoined"}:
+            if known_key is not None or not _device_id_matches(ride_id, device_id, public_key):
+                continue
+            if event_type == "rideCreated":
+                if (
+                    pilot_device_id is not None
+                    or public_key != root_public_key
+                    or payload.get("flightRole") != "pilot"
+                ):
+                    continue
+                pilot_device_id = device_id
+            elif payload.get("flightRole") in {"pilot", "observer"}:
+                continue
+            device_keys[device_id] = public_key
+            continue
+        if known_key != public_key or device_id in revoked:
+            continue
+        if event_type == "deviceAuthorityRotated":
+            new_key = payload.get("newPublicKey")
+            new_signature = payload.get("newDeviceSignature")
+            challenge = (
+                "balloon-crumbs-device-rotation-v1\n"
+                f"{ride_id}\n{device_id}\n{public_key}\n{new_key}"
+            )
+            if (
+                isinstance(new_key, str)
+                and isinstance(new_signature, str)
+                and _verify_signature(new_key, new_signature, challenge)
+            ):
+                device_keys[device_id] = new_key
+            continue
+        if event_type == "deviceAuthorityRevoked" and device_id == pilot_device_id:
+            target = payload.get("targetDeviceId")
+            if isinstance(target, str) and target != pilot_device_id:
+                revoked.add(target)
+            continue
+        if event_type == "pilotHandoverOffered" and device_id == pilot_device_id:
+            transfer_id = payload.get("transferId")
+            from_device_id = payload.get("fromDeviceId")
+            to_device_id = payload.get("toDeviceId")
+            offered_at = _event_time(body.get("createdAt"))
+            expires_at = _event_time(payload.get("expiresAt"))
+            if (
+                isinstance(transfer_id, str)
+                and transfer_id
+                and from_device_id == pilot_device_id
+                and isinstance(to_device_id, str)
+                and to_device_id != pilot_device_id
+                and offered_at is not None
+                and expires_at is not None
+                and expires_at > offered_at
+            ):
+                offers[transfer_id] = {
+                    **payload,
+                    "offeredAt": offered_at,
+                    "expiresAtParsed": expires_at,
+                }
+            continue
+        if event_type == "pilotHandoverAccepted":
+            transfer_id = payload.get("transferId")
+            offer = offers.get(transfer_id) if isinstance(transfer_id, str) else None
+            accepted_at = _event_time(body.get("createdAt"))
+            if (
+                offer is not None
+                and accepted_at is not None
+                and offer.get("fromDeviceId") == pilot_device_id
+                and offer.get("toDeviceId") == device_id
+                and payload.get("fromDeviceId") == pilot_device_id
+                and payload.get("toDeviceId") == device_id
+                and accepted_at <= offer["expiresAtParsed"]
+                and accepted_at >= offer["offeredAt"] - timedelta(minutes=2)
+            ):
+                pilot_device_id = device_id
+    if pilot_device_id is None or pilot_device_id in revoked:
+        return None
+    pilot_key = device_keys.get(pilot_device_id)
+    return (pilot_device_id, pilot_key) if pilot_key is not None else None
+
+
+def _verify_event_signature(body: dict[str, Any]) -> bool:
+    signature = body.get("deviceSignature")
+    public_key = body.get("devicePublicKey")
+    if not isinstance(signature, str) or not isinstance(public_key, str):
+        return False
+    signed = {
+        key: body.get(key)
+        for key in (
+            "schemaVersion",
+            "id",
+            "rideId",
+            "deviceId",
+            "type",
+            "priority",
+            "createdAt",
+            "expiresAt",
+            "payload",
+            "devicePublicKey",
+        )
+    }
+    canonical = json.dumps(
+        signed,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return _verify_signature(public_key, signature, canonical)
+
+
+def _event_time(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None
+    return parsed.astimezone(UTC)
+
+
+def _verify_signature(public_key: str, signature: str, challenge: str) -> bool:
+    try:
+        key_bytes = base64.urlsafe_b64decode(public_key + "=")
+        signature_bytes = base64.urlsafe_b64decode(signature + "==")
+        if len(key_bytes) != 32 or len(signature_bytes) != 64:
+            return False
+        Ed25519PublicKey.from_public_bytes(key_bytes).verify(
+            signature_bytes,
+            challenge.encode(),
+        )
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+def _device_id_matches(ride_id: str, device_id: str, public_key: str) -> bool:
+    import hashlib
+
+    digest = hashlib.sha256(
+        f"balloon-crumbs-device-id-v1\n{ride_id}\n{public_key}".encode()
+    ).digest()
+    expected = f"bcd1_{base64.urlsafe_b64encode(digest).decode().rstrip('=')}"
+    return hmac.compare_digest(device_id, expected)
+
+
+def _group_grant_challenge(
+    *,
+    ride_id: str,
+    device_id: str,
+    public_key: str,
+    signed_at_milliseconds: int,
+    label: str,
+    duration_minutes: int,
+    precision: str,
+) -> str:
+    body = {
+        "deviceId": device_id,
+        "devicePublicKey": public_key,
+        "durationMinutes": duration_minutes,
+        "label": label,
+        "precision": precision,
+        "rideId": ride_id,
+        "scope": "group",
+        "signedAtMilliseconds": signed_at_milliseconds,
+    }
+    return "balloon-crumbs-observer-group-grant-v1\n" + json.dumps(
+        body,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _reduce_snapshot_precision(snapshot: dict[str, Any]) -> dict[str, Any]:
+    def reduce_position(value: Any, *, include_accuracy: bool = True) -> Any:
+        if not isinstance(value, dict):
+            return value
+        reduced = dict(value)
+        latitude = reduced.get("latitude")
+        longitude = reduced.get("longitude")
+        if isinstance(latitude, int | float) and isinstance(longitude, int | float):
+            reduced["latitude"] = round(latitude, 2)
+            reduced["longitude"] = round(longitude, 2)
+            if include_accuracy:
+                reduced["accuracyMeters"] = max(
+                    float(reduced.get("accuracyMeters", 0)),
+                    1500.0,
+                )
+        return reduced
+
+    result = dict(snapshot)
+    result["position"] = reduce_position(result.get("position"))
+    participants = result.get("participants")
+    if isinstance(participants, list):
+        result["participants"] = [
+            {**participant, "position": reduce_position(participant.get("position"))}
+            if isinstance(participant, dict)
+            else participant
+            for participant in participants
+        ]
+    route = result.get("route")
+    if isinstance(route, dict) and isinstance(route.get("points"), list):
+        result["route"] = {
+            **route,
+            "points": [reduce_position(point, include_accuracy=False) for point in route["points"]],
+        }
+    return result
 
 
 def _authorized_grant(

--- a/apps/server/src/balloon_crumbs_server/schemas.py
+++ b/apps/server/src/balloon_crumbs_server/schemas.py
@@ -574,6 +574,15 @@ class GetPlanResponse(BaseModel):
     expiresAt: str
 
 
+class ObserverPilotAuthorization(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    deviceId: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+    devicePublicKey: str = Field(pattern=r"^[A-Za-z0-9_-]{43}$")
+    signedAtMilliseconds: int
+    signature: str = Field(pattern=r"^[A-Za-z0-9_-]{86}$")
+
+
 class CreateObserverGrantRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -581,14 +590,20 @@ class CreateObserverGrantRequest(BaseModel):
     durationMinutes: int = Field(ge=30, le=24 * 60)
     consentConfirmed: Literal[True]
     scope: Literal["rider", "group"] = "rider"
+    precision: Literal["reduced", "exact"] = "reduced"
     groupDisclosureConfirmed: Literal[True] | None = None
+    pilotAuthorization: ObserverPilotAuthorization | None = None
 
     @model_validator(mode="after")
     def group_scope_requires_disclosure(self) -> CreateObserverGrantRequest:
         if self.scope == "group" and self.groupDisclosureConfirmed is not True:
             raise ValueError("Group observer access requires group disclosure")
+        if self.scope == "group" and self.pilotAuthorization is None:
+            raise ValueError("Group observer access requires pilot authorization")
         if self.scope == "rider" and self.groupDisclosureConfirmed is not None:
             raise ValueError("Personal observer access has no group disclosure")
+        if self.scope == "rider" and self.pilotAuthorization is not None:
+            raise ValueError("Personal observer access has no pilot authorization")
         return self
 
 
@@ -598,6 +613,7 @@ class ObserverGrantResponse(BaseModel):
     id: str
     label: str
     scope: Literal["rider", "group"] = "rider"
+    precision: Literal["reduced", "exact"] = "reduced"
     createdAt: datetime
     expiresAt: datetime
     revokedAt: datetime | None
@@ -614,7 +630,7 @@ class ObserverPosition(BaseModel):
 
     latitude: float = Field(ge=-90, le=90)
     longitude: float = Field(ge=-180, le=180)
-    accuracyMeters: float = Field(ge=0, le=500)
+    accuracyMeters: float = Field(ge=0, le=5_000)
     recordedAt: datetime
 
     @field_validator("recordedAt")
@@ -707,6 +723,7 @@ class ObserverSnapshotResponse(BaseModel):
 
     protocolVersion: Literal[1, 2] = 1
     scope: Literal["rider", "group"] = "rider"
+    precision: Literal["reduced", "exact"] = "reduced"
     label: str
     subjectName: str | None
     rideStatus: Literal["waiting", "active", "paused", "ended"]

--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -622,6 +622,16 @@ class RelayService:
         )
         with session.begin():
             session.execute(delete(RideJoinCode).where(RideJoinCode.expires_at <= now))
+            ride = self._get_or_claim_ride(session, ride_id, bearer_token, now)
+            if not hmac.compare_digest(ride.token_hash, credential_hash):
+                raise RelayServiceError(403, "Ride credential rejected")
+            if authority_root_public_key is not None:
+                if (
+                    ride.authority_root_public_key is not None
+                    and ride.authority_root_public_key != authority_root_public_key
+                ):
+                    raise RelayServiceError(409, "Ride authority is already registered")
+                ride.authority_root_public_key = authority_root_public_key
             existing = session.get(RideJoinCode, ride_code)
             if existing is not None:
                 same_ride = existing.ride_id == ride_id

--- a/apps/server/tests/test_discovery_withdrawn.py
+++ b/apps/server/tests/test_discovery_withdrawn.py
@@ -78,7 +78,8 @@ def test_the_migration_chain_stays_linear() -> None:
 
     assert revisions["0011"] == "0010"
     assert revisions["0012"] == "0011"
+    assert revisions["0013"] == "0012"
     parents = [parent for parent in revisions.values() if parent is not None]
     assert len(parents) == len(set(parents)), "a revision is claimed as parent twice"
     heads = set(revisions) - set(parents)
-    assert heads == {"0012"}, heads
+    assert heads == {"0013"}, heads

--- a/apps/server/tests/test_join_codes.py
+++ b/apps/server/tests/test_join_codes.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 from balloon_crumbs_server.app import create_app
-from balloon_crumbs_server.models import RideJoinCode
+from balloon_crumbs_server.models import Ride, RideJoinCode
 
 from .conftest import ride_token
 
@@ -65,6 +65,26 @@ def test_join_code_round_trips_the_device_authority_root(client) -> None:
 
     assert resolved.status_code == 200
     assert resolved.json()["authorityRootPublicKey"] == ROOT_KEY
+    with client.app.state.session_factory() as session:
+        assert session.get(Ride, "ride-device-authority").authority_root_public_key == ROOT_KEY
+
+
+def test_registered_device_authority_root_cannot_be_replaced(client) -> None:
+    body = {
+        "rideId": "ride-device-authority-lock",
+        "inviteSecret": SECRET,
+        "resolveToken": RESOLVE_TOKEN,
+        "authorityRootPublicKey": ROOT_KEY,
+    }
+    headers = {"authorization": f"Bearer {ride_token('ride-device-authority-lock', SECRET)}"}
+    assert client.put("/api/v1/join-codes/123456", json=body, headers=headers).status_code == 204
+
+    rejected = client.put(
+        "/api/v1/join-codes/123456",
+        json={**body, "authorityRootPublicKey": "B" * 43},
+        headers=headers,
+    )
+    assert rejected.status_code == 409
 
 
 def test_resolve_with_correct_token_succeeds(client) -> None:

--- a/apps/server/tests/test_observer_access.py
+++ b/apps/server/tests/test_observer_access.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+import json
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -11,11 +15,162 @@ from sqlalchemy.orm import Session
 from balloon_crumbs_server.app import create_app
 from balloon_crumbs_server.models import ObserverGrant
 from balloon_crumbs_server.observer import get_managed_observer_grant
-from balloon_crumbs_server.service import RelayServiceError
+from balloon_crumbs_server.service import RelayServiceError, purge_expired
 
 from .conftest import event, ride_token, sync_request
 
 SECRET = "observer-test-secret-0123456789"
+PILOT_SEED = bytes(range(32))
+
+
+def _b64(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode().rstrip("=")
+
+
+def _identity(
+    ride_id: str,
+    seed: bytes,
+) -> tuple[Ed25519PrivateKey, str, str]:
+    private_key = Ed25519PrivateKey.from_private_bytes(seed)
+    public_key = _b64(private_key.public_key().public_bytes_raw())
+    device_digest = hashlib.sha256(
+        f"balloon-crumbs-device-id-v1\n{ride_id}\n{public_key}".encode()
+    ).digest()
+    device_id = f"bcd1_{_b64(device_digest)}"
+    return private_key, public_key, device_id
+
+
+def _signed_event(
+    *,
+    ride_id: str,
+    event_id: str,
+    event_type: str,
+    payload: dict,
+    private_key: Ed25519PrivateKey,
+    public_key: str,
+    device_id: str,
+    created_at: datetime,
+) -> dict:
+    value = {
+        "schemaVersion": 2,
+        "id": event_id,
+        "rideId": ride_id,
+        "deviceId": device_id,
+        "type": event_type,
+        "priority": "routine",
+        "createdAt": created_at.isoformat().replace("+00:00", "Z"),
+        "expiresAt": None,
+        "payload": payload,
+        "signature": "a" * 64,
+        "devicePublicKey": public_key,
+        "acknowledged": False,
+    }
+    canonical_event = {
+        key: value[key]
+        for key in (
+            "schemaVersion",
+            "id",
+            "rideId",
+            "deviceId",
+            "type",
+            "priority",
+            "createdAt",
+            "expiresAt",
+            "payload",
+            "devicePublicKey",
+        )
+    }
+    value["deviceSignature"] = _b64(
+        private_key.sign(
+            json.dumps(
+                canonical_event,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+                allow_nan=False,
+            ).encode()
+        )
+    )
+    return value
+
+
+def _group_authorization(
+    *,
+    ride_id: str,
+    private_key: Ed25519PrivateKey,
+    public_key: str,
+    device_id: str,
+    precision: str,
+    signed_at: datetime | None = None,
+) -> dict[str, object]:
+    signed_at_milliseconds = int((signed_at or datetime.now(UTC)).timestamp() * 1000)
+    challenge_body = {
+        "deviceId": device_id,
+        "devicePublicKey": public_key,
+        "durationMinutes": 60,
+        "label": "Home contact",
+        "precision": precision,
+        "rideId": ride_id,
+        "scope": "group",
+        "signedAtMilliseconds": signed_at_milliseconds,
+    }
+    challenge = "balloon-crumbs-observer-group-grant-v1\n" + json.dumps(
+        challenge_body,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return {
+        "deviceId": device_id,
+        "devicePublicKey": public_key,
+        "signedAtMilliseconds": signed_at_milliseconds,
+        "signature": _b64(private_key.sign(challenge.encode())),
+    }
+
+
+def _pilot_authority(client, ride_id: str, *, precision: str) -> dict[str, object]:
+    private_key, public_key, device_id = _identity(ride_id, PILOT_SEED)
+    authority_event = _signed_event(
+        ride_id=ride_id,
+        event_id="pilot-authority",
+        event_type="rideCreated",
+        payload={
+            "displayName": "Pilot",
+            "role": "lead",
+            "flightRole": "pilot",
+        },
+        private_key=private_key,
+        public_key=public_key,
+        device_id=device_id,
+        created_at=datetime.now(UTC),
+    )
+    synchronized = sync_request(
+        client,
+        ride_id=ride_id,
+        secret=SECRET,
+        device_id=device_id,
+        events=[authority_event],
+    )
+    assert synchronized.status_code == 200
+    registered = client.put(
+        "/api/v1/join-codes/987654",
+        json={
+            "rideId": ride_id,
+            "inviteSecret": SECRET,
+            "resolveToken": "observer-authority-token",
+            "authorityRootPublicKey": public_key,
+        },
+        headers={"authorization": f"Bearer {ride_token(ride_id, SECRET)}"},
+    )
+    assert registered.status_code == 204
+    return _group_authorization(
+        ride_id=ride_id,
+        private_key=private_key,
+        public_key=public_key,
+        device_id=device_id,
+        precision=precision,
+    )
 
 
 def _create_ride(client, ride_id: str, events: list[dict] | None = None) -> None:
@@ -34,7 +189,11 @@ def _create_grant(
     device_header: str = "rider-a",
     *,
     scope: str = "rider",
+    precision: str = "exact",
 ):
+    pilot_authorization = (
+        _pilot_authority(client, ride_id, precision=precision) if scope == "group" else None
+    )
     return client.post(
         f"/api/v1/rides/{ride_id}/observer-grants",
         headers={
@@ -48,7 +207,13 @@ def _create_grant(
             "durationMinutes": 60,
             "consentConfirmed": True,
             "scope": scope,
+            "precision": precision,
             **({"groupDisclosureConfirmed": True} if scope == "group" else {}),
+            **(
+                {"pilotAuthorization": pilot_authorization}
+                if pilot_authorization is not None
+                else {}
+            ),
         },
     )
 
@@ -208,6 +373,42 @@ def test_independent_publisher_supplies_only_the_minimized_snapshot(client) -> N
     assert ride_id not in observed.text
 
 
+def test_reduced_precision_is_the_default_and_is_applied_by_the_relay(client) -> None:
+    ride_id = "ride-observer-reduced-default"
+    now = datetime.now(UTC)
+    _create_ride(client, ride_id)
+    created = client.post(
+        f"/api/v1/rides/{ride_id}/observer-grants",
+        headers={"authorization": f"Bearer {ride_token(ride_id, SECRET)}"},
+        json={
+            "label": "Home contact",
+            "durationMinutes": 60,
+            "consentConfirmed": True,
+        },
+    )
+    assert created.status_code == 201
+    grant = created.json()
+    assert grant["precision"] == "reduced"
+
+    published = client.put(
+        f"/api/v1/observer-grants/{grant['id']}/snapshot",
+        headers=_authorization(grant["publisherToken"]),
+        json=_snapshot(now),
+    )
+    assert published.status_code == 204
+    body = client.get(
+        f"/api/v1/observer-grants/{grant['id']}",
+        headers=_authorization(grant["observerToken"]),
+    ).json()
+    assert body["precision"] == "reduced"
+    assert body["position"] == {
+        "latitude": 51.51,
+        "longitude": -0.13,
+        "accuracyMeters": 1500.0,
+        "recordedAt": now.isoformat().replace("+00:00", "Z"),
+    }
+
+
 def test_group_grant_publishes_a_bounded_read_only_group_snapshot(client) -> None:
     ride_id = "ride-observer-group"
     now = datetime.now(UTC)
@@ -244,6 +445,153 @@ def test_group_grant_publishes_a_bounded_read_only_group_snapshot(client) -> Non
     assert body["assistance"] is None
     assert ride_id not in observed.text
     assert SECRET not in observed.text
+
+
+def test_group_reduced_precision_covers_participants_and_route_points(client) -> None:
+    ride_id = "ride-observer-group-reduced"
+    now = datetime.now(UTC)
+    _create_ride(client, ride_id)
+    grant = _create_grant(
+        client,
+        ride_id,
+        scope="group",
+        precision="reduced",
+    ).json()
+    assert (
+        client.put(
+            f"/api/v1/observer-grants/{grant['id']}/snapshot",
+            headers=_authorization(grant["publisherToken"]),
+            json=_group_snapshot(now),
+        ).status_code
+        == 204
+    )
+    body = client.get(
+        f"/api/v1/observer-grants/{grant['id']}",
+        headers=_authorization(grant["observerToken"]),
+    ).json()
+    assert body["precision"] == "reduced"
+    assert body["participants"][0]["position"]["latitude"] == 51.51
+    assert body["participants"][0]["position"]["accuracyMeters"] == 1500
+    assert body["route"]["points"][0] == {
+        "latitude": 51.51,
+        "longitude": -0.13,
+    }
+
+
+def test_group_observer_authority_follows_an_accepted_pilot_handover(client) -> None:
+    ride_id = "ride-observer-pilot-handover"
+    _create_ride(client, ride_id)
+    old_pilot_proof = _pilot_authority(client, ride_id, precision="exact")
+    pilot_key, pilot_public_key, pilot_id = _identity(ride_id, PILOT_SEED)
+    crew_key, crew_public_key, crew_id = _identity(ride_id, bytes(range(31, -1, -1)))
+    now = datetime.now(UTC)
+    joined = _signed_event(
+        ride_id=ride_id,
+        event_id="crew-authority",
+        event_type="riderJoined",
+        payload={
+            "displayName": "Balloon crew",
+            "role": "rider",
+            "flightRole": "balloonCrew",
+        },
+        private_key=crew_key,
+        public_key=crew_public_key,
+        device_id=crew_id,
+        created_at=now,
+    )
+    offered = _signed_event(
+        ride_id=ride_id,
+        event_id="handover-offered",
+        event_type="pilotHandoverOffered",
+        payload={
+            "transferId": "transfer-1",
+            "fromDeviceId": pilot_id,
+            "toDeviceId": crew_id,
+            "expiresAt": (now + timedelta(minutes=10)).isoformat(),
+        },
+        private_key=pilot_key,
+        public_key=pilot_public_key,
+        device_id=pilot_id,
+        created_at=now + timedelta(seconds=1),
+    )
+    accepted = _signed_event(
+        ride_id=ride_id,
+        event_id="handover-accepted",
+        event_type="pilotHandoverAccepted",
+        payload={
+            "transferId": "transfer-1",
+            "fromDeviceId": pilot_id,
+            "toDeviceId": crew_id,
+        },
+        private_key=crew_key,
+        public_key=crew_public_key,
+        device_id=crew_id,
+        created_at=now + timedelta(seconds=2),
+    )
+    for device_id, event_body in (
+        (crew_id, joined),
+        (pilot_id, offered),
+        (crew_id, accepted),
+    ):
+        synchronized = sync_request(
+            client,
+            ride_id=ride_id,
+            secret=SECRET,
+            device_id=device_id,
+            events=[event_body],
+        )
+        assert synchronized.status_code == 200
+
+    def create(proof: dict[str, object]):
+        return client.post(
+            f"/api/v1/rides/{ride_id}/observer-grants",
+            headers={"authorization": f"Bearer {ride_token(ride_id, SECRET)}"},
+            json={
+                "label": "Home contact",
+                "durationMinutes": 60,
+                "consentConfirmed": True,
+                "scope": "group",
+                "precision": "exact",
+                "groupDisclosureConfirmed": True,
+                "pilotAuthorization": proof,
+            },
+        )
+
+    assert create(old_pilot_proof).status_code == 403
+    new_pilot_proof = _group_authorization(
+        ride_id=ride_id,
+        private_key=crew_key,
+        public_key=crew_public_key,
+        device_id=crew_id,
+        precision="exact",
+    )
+    assert create(new_pilot_proof).status_code == 201
+
+
+def test_shared_ride_bearer_cannot_forge_group_observer_authority(client) -> None:
+    ride_id = "ride-observer-forged-group"
+    _create_ride(client, ride_id)
+    response = client.post(
+        f"/api/v1/rides/{ride_id}/observer-grants",
+        headers={"authorization": f"Bearer {ride_token(ride_id, SECRET)}"},
+        json={
+            "label": "Home contact",
+            "durationMinutes": 60,
+            "consentConfirmed": True,
+            "scope": "group",
+            "precision": "reduced",
+            "groupDisclosureConfirmed": True,
+            "pilotAuthorization": {
+                "deviceId": "spoofed-crew-device",
+                "devicePublicKey": "A" * 43,
+                "signedAtMilliseconds": int(datetime.now(UTC).timestamp() * 1000),
+                "signature": "A" * 86,
+            },
+        },
+    )
+    assert response.status_code == 403
+    with Session(client.app.state.engine) as session:
+        assert session.scalar(select(ObserverGrant)) is None
 
 
 def test_observer_grant_scope_cannot_be_changed_by_its_publisher(client) -> None:
@@ -517,6 +865,23 @@ def test_expired_grant_denies_all_roles(client) -> None:
         ).status_code
         == 404
     )
+
+
+def test_expired_grant_is_deleted_by_bounded_retention_cleanup(client) -> None:
+    ride_id = "ride-observer-retention-cleanup"
+    _create_ride(client, ride_id)
+    grant = _create_grant(client, ride_id).json()
+    now = datetime.now(UTC)
+    with Session(client.app.state.engine) as session, session.begin():
+        stored = session.get(ObserverGrant, grant["id"])
+        assert stored is not None
+        stored.expires_at = now - timedelta(seconds=1)
+
+    with Session(client.app.state.engine) as session:
+        counts = purge_expired(session, now=now)
+    assert counts[5] == 1
+    with Session(client.app.state.engine) as session:
+        assert session.get(ObserverGrant, grant["id"]) is None
 
 
 def test_new_status_cannot_roll_back_an_existing_position(client) -> None:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -42,7 +42,7 @@ not a claim that every P0 item is small. Work packages are defined in
 | 18 | P1 | Decide airspace, NOTAM, landing-note, and access data sources (#13) | WP11 | 5 |
 | 19 | P1 | Evaluate aeronautical chart layers as flight context (#17) | WP11 | 18 |
 | 20 | P1 | Restore CarPlay / Android Auto for the chase driver | — | 8 |
-| 21 | P1 | Revocable observer sharing and balloon-specific exports | — | 3, 5 |
+| 21 | P1 | ~~Revocable observer sharing and balloon-specific exports (#14)~~ **done** | — | 3, 5 |
 | 22 | P2 | Multiple balloons in one event, with a shared vehicle pool | — | 3, 7 |
 | 23 | P2 | Dynamic chase reassignment across balloons by distance and wind | — | 22, 17 |
 | 24 | P1 | Saved launch/landing-area catalogue and time-by-altitude weather scan informed by the Ballooning Maps review | WP11 | 17, 18 |

--- a/docs/observer-access.md
+++ b/docs/observer-access.md
@@ -1,0 +1,90 @@
+# Observer sharing and flight-data exports
+
+Observer access is a deliberately smaller product surface than flight
+membership. A watcher link can show bounded last-known state; it cannot resolve
+the flight code, download the event journal, publish events, or join the crew.
+
+## Credentials and authority
+
+Each grant receives three independent random credentials. The relay stores only
+their SHA-256 hashes:
+
+- `om1_…` manages and revokes the grant;
+- `op1_…` publishes its minimized snapshot; and
+- `ro1_…` reads the snapshot.
+
+The viewer credential is placed in the URL fragment so it is not sent in the
+initial HTTP request, proxy logs, or referrer headers. Management and publisher
+credentials stay in platform secure storage on the phone. Possession of the
+ordinary shared flight bearer is insufficient to read, publish, or revoke a
+grant.
+
+A participant may create a personal grant for the state their own phone
+publishes. A whole-flight grant additionally requires:
+
+1. the in-app disclosure that the crew has been told;
+2. a current, operation-scoped Ed25519 pilot signature over the grant scope,
+   duration, precision, label, flight ID, key identity, and signing time; and
+3. server verification of the signed device-authority journal, including key
+   rotation, revocation, and accepted pilot handover.
+
+This prevents a crew member who knows the shared flight code from silently
+creating a view of everybody.
+
+## Precision and content
+
+Approximate sharing is the default. Before storage, the relay rounds latitude
+and longitude to two decimal places and reports at least 1,500 metres of
+uncertainty. This reduction is applied independently to personal positions,
+group participants, and group route points, so a publisher cannot bypass it.
+
+Exact last-known position is an explicit choice with separate warning and
+consent text. Observer snapshots never contain the event journal, invitation
+credentials, historical trails, altitude, wind, private contact data, or land
+access notes. Responses name whether their precision is `reduced` or `exact`.
+
+## Lifetime, revocation, and retention
+
+Grants last from 30 minutes to 24 hours. Expiry denies all three credentials.
+Revocation immediately denies viewing, publishing, and management, and clears
+the encrypted snapshot. Scheduled relay cleanup removes expired grants and
+ended-flight data within the retention bounds in
+`security-privacy-field-gate.md`.
+
+The phone retains only active grant credentials in secure storage. Expired or
+revoked entries are removed. Completed-flight archives are local, opt-in
+retention and can be deleted from Previous flights; deletion does not retract a
+file the user already exported to another app.
+
+## Flight-data export
+
+Ordinary summary sharing contains no location trail. Adding exact flight data
+requires a separate affirmative choice that names the privacy consequence.
+Previous-flight export repeats that confirmation before opening the system
+share sheet.
+
+An exact export contains:
+
+- GPX 1.1 for interoperable track geometry and altitude metadata;
+- KML with recorded and planned/forecast lines kept distinct; and
+- CSV with each telemetry row classified as `measured`, `calculated`,
+  `missing`, or `rejected`.
+
+The CSV preserves timestamps, metres, altitude source, altitude datum,
+uncertainty, recording gaps, and rejected malformed samples. It excludes crew
+device identifiers and invitation credentials. A missing altitude remains
+blank and is never replaced with zero.
+
+## Verification evidence
+
+The automated evidence includes relay tests for token separation, scope
+isolation, reduced-precision enforcement, pilot authorization, forged shared
+bearers, expiry, revocation, retention cleanup, races, and rate limits. Mobile
+tests cover secure credential persistence, scoped publishing, canonical pilot
+signatures, disclosure UI, exact-export confirmation, KML separation, and all
+four telemetry-quality states.
+
+The remaining field check is deliberately manual: exercise creation,
+foreground/background publication, expiry, and revocation on real iOS and
+Android devices against the production TLS endpoint before treating the feature
+as operationally validated.


### PR DESCRIPTION
Closes #14

## What changed
- require current-pilot Ed25519 authorization for whole-operation observer links
- default observer positions to server-enforced reduced precision, with explicit exact-position consent
- preserve independent, expiring and revocable viewer/publisher/management credentials
- add explicit exact-track confirmation and GPX/KML/CSV flight-data exports
- label telemetry as measured, calculated, missing or rejected, including gaps and altitude metadata
- document credential, retention, revocation and manual field-validation boundaries

## Verification
- `cd apps/mobile && dart format --output=none --set-exit-if-changed lib test`
- `cd apps/mobile && flutter analyze`
- `cd apps/mobile && flutter test -r compact` (1,839 passed, 24 skipped)
- `cd apps/server && uv run ruff format --check .`
- `cd apps/server && uv run ruff check .`
- `cd apps/server && uv run pytest -q --tb=short` (160 passed)
- `git diff --check`

## Remaining field evidence
Real-device foreground/background publication, expiry and revocation remains an operational validation gate and is documented rather than claimed as automated evidence.