### PR TITLE
fix: submit existing TestFlight builds

### DIFF
--- a/.github/workflows/testflight-status.yml
+++ b/.github/workflows/testflight-status.yml
@@ -1,5 +1,7 @@
 # Reports whether a processed build is assigned to the configured external
-# tester group and what Apple currently reports for its beta review state.
+# tester group and what Apple currently reports for its beta review state. It
+# can also idempotently assign and submit an existing build without rebuilding
+# or uploading the IPA again.
 name: TestFlight status
 
 on:
@@ -9,6 +11,11 @@ on:
         description: iOS build number to inspect
         required: true
         type: string
+      submit_external:
+        description: Assign this existing build and submit it for external beta review
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -19,7 +26,7 @@ concurrency:
 
 jobs:
   status:
-    name: Report external TestFlight status
+    name: Report or submit external TestFlight build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -31,6 +38,7 @@ jobs:
           REVIEW_API_KEY_ID: ${{ secrets.APPSTORE_CONNECT_REVIEW_API_KEY_ID }}
           REVIEW_API_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_REVIEW_API_ISSUER_ID }}
           REVIEW_API_PRIVATE_KEY_BASE64: ${{ secrets.APPSTORE_CONNECT_REVIEW_API_PRIVATE_KEY_BASE64 }}
+          SUBMIT_EXTERNAL: ${{ inputs.submit_external }}
         run: |
           set -euo pipefail
           test -n "$BUILD_NUMBER"
@@ -52,6 +60,10 @@ jobs:
           review_venv="$RUNNER_TEMP/testflight-status-venv"
           python3 -m venv "$review_venv"
           "$review_venv/bin/python" -m pip install --quiet "PyJWT[crypto]==2.10.1"
+          submit_args=()
+          if [ "$SUBMIT_EXTERNAL" != "true" ]; then
+            submit_args+=(--dry-run)
+          fi
           "$review_venv/bin/python" tools/testflight/submit_external.py \
             --bundle-id dev.osholt.ballooncrumbs \
             --build-number "$BUILD_NUMBER" \
@@ -59,4 +71,4 @@ jobs:
             --issuer-id "$REVIEW_API_ISSUER_ID" \
             --key-id "$REVIEW_API_KEY_ID" \
             --private-key "$review_key_path" \
-            --dry-run
+            "${submit_args[@]}"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -138,15 +138,15 @@ jobs:
           REQUESTED: ${{ inputs.build_number }}
         run: |
           set -euo pipefail
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          printf '%s' "$APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64" | base64 -D \
+            > "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
           if [ -n "$REQUESTED" ]; then
             echo "BUILD_NUMBER=$REQUESTED" >> "$GITHUB_ENV"
             echo "Using the requested build number $REQUESTED."
             exit 0
           fi
-          mkdir -p "$HOME/.appstoreconnect/private_keys"
-          printf '%s' "$APPSTORE_CONNECT_API_PRIVATE_KEY_BASE64" | base64 -D \
-            > "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
-          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_$APPSTORE_CONNECT_API_KEY_ID.p8"
           build_number_venv="$RUNNER_TEMP/testflight-build-number-venv"
           python3 -m venv "$build_number_venv"
           "$build_number_venv/bin/python" -m pip install \

--- a/docs/testflight.md
+++ b/docs/testflight.md
@@ -166,6 +166,11 @@ submission uses the separate App Manager key. The `submit_external` workflow
 input defaults to true and the operation is idempotent: a retry leaves an
 existing group assignment or active review submission in place.
 
+To submit an already-processed build without rebuilding or uploading its IPA,
+run the `TestFlight status` workflow with that build number and
+`submit_external` enabled. With the option disabled, the same workflow remains
+a read-only status check.
+
 OpenAIP is not a mobile release secret. Aeronautical charts are optional
 planner-only context and the planner reaches them through the relay's bounded
 server-side proxy, so TestFlight binaries contain no OpenAIP credential.


### PR DESCRIPTION
## Summary
- install the upload API key even when a specific TestFlight build number is requested
- let the TestFlight status workflow idempotently submit an existing processed build
- document the direct external-submission path

## Verification
- workflow YAML parsed successfully
- `python3 -m unittest tools/testflight/test_submit_external.py`
- build 35 assigned to External Testers and submitted: WAITING_FOR_REVIEW