### PR TITLE
fix: support honest regional HMLR indexes

### DIFF
--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -9172,7 +9172,8 @@ class _HmlrInspireReferenceSheet extends StatelessWidget {
             const SizedBox(height: 8),
             const Text(
               'A neutral reference outline near the landing zone, using HM '
-              'Land Registry INSPIRE Index Polygons for England and Wales.',
+              'Land Registry INSPIRE Index Polygons where a current relay '
+              'dataset is installed.',
             ),
             const SizedBox(height: 14),
             ListTile(
@@ -9226,7 +9227,8 @@ class _HmlrInspireReferenceSheet extends StatelessWidget {
             Text(
               reference?.limitation ??
                   'Indicative registered freehold extents only. Coverage is '
-                      'England and Wales and may be incomplete.',
+                      'reported by the installed relay dataset and may be '
+                      'incomplete.',
               key: const Key('hmlr-inspire-limitation'),
               style: const TextStyle(color: Color(0xFFFFC857)),
             ),

--- a/apps/server/src/balloon_crumbs_server/inspire.py
+++ b/apps/server/src/balloon_crumbs_server/inspire.py
@@ -20,8 +20,12 @@ LIMITATION = (
     "and does not grant access or permission."
 )
 MAXIMUM_QUERY_FEATURES = 100
-MAXIMUM_RESPONSE_GEOMETRY_BYTES = 256 * 1024
-MAXIMUM_FEATURE_GEOMETRY_BYTES = 64 * 1024
+# Current HMLR authority files contain a small number of legitimate complex
+# freehold polygons above 256 KiB once converted to minified GeoJSON. Keep the
+# cap below the mobile/provider response ceiling while accepting those source
+# records; the aggregate query cap still truncates a crowded result safely.
+MAXIMUM_RESPONSE_GEOMETRY_BYTES = 368 * 1024
+MAXIMUM_FEATURE_GEOMETRY_BYTES = 368 * 1024
 MAXIMUM_FEATURE_POINTS = 20_000
 
 
@@ -64,6 +68,12 @@ class InspireReferenceCatalogue:
             connection = sqlite3.connect(f"{self.path.as_uri()}?mode=ro", uri=True)
             connection.execute("PRAGMA query_only = ON")
             metadata = dict(connection.execute("SELECT key, value FROM metadata"))
+            if not _installed_coverage_contains(
+                metadata,
+                latitude=query.latitude,
+                longitude=query.longitude,
+            ):
+                return _outside_installed_coverage_response(metadata)
             rows = connection.execute(
                 """
                 SELECT p.inspire_id, p.geometry_json
@@ -115,7 +125,11 @@ class InspireReferenceCatalogue:
         return {
             "type": "FeatureCollection",
             "features": features,
-            "metadata": _metadata(dataset_date, truncated=truncated, coverage="England and Wales"),
+            "metadata": _metadata(
+                dataset_date,
+                truncated=truncated,
+                coverage=metadata.get("coverage", "England and Wales"),
+            ),
         }
 
 
@@ -132,6 +146,41 @@ def _outside_coverage_response() -> dict[str, Any]:
             ),
         },
     }
+
+
+def _outside_installed_coverage_response(metadata: dict[str, str]) -> dict[str, Any]:
+    coverage = metadata.get("coverage", "the installed regional index")
+    return {
+        "type": "FeatureCollection",
+        "features": [],
+        "metadata": {
+            "available": False,
+            "coverage": coverage,
+            "limitation": (
+                "This location is outside the installed HMLR regional index. "
+                "Absence of a displayed polygon does not mean land is unregistered "
+                "or that access is permitted."
+            ),
+        },
+    }
+
+
+def _installed_coverage_contains(
+    metadata: dict[str, str],
+    *,
+    latitude: float,
+    longitude: float,
+) -> bool:
+    try:
+        return float(metadata["coverage_min_longitude"]) <= longitude <= float(
+            metadata["coverage_max_longitude"]
+        ) and float(metadata["coverage_min_latitude"]) <= latitude <= float(
+            metadata["coverage_max_latitude"]
+        )
+    except (KeyError, ValueError):
+        # Schema-version 1 catalogues produced before regional coverage bounds
+        # remain readable; their human-readable coverage label still applies.
+        return True
 
 
 def _metadata(dataset_date: date, *, truncated: bool, coverage: str) -> dict[str, Any]:
@@ -165,11 +214,15 @@ def build_catalogue(
     output: Path,
     *,
     dataset_date: date,
+    coverage: str = "England and Wales",
 ) -> int:
     """Build from WGS84 GeoJSON Sequence, keeping no source attributes but the ID."""
 
     if not inputs:
         raise ValueError("At least one GeoJSON Sequence input is required")
+    coverage = coverage.strip()
+    if not coverage or len(coverage) > 200:
+        raise ValueError("Coverage must be between 1 and 200 characters")
     output.parent.mkdir(parents=True, exist_ok=True)
     temporary_handle, temporary_name = tempfile.mkstemp(
         prefix=f".{output.name}.",
@@ -207,8 +260,10 @@ def build_catalogue(
                 ("dataset_date", dataset_date.isoformat()),
                 ("source", SOURCE_NAME),
                 ("source_url", SOURCE_URL),
+                ("coverage", coverage),
             ],
         )
+        coverage_bounds: list[float] | None = None
         for input_path in inputs:
             with input_path.open(encoding="utf-8") as source:
                 for line_number, line in enumerate(source, start=1):
@@ -229,6 +284,13 @@ def build_catalogue(
                     )
                     if cursor.rowcount == 0:
                         continue
+                    if coverage_bounds is None:
+                        coverage_bounds = list(bounds)
+                    else:
+                        coverage_bounds[0] = min(coverage_bounds[0], bounds[0])
+                        coverage_bounds[1] = max(coverage_bounds[1], bounds[1])
+                        coverage_bounds[2] = min(coverage_bounds[2], bounds[2])
+                        coverage_bounds[3] = max(coverage_bounds[3], bounds[3])
                     polygon_id = cursor.lastrowid
                     connection.execute(
                         "INSERT INTO polygon_bounds VALUES (?, ?, ?, ?, ?)",
@@ -237,6 +299,16 @@ def build_catalogue(
                     inserted += 1
         if inserted == 0:
             raise ValueError("The input contained no valid unique polygons")
+        assert coverage_bounds is not None
+        connection.executemany(
+            "INSERT INTO metadata(key, value) VALUES (?, ?)",
+            [
+                ("coverage_min_longitude", str(coverage_bounds[0])),
+                ("coverage_max_longitude", str(coverage_bounds[1])),
+                ("coverage_min_latitude", str(coverage_bounds[2])),
+                ("coverage_max_latitude", str(coverage_bounds[3])),
+            ],
+        )
         connection.execute("PRAGMA optimize")
         connection.commit()
         connection.close()
@@ -316,8 +388,18 @@ def main() -> None:
     parser.add_argument("inputs", nargs="+", type=Path, help="WGS84 GeoJSON Sequence files")
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--dataset-date", required=True, type=date.fromisoformat)
+    parser.add_argument(
+        "--coverage",
+        default="England and Wales",
+        help="Honest description of the installed authority-file coverage",
+    )
     args = parser.parse_args()
-    count = build_catalogue(args.inputs, args.output, dataset_date=args.dataset_date)
+    count = build_catalogue(
+        args.inputs,
+        args.output,
+        dataset_date=args.dataset_date,
+        coverage=args.coverage,
+    )
     print(f"Built {count} indicative INSPIRE polygons at {args.output}")
 
 

--- a/apps/server/tests/test_inspire_reference.py
+++ b/apps/server/tests/test_inspire_reference.py
@@ -54,7 +54,15 @@ def test_build_and_bounded_query_expose_geometry_not_owner_data(tmp_path: Path) 
         _feature("inspire-near", -2.588, 51.454),
     )
 
-    assert build_catalogue([source], output, dataset_date=date(2026, 8, 2)) == 2
+    assert (
+        build_catalogue(
+            [source],
+            output,
+            dataset_date=date(2026, 8, 2),
+            coverage="Bristol and Somerset regional index",
+        )
+        == 2
+    )
     result = InspireReferenceCatalogue(output).query(
         InspireReferenceQuery(latitude=51.4545, longitude=-2.5879, radius_metres=500)
     )
@@ -62,9 +70,44 @@ def test_build_and_bounded_query_expose_geometry_not_owner_data(tmp_path: Path) 
     assert [feature["id"] for feature in result["features"]] == ["inspire-near"]
     assert "ownerName" not in json.dumps(result)
     assert result["metadata"]["datasetDate"] == "2026-08-02"
+    assert result["metadata"]["coverage"] == "Bristol and Somerset regional index"
     assert result["metadata"]["registeredInterestsIncluded"] == ("registered freehold subset only")
     assert "does not identify an owner" in result["metadata"]["limitation"]
     assert len(result["metadata"]["attribution"]) == 2
+
+
+def test_current_hmlr_complex_polygon_fits_bounded_mobile_response(tmp_path: Path) -> None:
+    source = tmp_path / "complex.geojsonseq"
+    output = tmp_path / "current.sqlite"
+    feature = _feature("complex", -2.588, 51.454)
+    ring = [
+        [-2.588 + (index % 100) * 0.000001, 51.454 + (index // 100) * 0.000001]
+        for index in range(5000)
+    ]
+    ring.append(ring[0])
+    feature["geometry"] = {"type": "Polygon", "coordinates": [ring]}
+    _write_sequence(source, feature)
+
+    assert source.stat().st_size > 64 * 1024
+    assert build_catalogue([source], output, dataset_date=date(2026, 8, 2)) == 1
+    result = InspireReferenceCatalogue(output).query(
+        InspireReferenceQuery(latitude=51.454, longitude=-2.588, radius_metres=500)
+    )
+    assert [item["id"] for item in result["features"]] == ["complex"]
+    assert result["metadata"]["truncated"] is False
+
+
+def test_catalogue_rejects_ambiguous_coverage_label(tmp_path: Path) -> None:
+    source = tmp_path / "source.geojsonseq"
+    _write_sequence(source, _feature("one", -2.588, 51.454))
+
+    with pytest.raises(ValueError, match="Coverage"):
+        build_catalogue(
+            [source],
+            tmp_path / "current.sqlite",
+            dataset_date=date(2026, 8, 2),
+            coverage=" ",
+        )
 
 
 def test_catalogue_replacement_and_removal_need_no_app_release(tmp_path: Path) -> None:
@@ -99,6 +142,26 @@ def test_outside_coverage_degrades_without_implying_unregistered_land(tmp_path: 
     assert result["metadata"]["available"] is False
     assert "Scotland" in result["metadata"]["limitation"]
     assert "does not mean land is unregistered" in result["metadata"]["limitation"]
+
+
+def test_outside_installed_regional_index_is_reported_honestly(tmp_path: Path) -> None:
+    source = tmp_path / "bristol.geojsonseq"
+    output = tmp_path / "current.sqlite"
+    _write_sequence(source, _feature("bristol", -2.588, 51.454))
+    build_catalogue(
+        [source],
+        output,
+        dataset_date=date(2026, 8, 2),
+        coverage="Bristol regional index",
+    )
+
+    result = InspireReferenceCatalogue(output).query(
+        InspireReferenceQuery(latitude=53.48, longitude=-2.24, radius_metres=500)
+    )
+    assert result["features"] == []
+    assert result["metadata"]["available"] is False
+    assert result["metadata"]["coverage"] == "Bristol regional index"
+    assert "outside the installed" in result["metadata"]["limitation"]
 
 
 def test_endpoint_is_bounded_and_unavailable_data_does_not_affect_health(

--- a/docs/hmlr-inspire-reference.md
+++ b/docs/hmlr-inspire-reference.md
@@ -77,13 +77,18 @@ cd apps/server
 uv run balloon-crumbs-build-inspire \
   ../../imports/*.geojsonseq \
   --output ../../deploy/maps/data/hmlr/current.sqlite \
-  --dataset-date 2026-08-02
+  --dataset-date 2026-08-02 \
+  --coverage "Somerset Council regional index"
 ```
 
 For national coverage, convert every current England and Wales local-authority
-download in the same batch. HMLR warns that reprojection can displace displayed
-geometry, which is another reason the UI must not describe the result as an
-exact boundary.
+download in the same batch and use `--coverage "England and Wales"`. A regional
+install must list its included authorities honestly in `--coverage`; it must
+never use the national label. HMLR warns that reprojection can displace
+displayed geometry, which is another reason the UI must not describe the result
+as an exact boundary. The builder records the installed data envelope so a
+lookup clearly reports `available: false` outside a regional index instead of
+silently implying that no registered interest exists there.
 
 The builder validates coordinate bounds, geometry size and point count and
 atomically replaces `current.sqlite`; a failed build leaves the prior index in


### PR DESCRIPTION
## Summary
- accept legitimate complex polygons in the current HMLR authority files while retaining the mobile response ceiling
- record and report the exact installed regional coverage and fail honestly outside its envelope
- make the app wording reflect relay-installed coverage and document the regional build procedure

## Verification
- `cd apps/server && uv run ruff format --check .`
- `cd apps/server && uv run ruff check .`
- `cd apps/server && uv run pytest` (163 passed)
- `cd apps/mobile && dart format --output=none --set-exit-if-changed lib/features/map/ride_map_feature.dart`
- `cd apps/mobile && flutter analyze`
- `cd apps/mobile && flutter test test/services/hmlr_inspire_reference_test.dart test/features/map/ride_map_feature_test.dart` (71 passed)
- built and integrity-checked the 2026-08-02 seven-authority regional index (1,110,875 unique polygons); Bristol and Tucker’s Grave queries succeed, Manchester reports outside installed coverage

Related to #77 and #70.