### PR TITLE
Make crew rooms and flight roles explicit

### DIFF
--- a/apps/mobile/lib/app/ride_invitation_link_gate.dart
+++ b/apps/mobile/lib/app/ride_invitation_link_gate.dart
@@ -160,6 +160,7 @@ class _RideInvitationLinkGateState extends State<RideInvitationLinkGate> {
                     runSpacing: 8,
                     children: [
                       for (final role in const [
+                        FlightRole.pilot,
                         FlightRole.balloonCrew,
                         FlightRole.chaseDriver,
                         FlightRole.chaseCrew,
@@ -173,6 +174,13 @@ class _RideInvitationLinkGateState extends State<RideInvitationLinkGate> {
                         ),
                     ],
                   ),
+                  if (selectedRole == FlightRole.pilot) ...[
+                    const SizedBox(height: 10),
+                    const Text(
+                      'You will join the balloon crew and request Pilot. The current coordinator must assign it, and you must accept.',
+                      style: TextStyle(color: Color(0xFFABB5C1), fontSize: 13),
+                    ),
+                  ],
                   if (selectedRole.isChasing) ...[
                     const SizedBox(height: 14),
                     TextField(

--- a/apps/mobile/lib/controllers/ride_controller.dart
+++ b/apps/mobile/lib/controllers/ride_controller.dart
@@ -147,6 +147,7 @@ class RideController extends ChangeNotifier {
   /// never reached this phone's journal (#144).
   List<PresenceRosterMember> _presenceRoster = const [];
   List<RideParticipant>? _membershipParticipantsCache;
+  Set<String>? _requestedPilotDeviceIdsCache;
   int _membershipProjectionCount = 0;
   LandingZoneTarget? _landingZoneCache;
   bool _landingZoneDirty = true;
@@ -257,6 +258,32 @@ class RideController extends ChangeNotifier {
   PilotHandoverOffer? get pendingLocalPilotHandover {
     final localId = _session?.localRiderId;
     return localId == null ? null : pilotAuthority.pendingFor(localId);
+  }
+
+  /// Devices that chose Pilot while joining and are waiting for the current
+  /// flight coordinator to offer the existing two-party authority handover.
+  ///
+  /// The request is deliberately advisory: possession of an invitation must
+  /// never be enough to take control of a flight.
+  Set<String> get requestedPilotDeviceIds {
+    final cached = _requestedPilotDeviceIdsCache;
+    if (cached != null) return cached;
+    final requests = <String>{};
+    final ordered = _events.toList(growable: false)
+      ..sort(RideLifecycleReducer.compareEvents);
+    for (final event in ordered) {
+      if (event.type == RideEventType.riderJoined) {
+        if (event.payload['requestedFlightRole'] == FlightRole.pilot.name) {
+          requests.add(event.deviceId);
+        } else {
+          requests.remove(event.deviceId);
+        }
+      } else if (event.type == RideEventType.pilotHandoverAccepted) {
+        final assigned = event.payload['toDeviceId'];
+        if (assigned is String) requests.remove(assigned);
+      }
+    }
+    return _requestedPilotDeviceIdsCache = Set.unmodifiable(requests);
   }
 
   String? get localCraftId => _session?.localCraftId;
@@ -501,6 +528,7 @@ class RideController extends ChangeNotifier {
 
   void _invalidateMembershipProjection() {
     _membershipParticipantsCache = null;
+    _requestedPilotDeviceIdsCache = null;
   }
 
   /// Whether the ride has ended, by the later of its end and reopen events.
@@ -658,6 +686,7 @@ class RideController extends ChangeNotifier {
     final activeSession = _requireSession();
     final name = activeSession.rideName;
     final group = name == null ? 'my Balloon Crumbs group' : '"$name"';
+    final room = currentCrewRoom;
     final invite = joinInviteText(
       activeSession.rideCode,
       activeSession.joinToken,
@@ -666,7 +695,8 @@ class RideController extends ChangeNotifier {
       activeSession.rideCode,
       activeSession.joinToken,
     );
-    return 'Join $group in Balloon Crumbs: $link\n\n'
+    return '${room == null ? '' : '${room.alias} crew room · private code for this launch ${activeSession.rideCode}\n\n'}'
+        'Join $group in Balloon Crumbs: $link\n\n'
         'Enter flight code ${activeSession.rideCode} in the app, or paste this '
         'private invite: $invite.';
   }
@@ -831,6 +861,8 @@ class RideController extends ChangeNotifier {
     RideCoordinationMode coordinationMode = RideCoordinationMode.keepTogether,
     String? rideName,
     String? crewRoomAlias,
+    FlightRole flightRole = FlightRole.pilot,
+    String vehicleLabel = 'Land Rover',
   }) async {
     await _run(() async {
       final roomAlias = crewRoomAlias == null || crewRoomAlias.trim().isEmpty
@@ -843,6 +875,8 @@ class RideController extends ChangeNotifier {
         riderColor: riderColor,
         coordinationMode: coordinationMode,
         rideName: rideName,
+        flightRole: flightRole,
+        vehicleLabel: vehicleLabel,
       );
       if (roomAlias != null) {
         final operation = _requireSession();
@@ -860,7 +894,8 @@ class RideController extends ChangeNotifier {
             deviceId: deviceId,
             deviceCredential: access.deviceCredential,
             displayName: operation.displayName,
-            flightRole: FlightRole.pilot,
+            flightRole: operation.flightRole,
+            vehicleLabel: vehicleLabel,
             owner: access.owner,
             operationGeneration: access.operationGeneration,
             operationExpiresAt: access.operationExpiresAt,
@@ -884,6 +919,9 @@ class RideController extends ChangeNotifier {
     CraftIconStyle craftStyle = craftIconStyleDefault,
     RiderSymbol riderSymbol = riderSymbolDefault,
     RiderColor riderColor = riderColorDefault,
+    String? rideName,
+    FlightRole? flightRole,
+    String? vehicleLabel,
   }) async {
     await _run(() async {
       if (!membership.owner) {
@@ -891,6 +929,8 @@ class RideController extends ChangeNotifier {
           'Only the crew room owner can start a fresh flight.',
         );
       }
+      final operationRole = flightRole ?? membership.flightRole;
+      final operationVehicle = vehicleLabel ?? membership.vehicleLabel;
       await _createRide(
         displayName: displayName,
         craftStyle: craftStyle,
@@ -898,6 +938,9 @@ class RideController extends ChangeNotifier {
         riderColor: riderColor,
         coordinationMode: RideCoordinationMode.keepTogether,
         crewRoomId: membership.roomId,
+        rideName: rideName,
+        flightRole: operationRole,
+        vehicleLabel: operationVehicle,
       );
       final operation = _requireSession();
       try {
@@ -907,6 +950,8 @@ class RideController extends ChangeNotifier {
         );
         await _saveCrewRoomMembership(
           membership.copyWith(
+            flightRole: operationRole,
+            vehicleLabel: operationVehicle,
             operationGeneration: access.operationGeneration,
             operationExpiresAt: access.operationExpiresAt,
             inviteToken: access.inviteToken,
@@ -950,7 +995,7 @@ class RideController extends ChangeNotifier {
           deviceId: membership.deviceId,
           deviceCredential: access.deviceCredential,
           displayName: membership.displayName,
-          flightRole: membership.flightRole,
+          flightRole: _requireSession().flightRole,
           vehicleLabel: membership.vehicleLabel,
           owner: access.owner,
           operationGeneration: access.operationGeneration,
@@ -1009,7 +1054,7 @@ class RideController extends ChangeNotifier {
           deviceId: deviceId,
           deviceCredential: access.deviceCredential,
           displayName: _normaliseName(displayName),
-          flightRole: flightRole,
+          flightRole: _requireSession().flightRole,
           vehicleLabel: vehicleLabel,
           owner: access.owner,
           operationGeneration: access.operationGeneration,
@@ -1224,7 +1269,7 @@ class RideController extends ChangeNotifier {
             deviceId: roomDeviceId,
             deviceCredential: access.deviceCredential,
             displayName: _normaliseName(displayName),
-            flightRole: flightRole,
+            flightRole: _requireSession().flightRole,
             vehicleLabel: vehicleLabel,
             owner: access.owner,
             operationGeneration: access.operationGeneration,
@@ -1314,13 +1359,16 @@ class RideController extends ChangeNotifier {
         joinToken: joinToken,
       );
       final now = _clock();
-      if ((flightRole == FlightRole.pilot && !allowPilotRole) ||
-          flightRole == FlightRole.observer) {
+      if (flightRole == FlightRole.observer) {
         throw const FormatException(
-          'Join as balloon crew, a chase driver, or chase crew.',
+          'Join as pilot, balloon crew, a chase driver, or chase crew.',
         );
       }
-      final craftKind = flightRole.isAboardBalloon
+      final requestedPilot = flightRole == FlightRole.pilot && !allowPilotRole;
+      final assignedFlightRole = requestedPilot
+          ? FlightRole.balloonCrew
+          : flightRole;
+      final craftKind = assignedFlightRole.isAboardBalloon
           ? CraftKind.balloon
           : CraftKind.vehicle;
       final craftLabel = craftKind == CraftKind.balloon
@@ -1346,8 +1394,10 @@ class RideController extends ChangeNotifier {
         authorityRootPublicKey: authorityRootPublicKey,
         localDevicePublicKey: identity?.publicKey,
         displayName: _normaliseName(displayName),
-        role: flightRole == FlightRole.pilot ? RideRole.lead : RideRole.rider,
-        flightRole: flightRole,
+        role: assignedFlightRole == FlightRole.pilot
+            ? RideRole.lead
+            : RideRole.rider,
+        flightRole: assignedFlightRole,
         localCraftId: craftId,
         joinedAt: now,
         craftStyle: craftStyle.kind == craftKind
@@ -1370,6 +1420,7 @@ class RideController extends ChangeNotifier {
           'displayName': session.displayName,
           'role': session.role.name,
           'flightRole': session.flightRole.name,
+          if (requestedPilot) 'requestedFlightRole': FlightRole.pilot.name,
           ...craftStyleWireFields(
             symbol: session.riderSymbol,
             craftStyle: session.craftStyle,
@@ -1484,7 +1535,7 @@ class RideController extends ChangeNotifier {
       if (!hasFlightAuthority ||
           pilotAuthority.pilotDeviceId != session.localRiderId) {
         throw const FormatException(
-          'Only the current pilot can offer handover.',
+          'Only the current flight coordinator can assign the pilot.',
         );
       }
       final balloon = resolveCraftRoster().balloon;
@@ -1495,7 +1546,7 @@ class RideController extends ChangeNotifier {
           target.flightRole != FlightRole.balloonCrew ||
           !target.isIncludedInLiveCount) {
         throw const FormatException(
-          'Choose an active balloon crew member for pilot handover.',
+          'Choose an active balloon crew member to assign as pilot.',
         );
       }
       final now = _clock();
@@ -1757,13 +1808,22 @@ class RideController extends ChangeNotifier {
   /// reporting device, or declare a landing.
   ///
   /// The inherited leader flag remains on the wire for older builds, but it no
-  /// longer grants authority. A restored legacy session is deliberately denied
-  /// authority until its explicit flight assignment has been repaired.
+  /// longer grants authority in device-signed flights. A restored version-one
+  /// creator is deliberately denied authority until they explicitly repair the
+  /// assignment as Pilot; version-one has no signed creation event from which
+  /// stronger authority can be reconstructed.
   bool get hasFlightAuthority {
     final session = _session;
-    return session != null &&
-        !session.requiresFlightAssignment &&
-        session.flightRole.hasFlightAuthority;
+    if (session == null || session.requiresFlightAssignment) return false;
+    final journalPilotDeviceId = pilotAuthority.pilotDeviceId;
+    if (journalPilotDeviceId != null) {
+      return journalPilotDeviceId == session.localRiderId;
+    }
+    if (!session.usesDeviceAuthority) {
+      return session.role == RideRole.lead &&
+          session.flightRole == FlightRole.pilot;
+    }
+    return false;
   }
 
   /// Whether this device may record balloon release and begin live tracking.
@@ -2771,6 +2831,8 @@ class RideController extends ChangeNotifier {
     RideCoordinationMode coordinationMode = RideCoordinationMode.keepTogether,
     String? rideName,
     String? crewRoomId,
+    FlightRole flightRole = FlightRole.pilot,
+    String vehicleLabel = 'Land Rover',
   }) async {
     // The home screen deliberately remains available while an ended ride is
     // set aside (#207). Creating its replacement must file that completed ride
@@ -2802,6 +2864,24 @@ class RideController extends ChangeNotifier {
       kind: CraftKind.balloon,
       label: 'Balloon',
     );
+    final localCraftKind = flightRole.isChasing
+        ? CraftKind.vehicle
+        : CraftKind.balloon;
+    final localCraftLabel = localCraftKind == CraftKind.balloon
+        ? 'Balloon'
+        : _normaliseVehicleLabel(vehicleLabel);
+    final localCraftId = localCraftKind == CraftKind.balloon
+        ? balloonCraftId
+        : _craftIdFor(
+            rideId: rideId,
+            kind: localCraftKind,
+            label: localCraftLabel,
+          );
+    final localCraftStyle = localCraftKind == CraftKind.balloon
+        ? CraftIconStyle.balloon
+        : craftStyle.kind == CraftKind.vehicle
+        ? craftStyle
+        : defaultCraftIconStyleFor(CraftKind.vehicle);
     final session = RideSession(
       rideId: rideId,
       rideCode: _generateCode(),
@@ -2813,12 +2893,12 @@ class RideController extends ChangeNotifier {
       localDevicePublicKey: identity?.publicKey,
       displayName: normalisedDisplayName,
       role: RideRole.lead,
-      flightRole: FlightRole.pilot,
-      localCraftId: balloonCraftId,
+      flightRole: flightRole,
+      localCraftId: localCraftId,
       joinedAt: now,
       isSimulation: isSimulation,
       simulationRiderCount: simulationRiderCount,
-      craftStyle: CraftIconStyle.balloon,
+      craftStyle: localCraftStyle,
       riderSymbol: riderSymbol,
       riderColor: riderColor,
       coordinationMode: coordinationMode,
@@ -2834,7 +2914,10 @@ class RideController extends ChangeNotifier {
       payload: {
         'displayName': session.displayName,
         'role': session.role.name,
-        'flightRole': session.flightRole.name,
+        // Keep the authority-root declaration readable by build 35 and older
+        // clients while newer builds render the creator's actual job.
+        'flightRole': FlightRole.pilot.name,
+        'operationalFlightRole': session.flightRole.name,
         if (isSimulation) 'simulation': true,
         ...craftStyleWireFields(
           symbol: session.riderSymbol,
@@ -2855,22 +2938,34 @@ class RideController extends ChangeNotifier {
         'craftStyle': CraftIconStyle.balloon.name,
       },
     );
+    if (localCraftId != balloonCraftId) {
+      await _record(
+        type: RideEventType.craftRegistered,
+        priority: EventPriority.important,
+        payload: {
+          'craftId': localCraftId,
+          'kind': localCraftKind.name,
+          'label': localCraftLabel,
+          'craftStyle': session.craftStyle.name,
+        },
+      );
+    }
     await _record(
       type: RideEventType.deviceAttachedToCraft,
       priority: EventPriority.important,
       payload: {
         'deviceId': session.localRiderId,
-        'craftId': balloonCraftId,
-        'craftLabel': 'Balloon',
+        'craftId': localCraftId,
+        'craftLabel': localCraftLabel,
       },
     );
     await _record(
       type: RideEventType.craftPrimaryDeviceNominated,
       priority: EventPriority.important,
       payload: {
-        'craftId': balloonCraftId,
+        'craftId': localCraftId,
         'deviceId': session.localRiderId,
-        'craftLabel': 'Balloon',
+        'craftLabel': localCraftLabel,
       },
     );
   }

--- a/apps/mobile/lib/domain/crew_room.dart
+++ b/apps/mobile/lib/domain/crew_room.dart
@@ -84,6 +84,8 @@ class CrewRoomMembership {
 
   CrewRoomMembership copyWith({
     String? alias,
+    FlightRole? flightRole,
+    String? vehicleLabel,
     bool? owner,
     int? operationGeneration,
     DateTime? operationExpiresAt,
@@ -94,8 +96,8 @@ class CrewRoomMembership {
     deviceId: deviceId,
     deviceCredential: deviceCredential,
     displayName: displayName,
-    flightRole: flightRole,
-    vehicleLabel: vehicleLabel,
+    flightRole: flightRole ?? this.flightRole,
+    vehicleLabel: vehicleLabel ?? this.vehicleLabel,
     owner: owner ?? this.owner,
     operationGeneration: operationGeneration ?? this.operationGeneration,
     operationExpiresAt: operationExpiresAt ?? this.operationExpiresAt,

--- a/apps/mobile/lib/domain/flight_role.dart
+++ b/apps/mobile/lib/domain/flight_role.dart
@@ -7,8 +7,10 @@
 /// craft and hold different roles; two drivers in different vehicles share a role
 /// and hold different crafts.
 enum FlightRole {
-  /// Flies the balloon. Exactly one per flight, and the only role that can start
-  /// or end it. Not necessarily the device reporting the balloon's position —
+  /// Flies the balloon. Exactly one per flight after assignment, and normally
+  /// holds authority to change the flight. During setup, the operation creator
+  /// temporarily holds that authority even when their operational role is on
+  /// the ground. Not necessarily the device reporting the balloon's position —
   /// a pilot with both hands on the burner is usually not the one holding a
   /// phone, which is the whole reason craft telemetry is elected rather than
   /// assigned.
@@ -51,8 +53,10 @@ extension FlightRoleLabel on FlightRole {
   /// driving, and never anyone in the basket.
   bool get seesRoadFurniture => this == FlightRole.chaseDriver;
 
-  /// Whether this role holds pilot-only authority over the balloon and shared
-  /// forecast. Starting live recovery is deliberately a separate permission:
+  /// Whether this role normally holds authority over the balloon and shared
+  /// forecast. The operation creator's temporary setup authority is projected
+  /// from the signed journal rather than inferred from this label. Starting
+  /// live recovery is deliberately a separate permission:
   /// field testing showed that the ground crew are the people free to do it at
   /// release, while the pilot is occupied with the aircraft.
   bool get hasFlightAuthority => this == FlightRole.pilot;

--- a/apps/mobile/lib/features/home/home_screen.dart
+++ b/apps/mobile/lib/features/home/home_screen.dart
@@ -1432,7 +1432,9 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
   final _codeFieldKey = GlobalKey();
   RideCoordinationMode _selectedCoordinationMode =
       RideCoordinationMode.keepTogether;
+  FlightRole _selectedCreatorRole = FlightRole.pilot;
   FlightRole _selectedJoinRole = FlightRole.chaseCrew;
+  String? _selectedCrewRoomId;
 
   /// Set once a created ride's code needs sharing before handing off to the
   /// map - the moment a leader most needs it, with people waiting nearby.
@@ -1450,6 +1452,14 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    final ownerRooms = widget.controller.crewRooms
+        .where((room) => room.owner)
+        .toList(growable: false);
+    if (widget.creating && ownerRooms.length == 1) {
+      _selectedCrewRoomId = ownerRooms.single.roomId;
+      _selectedCreatorRole = ownerRooms.single.flightRole;
+      _vehicleLabelController.text = ownerRooms.single.vehicleLabel;
+    }
     WidgetsBinding.instance.addObserver(this);
     _codeFocusNode.addListener(_keepCodeFieldVisible);
   }
@@ -1502,8 +1512,8 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
               const SizedBox(height: 8),
               Text(
                 widget.creating
-                    ? 'You will become the pilot and get a six-digit code to share.'
-                    : 'Choose your job, then enter the six-digit code shared by the pilot. You need a connection once to join, then the app keeps using the secure relay.',
+                    ? 'Choose your job, create the crew room, then share the private launch invitation.'
+                    : 'Choose your job, then enter the six-digit launch code shared by the crew. You need a connection once to join, then the app keeps using the secure relay.',
                 style: const TextStyle(color: Color(0xFFABB5C1)),
               ),
               const SizedBox(height: 24),
@@ -1543,6 +1553,66 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
                   ),
                 ),
                 const SizedBox(height: 12),
+                Text(
+                  'Your role in this flight',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final role in const [
+                      FlightRole.pilot,
+                      FlightRole.balloonCrew,
+                      FlightRole.chaseDriver,
+                      FlightRole.chaseCrew,
+                    ])
+                      ChoiceChip(
+                        key: Key('create-role-${role.name}'),
+                        selected: _selectedCreatorRole == role,
+                        avatar: Icon(
+                          role == FlightRole.pilot ||
+                                  role == FlightRole.balloonCrew
+                              ? Icons.air
+                              : role == FlightRole.chaseDriver
+                              ? Icons.directions_car
+                              : Icons.groups_2_outlined,
+                          size: 18,
+                        ),
+                        label: Text(role.label),
+                        onSelected: (_) =>
+                            setState(() => _selectedCreatorRole = role),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  _selectedCreatorRole == FlightRole.pilot
+                      ? 'You begin as Pilot and can transfer that role later.'
+                      : 'You coordinate setup until an arriving balloon crew member accepts the Pilot assignment.',
+                  style: const TextStyle(
+                    color: Color(0xFFABB5C1),
+                    fontSize: 13,
+                  ),
+                ),
+                if (_selectedCreatorRole.isChasing) ...[
+                  const SizedBox(height: 12),
+                  TextField(
+                    key: const Key('create-vehicle-label-field'),
+                    controller: _vehicleLabelController,
+                    maxLength: 32,
+                    textCapitalization: TextCapitalization.words,
+                    decoration: const InputDecoration(
+                      labelText: 'Your chase vehicle',
+                      helperText:
+                          'Crew joining this vehicle should use the same name.',
+                      hintText: 'e.g. Land Rover',
+                      counterText: '',
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 12),
                 TextField(
                   controller: _rideNameController,
                   maxLength: 32,
@@ -1555,24 +1625,74 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
                 ),
                 const SizedBox(height: 12),
                 if (_selectedCoordinationMode.isGroup) ...[
-                  TextField(
-                    key: const Key('crew-room-alias-field'),
-                    controller: _crewRoomAliasController,
-                    maxLength: 12,
-                    textCapitalization: TextCapitalization.characters,
-                    autocorrect: false,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.allow(RegExp('[A-Za-z0-9]')),
-                      LengthLimitingTextInputFormatter(12),
-                    ],
-                    decoration: const InputDecoration(
-                      labelText: 'Reusable crew room (optional)',
-                      hintText: 'e.g. TUCKER',
-                      helperText:
-                          '5–12 letters or numbers. The name can be reused; private device access cannot be guessed from it.',
-                      counterText: '',
+                  if (widget.controller.crewRooms.any(
+                    (room) => room.owner,
+                  )) ...[
+                    Text(
+                      'Crew room for this launch',
+                      style: Theme.of(context).textTheme.titleMedium,
                     ),
-                  ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        ChoiceChip(
+                          key: const Key('create-new-crew-room'),
+                          selected: _selectedCrewRoomId == null,
+                          label: const Text('New room'),
+                          onSelected: (_) =>
+                              setState(() => _selectedCrewRoomId = null),
+                        ),
+                        for (final room in widget.controller.crewRooms.where(
+                          (room) => room.owner,
+                        ))
+                          ChoiceChip(
+                            key: Key('reuse-crew-room-${room.alias}'),
+                            selected: _selectedCrewRoomId == room.roomId,
+                            avatar: const Icon(Icons.tag, size: 18),
+                            label: Text(room.alias),
+                            onSelected: (_) => setState(() {
+                              _selectedCrewRoomId = room.roomId;
+                              _selectedCreatorRole = room.flightRole;
+                              _vehicleLabelController.text = room.vehicleLabel;
+                            }),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      _selectedCrewRoomId == null
+                          ? 'Create a new reusable crew identity.'
+                          : 'The room name stays the same; this launch gets a fresh private journal and invitation.',
+                      style: const TextStyle(
+                        color: Color(0xFFABB5C1),
+                        fontSize: 13,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                  ],
+                  if (_selectedCrewRoomId == null)
+                    TextField(
+                      key: const Key('crew-room-alias-field'),
+                      controller: _crewRoomAliasController,
+                      maxLength: 12,
+                      textCapitalization: TextCapitalization.characters,
+                      autocorrect: false,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(
+                          RegExp('[A-Za-z0-9]'),
+                        ),
+                        LengthLimitingTextInputFormatter(12),
+                      ],
+                      decoration: const InputDecoration(
+                        labelText: 'Reusable crew room code (optional)',
+                        hintText: 'e.g. TUCKER',
+                        helperText:
+                            '5–12 letters or numbers. TUCKER stays with the crew; every launch still has a fresh private invitation.',
+                        counterText: '',
+                      ),
+                    ),
                   const SizedBox(height: 12),
                 ],
                 TextField(
@@ -1609,6 +1729,14 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
                   runSpacing: 8,
                   children: [
                     ChoiceChip(
+                      key: const Key('join-role-pilot'),
+                      selected: _selectedJoinRole == FlightRole.pilot,
+                      avatar: const Icon(Icons.air, size: 18),
+                      label: const Text('Pilot'),
+                      onSelected: (_) =>
+                          setState(() => _selectedJoinRole = FlightRole.pilot),
+                    ),
+                    ChoiceChip(
                       key: const Key('join-role-balloon-crew'),
                       selected: _selectedJoinRole == FlightRole.balloonCrew,
                       avatar: const Icon(Icons.air, size: 18),
@@ -1637,6 +1765,13 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
                     ),
                   ],
                 ),
+                if (_selectedJoinRole == FlightRole.pilot) ...[
+                  const SizedBox(height: 8),
+                  const Text(
+                    'You will join the balloon crew and request Pilot. The current coordinator must assign it, and you must accept.',
+                    style: TextStyle(color: Color(0xFFABB5C1), fontSize: 13),
+                  ),
+                ],
                 if (_selectedJoinRole.isChasing) ...[
                   const SizedBox(height: 12),
                   TextField(
@@ -1857,17 +1992,37 @@ class _RideFormState extends State<_RideForm> with WidgetsBindingObserver {
           if (mounted) setState(() => _checkingPlanCode = false);
         }
       }
-      await widget.controller.createRide(
-        name,
-        craftStyle: widget.riderProfile.craftStyle,
-        riderSymbol: widget.riderProfile.riderSymbol,
-        riderColor: widget.riderProfile.riderColor,
-        coordinationMode: _selectedCoordinationMode,
-        rideName: _rideNameController.text,
-        crewRoomAlias: _selectedCoordinationMode.isGroup
-            ? _crewRoomAliasController.text
-            : null,
-      );
+      final selectedRoom = _selectedCrewRoomId == null
+          ? null
+          : widget.controller.crewRooms
+                .where((room) => room.roomId == _selectedCrewRoomId)
+                .firstOrNull;
+      if (selectedRoom != null && _selectedCoordinationMode.isGroup) {
+        await widget.controller.startNewCrewRoomOperation(
+          selectedRoom,
+          displayName: name,
+          craftStyle: widget.riderProfile.craftStyle,
+          riderSymbol: widget.riderProfile.riderSymbol,
+          riderColor: widget.riderProfile.riderColor,
+          rideName: _rideNameController.text,
+          flightRole: _selectedCreatorRole,
+          vehicleLabel: _vehicleLabelController.text,
+        );
+      } else {
+        await widget.controller.createRide(
+          name,
+          craftStyle: widget.riderProfile.craftStyle,
+          riderSymbol: widget.riderProfile.riderSymbol,
+          riderColor: widget.riderProfile.riderColor,
+          coordinationMode: _selectedCoordinationMode,
+          rideName: _rideNameController.text,
+          crewRoomAlias: _selectedCoordinationMode.isGroup
+              ? _crewRoomAliasController.text
+              : null,
+          flightRole: _selectedCreatorRole,
+          vehicleLabel: _vehicleLabelController.text,
+        );
+      }
       if (widget.controller.hasActiveRide) {
         final target = widget.initialLandingZone;
         if (target != null) await widget.controller.setLandingZone(target);
@@ -2016,6 +2171,7 @@ class _ShareCodeStep extends StatelessWidget {
   Widget build(BuildContext context) {
     final session = controller.session;
     final code = session?.rideCode ?? '';
+    final room = controller.currentCrewRoom;
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 28, 24, 28),
       child: Column(
@@ -2025,14 +2181,33 @@ class _ShareCodeStep extends StatelessWidget {
           const Icon(Icons.check_circle, color: Color(0xFF6ED89A), size: 40),
           const SizedBox(height: 16),
           Text(
-            session?.rideName ?? 'Flight created',
+            room?.alias ?? session?.rideName ?? 'Flight created',
             style: Theme.of(context).textTheme.headlineMedium,
           ),
           const SizedBox(height: 8),
-          const Text(
-            'Share this code so the group can join.',
-            style: TextStyle(color: Color(0xFFABB5C1)),
+          Text(
+            room == null
+                ? 'Share the private launch code so the crew can join.'
+                : '${room.alias} is the reusable crew room. It stays the same for future launches.',
+            style: const TextStyle(color: Color(0xFFABB5C1)),
           ),
+          if (room != null) ...[
+            const SizedBox(height: 12),
+            const Text(
+              'PRIVATE CODE FOR THIS LAUNCH',
+              style: TextStyle(
+                color: Color(0xFFABB5C1),
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0.8,
+              ),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              'New phones use this code or the private QR/link. It changes when a fresh flight starts; the crew room does not.',
+              style: TextStyle(color: Color(0xFFABB5C1), fontSize: 13),
+            ),
+          ],
           const SizedBox(height: 20),
           Container(
             padding: const EdgeInsets.symmetric(vertical: 18),

--- a/apps/mobile/lib/features/map/ride_map_feature.dart
+++ b/apps/mobile/lib/features/map/ride_map_feature.dart
@@ -330,6 +330,7 @@ class RideMapFeature extends StatefulWidget {
     this.speedLimitDisplay,
     this.showRouteProgress = true,
     this.routeTargetsBalloon = false,
+    this.showLandscapeChaseSplit = false,
     this.basemapConfiguration = const BasemapConfiguration(),
     this.localCraftStyle = craftIconStyleDefault,
     this.localRiderSymbol = riderSymbolDefault,
@@ -400,6 +401,7 @@ class RideMapFeature extends StatefulWidget {
     SpeedLimitDisplayController? speedLimitDisplay,
     bool showRouteProgress = true,
     bool routeTargetsBalloon = false,
+    bool showLandscapeChaseSplit = false,
     bool darkMapStyle = false,
     bool restrainedLightMapStyle = true,
     CraftIconStyle localCraftStyle = craftIconStyleDefault,
@@ -465,6 +467,7 @@ class RideMapFeature extends StatefulWidget {
     speedLimitDisplay: speedLimitDisplay,
     showRouteProgress: showRouteProgress,
     routeTargetsBalloon: routeTargetsBalloon,
+    showLandscapeChaseSplit: showLandscapeChaseSplit,
     basemapConfiguration: BasemapConfiguration.fromEnvironment().forBrightness(
       dark: darkMapStyle,
       restrainedLightStyle: restrainedLightMapStyle,
@@ -568,6 +571,7 @@ class RideMapFeature extends StatefulWidget {
   final SpeedLimitDisplayController? speedLimitDisplay;
   final bool showRouteProgress;
   final bool routeTargetsBalloon;
+  final bool showLandscapeChaseSplit;
   final BasemapConfiguration basemapConfiguration;
   final CraftIconStyle localCraftStyle;
   final RiderSymbol localRiderSymbol;
@@ -735,6 +739,7 @@ class _RideMapFeatureState extends State<RideMapFeature> {
         speedLimitDisplay: widget.speedLimitDisplay,
         showRouteProgress: widget.showRouteProgress,
         routeTargetsBalloon: widget.routeTargetsBalloon,
+        showLandscapeChaseSplit: widget.showLandscapeChaseSplit,
         localCraftStyle: widget.localCraftStyle,
         localRiderSymbol: widget.localRiderSymbol,
         localDisplayName: widget.localDisplayName,
@@ -839,6 +844,7 @@ class RideMapScreen extends StatefulWidget {
     this.speedLimitDisplay,
     this.showRouteProgress = true,
     this.routeTargetsBalloon = false,
+    this.showLandscapeChaseSplit = false,
     this.disposeOfflineTileCache = false,
     this.localCraftStyle = craftIconStyleDefault,
     this.localRiderSymbol = riderSymbolDefault,
@@ -967,6 +973,7 @@ class RideMapScreen extends StatefulWidget {
   final SpeedLimitDisplayController? speedLimitDisplay;
   final bool showRouteProgress;
   final bool routeTargetsBalloon;
+  final bool showLandscapeChaseSplit;
   final bool disposeOfflineTileCache;
   final CraftIconStyle localCraftStyle;
   final RiderSymbol localRiderSymbol;
@@ -1070,8 +1077,8 @@ class _RideMapScreenState extends State<RideMapScreen> {
   /// together and turn the road pane back into the old static TEC viewport.
   bool get _landscapeChaseSplitActive =>
       !_isBalloonView &&
-      widget.rideStarted &&
-      _hasBalloonOverlay &&
+      widget.showLandscapeChaseSplit &&
+      widget.overlayMarkers != null &&
       MediaQuery.maybeOf(context)?.orientation == Orientation.landscape;
 
   bool get _showWindForecast {

--- a/apps/mobile/lib/features/ride/active_ride_shell.dart
+++ b/apps/mobile/lib/features/ride/active_ride_shell.dart
@@ -801,9 +801,9 @@ class _RideActionsPanel extends StatelessWidget {
             ListTile(
               key: const Key('flight-offer-pilot-handover'),
               leading: const Icon(Icons.swap_horiz_rounded),
-              title: const Text('Transfer pilot role'),
+              title: const Text('Assign pilot'),
               subtitle: const Text(
-                'Offer authority to an active crew member in the balloon',
+                'Confirm a Pilot request or transfer authority in the balloon',
               ),
               onTap: onOfferPilotHandover,
             ),
@@ -4935,6 +4935,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       showRouteProgress:
           isDriverView && (widget.routeProgressDisplay?.enabled ?? true),
       routeTargetsBalloon: _chaseGuidanceTarget == ChaseGuidanceTarget.balloon,
+      showLandscapeChaseSplit: _isChaserPerspective,
       darkMapStyle: widget.mapStyleMode.resolveDark(
         MediaQuery.platformBrightnessOf(context),
       ),
@@ -6454,7 +6455,8 @@ class _ActiveRideShellState extends State<ActiveRideShell>
     final balloonDeviceIds =
         widget.rideController.resolveCraftRoster().balloon?.deviceIds.toSet() ??
         const <String>{};
-    return widget.rideController.liveParticipants
+    final requested = widget.rideController.requestedPilotDeviceIds;
+    final targets = widget.rideController.liveParticipants
         .where(
           (participant) =>
               !participant.isLocal &&
@@ -6462,6 +6464,12 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               balloonDeviceIds.contains(participant.riderId),
         )
         .toList(growable: false);
+    return targets..sort((left, right) {
+      final leftRequested = requested.contains(left.riderId);
+      final rightRequested = requested.contains(right.riderId);
+      if (leftRequested != rightRequested) return leftRequested ? -1 : 1;
+      return left.displayName.compareTo(right.displayName);
+    });
   }
 
   String? get _pendingPilotHandoverFrom {
@@ -6493,9 +6501,9 @@ class _ActiveRideShellState extends State<ActiveRideShell>
         mainAxisSize: MainAxisSize.min,
         children: [
           const ListTile(
-            title: Text('Transfer pilot role'),
+            title: Text('Assign pilot'),
             subtitle: Text(
-              'Choose someone in the balloon. They become pilot only after accepting the ten-minute offer; you remain pilot until then.',
+              'Choose someone in the balloon. They become Pilot only after accepting the ten-minute offer; you retain flight authority until then.',
             ),
           ),
           for (final participant in targets)
@@ -6503,7 +6511,13 @@ class _ActiveRideShellState extends State<ActiveRideShell>
               key: Key('pilot-handover-target-${participant.riderId}'),
               leading: const Icon(Icons.person_outline),
               title: Text(participant.displayName),
-              subtitle: Text(participant.stateLabel),
+              subtitle: Text(
+                widget.rideController.requestedPilotDeviceIds.contains(
+                      participant.riderId,
+                    )
+                    ? 'Requested Pilot · ${participant.stateLabel}'
+                    : participant.stateLabel,
+              ),
               onTap: () => Navigator.pop(sheetContext, participant),
             ),
           const SizedBox(height: 12),
@@ -6518,7 +6532,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       SnackBar(
         content: Text(
           error ??
-              'Pilot handover offered to ${target.displayName}. You retain authority until they accept.',
+              'Pilot assignment offered to ${target.displayName}. You retain authority until they accept.',
         ),
       ),
     );
@@ -6533,7 +6547,7 @@ class _ActiveRideShellState extends State<ActiveRideShell>
       builder: (dialogContext) => AlertDialog(
         title: const Text('Accept pilot authority?'),
         content: Text(
-          '${pilot?.displayName ?? 'The current pilot'} will become balloon crew and this device will gain authority to update landing intent and end the flight.',
+          '${pilot?.displayName ?? 'The current coordinator'} will no longer hold flight authority. This device will become Pilot and can update landing intent and end the flight.',
         ),
         actions: [
           TextButton(

--- a/apps/mobile/lib/services/device_authority_policy.dart
+++ b/apps/mobile/lib/services/device_authority_policy.dart
@@ -80,7 +80,13 @@ class DeviceAuthorityPolicy {
         return false;
       }
       _pilotDeviceId = event.deviceId;
-      _roles[event.deviceId] = FlightRole.pilot;
+      final operationalRole = flightRoleFromName(
+        event.payload['operationalFlightRole'],
+        fallback: FlightRole.pilot,
+      );
+      _roles[event.deviceId] = operationalRole == FlightRole.observer
+          ? FlightRole.pilot
+          : operationalRole;
       return true;
     }
     if (event.type != RideEventType.riderJoined) {
@@ -172,7 +178,9 @@ class DeviceAuthorityPolicy {
               offer.offeredAt.subtract(PilotAuthorityReducer.maximumClockSkew),
             )) {
           final previousPilot = _pilotDeviceId!;
-          _roles[previousPilot] = FlightRole.balloonCrew;
+          if (_roles[previousPilot] == FlightRole.pilot) {
+            _roles[previousPilot] = FlightRole.balloonCrew;
+          }
           _roles[event.deviceId] = FlightRole.pilot;
           _pilotDeviceId = event.deviceId;
         }

--- a/apps/mobile/lib/services/ride_membership.dart
+++ b/apps/mobile/lib/services/ride_membership.dart
@@ -442,7 +442,12 @@ class RideMembershipReducer {
         final displayName = _nonEmptyString(event.payload['displayName']);
         final role = _role(event.payload['role']);
         if (displayName == null || role == null) continue;
-        final flightRole = flightRoleFromName(event.payload['flightRole']);
+        final flightRole = flightRoleFromName(
+          event.type == RideEventType.rideCreated
+              ? event.payload['operationalFlightRole'] ??
+                    event.payload['flightRole']
+              : event.payload['flightRole'],
+        );
         final isLocal = event.deviceId == localRiderId;
         final joiningRole = isLocal ? localRole : role;
         if (joiningRole == RideRole.lead) {
@@ -724,7 +729,9 @@ class RideMembershipReducer {
                   participant.flightRole == FlightRole.pilot)
                 participant.copyWith(
                   role: RideRole.rider,
-                  flightRole: FlightRole.balloonCrew,
+                  flightRole: participant.flightRole == FlightRole.pilot
+                      ? FlightRole.balloonCrew
+                      : participant.flightRole,
                 )
               else
                 participant,

--- a/apps/mobile/test/app/ride_invitation_link_gate_test.dart
+++ b/apps/mobile/test/app/ride_invitation_link_gate_test.dart
@@ -81,6 +81,33 @@ void main() {
     expect(fixture.rideController.hasFlightAuthority, isFalse);
   });
 
+  testWidgets('choosing Pilot requests a confirmed assignment', (tester) async {
+    const token = 'PilotRequestToken12345678';
+    final fixture = await _Fixture.create(
+      directory: _Directory(expectedCode: '123456', expectedToken: token),
+      link: rideInvitationUrl('123456', token),
+    );
+    addTearDown(fixture.dispose);
+
+    await tester.pumpWidget(fixture.app);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('invitation-role-pilot')));
+    await tester.pump();
+    expect(
+      find.textContaining('current coordinator must assign it'),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const Key('accept-ride-invitation-link')));
+    await tester.pumpAndSettle();
+
+    expect(fixture.rideController.session?.flightRole, FlightRole.balloonCrew);
+    expect(
+      fixture.rideController.requestedPilotDeviceIds,
+      contains(fixture.rideController.session!.localRiderId),
+    );
+    expect(fixture.rideController.hasFlightAuthority, isFalse);
+  });
+
   testWidgets('an invitation cannot silently replace an active ride', (
     tester,
   ) async {

--- a/apps/mobile/test/controllers/crew_room_controller_test.dart
+++ b/apps/mobile/test/controllers/crew_room_controller_test.dart
@@ -48,6 +48,11 @@ void main() {
       expect(controller.currentCrewRoom?.alias, 'TUCKER');
       expect(controller.currentCrewRoom?.owner, isTrue);
       expect(controller.currentCrewRoom?.inviteToken, startsWith('cri1_'));
+      expect(controller.rideCodeShareText, contains('TUCKER crew room'));
+      expect(
+        controller.rideCodeShareText,
+        contains('private code for this launch'),
+      );
       final firstRideId = controller.session!.rideId;
       final membership = controller.currentCrewRoom!;
 
@@ -67,6 +72,32 @@ void main() {
         isTrue,
       );
       expect(directory.startedRideIds, [controller.session!.rideId]);
+    },
+  );
+
+  test(
+    'the room owner keeps their chosen chase role on fresh flights',
+    () async {
+      await controller.createRide(
+        'Oliver',
+        crewRoomAlias: 'TUCKER',
+        flightRole: FlightRole.chaseDriver,
+        vehicleLabel: 'Recovery One',
+      );
+      final membership = controller.currentCrewRoom!;
+      expect(membership.flightRole, FlightRole.chaseDriver);
+      expect(membership.vehicleLabel, 'Recovery One');
+
+      await controller.startRide();
+      await controller.endRide();
+      await controller.startNewCrewRoomOperation(
+        membership,
+        displayName: 'Oliver',
+      );
+
+      expect(controller.session?.flightRole, FlightRole.chaseDriver);
+      expect(controller.localCraft?.craft.label, 'Recovery One');
+      expect(controller.hasFlightAuthority, isTrue);
     },
   );
 

--- a/apps/mobile/test/controllers/ride_controller_test.dart
+++ b/apps/mobile/test/controllers/ride_controller_test.dart
@@ -116,6 +116,52 @@ void main() {
   );
 
   test(
+    'a chase crew creator coordinates setup without becoming Pilot',
+    () async {
+      await controller.createRide(
+        'Oliver',
+        flightRole: FlightRole.chaseCrew,
+        vehicleLabel: 'Recovery One',
+      );
+
+      expect(controller.session?.flightRole, FlightRole.chaseCrew);
+      expect(controller.localCraft?.isBalloon, isFalse);
+      expect(controller.localCraft?.craft.label, 'Recovery One');
+      expect(controller.resolveCraftRoster().balloon, isNotNull);
+      expect(controller.hasFlightAuthority, isTrue);
+      final created = controller.events.first;
+      expect(created.payload['flightRole'], FlightRole.pilot.name);
+      expect(
+        created.payload['operationalFlightRole'],
+        FlightRole.chaseCrew.name,
+      );
+    },
+  );
+
+  test(
+    'choosing Pilot while joining makes an explicit assignment request',
+    () async {
+      await controller.createRide('Oliver');
+      final joiningPilot = await joinedController(FlightRole.pilot);
+
+      expect(joiningPilot.session?.flightRole, FlightRole.balloonCrew);
+      expect(joiningPilot.localCraft?.isBalloon, isTrue);
+      expect(joiningPilot.hasFlightAuthority, isFalse);
+      final joined = joiningPilot.events.singleWhere(
+        (event) => event.type == RideEventType.riderJoined,
+      );
+      expect(joined.payload['requestedFlightRole'], FlightRole.pilot.name);
+      for (final event in joiningPilot.events) {
+        controller.ingestStoredEvent(event);
+      }
+      expect(
+        controller.requestedPilotDeviceIds,
+        contains(joiningPilot.session!.localRiderId),
+      );
+    },
+  );
+
+  test(
     'pilot handover is offered, accepted and applied on both devices',
     () async {
       await controller.createRide('Oliver');

--- a/apps/mobile/test/features/home/home_reachability_test.dart
+++ b/apps/mobile/test/features/home/home_reachability_test.dart
@@ -14,6 +14,7 @@ import 'package:balloon_crumbs/data/in_memory_event_store.dart';
 import 'package:balloon_crumbs/data/in_memory_session_store.dart';
 import 'package:balloon_crumbs/domain/completed_ride.dart';
 import 'package:balloon_crumbs/domain/completed_ride_store.dart';
+import 'package:balloon_crumbs/domain/flight_role.dart';
 import 'package:balloon_crumbs/domain/rider_color.dart';
 import 'package:balloon_crumbs/domain/recorded_route_store.dart';
 import 'package:balloon_crumbs/domain/ride_session.dart';
@@ -179,11 +180,45 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('crew-room-alias-field')), findsOneWidget);
-    expect(find.text('Reusable crew room (optional)'), findsOneWidget);
+    expect(find.text('Reusable crew room code (optional)'), findsOneWidget);
     expect(
-      find.textContaining('private device access cannot be guessed'),
+      find.textContaining('every launch still has a fresh private invitation'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('the flight creator chooses their operational role', (
+    tester,
+  ) async {
+    await pumpHome(tester);
+    await tester.tap(find.text('Create flight'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('create-role-pilot')), findsOneWidget);
+    expect(find.byKey(const Key('create-role-chaseDriver')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('create-role-chaseDriver')));
+    await tester.pump();
+    expect(find.byKey(const Key('create-vehicle-label-field')), findsOneWidget);
+    await tester.enterText(find.byKey(const Key('rider-name-field')), 'Oliver');
+
+    await tester.scrollUntilVisible(
+      find.widgetWithText(FilledButton, 'Create private flight'),
+      180,
+      scrollable: find
+          .descendant(
+            of: find.byKey(const Key('ride-form-scroll-view')),
+            matching: find.byType(Scrollable),
+          )
+          .first,
+    );
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Create private flight'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(rideController.session?.flightRole, FlightRole.chaseDriver);
+    expect(rideController.localCraft?.isBalloon, isFalse);
+    expect(rideController.hasFlightAuthority, isTrue);
   });
 
   testWidgets('a past ride is reachable by words alone', (tester) async {

--- a/apps/mobile/test/features/map/ride_map_feature_test.dart
+++ b/apps/mobile/test/features/map/ride_map_feature_test.dart
@@ -2507,13 +2507,6 @@ void main() {
       addTearDown(navigation.dispose);
       final overlays = ValueNotifier<List<MapOverlayMarker>>(const [
         MapOverlayMarker(
-          id: 'craft-balloon',
-          point: GeoPoint(latitude: 51.37, longitude: -2.35),
-          label: 'Balloon · live',
-          craftStyle: CraftIconStyle.balloon,
-          riderDisplayName: 'Balloon',
-        ),
-        MapOverlayMarker(
           id: 'craft-recovery-two',
           point: GeoPoint(latitude: 51.355, longitude: -2.39),
           label: 'Recovery two · live',
@@ -2572,6 +2565,7 @@ void main() {
             riderTrails: trails,
             groupRiderCount: 3,
             routeTargetsBalloon: true,
+            showLandscapeChaseSplit: true,
             mapOrientation: MapOrientationMode.northUp,
             onMapOrientationChanged: (_) {},
             onNavigationViewportChanged: viewports.add,
@@ -2585,6 +2579,26 @@ void main() {
       await tester.pump(const Duration(milliseconds: 600));
 
       expect(find.byKey(const Key('landscape-relative-map')), findsOneWidget);
+      expect(
+        find.textContaining('Waiting for balloon position'),
+        findsOneWidget,
+      );
+      overlays.value = const [
+        MapOverlayMarker(
+          id: 'craft-balloon',
+          point: GeoPoint(latitude: 51.37, longitude: -2.35),
+          label: 'Balloon · live',
+          craftStyle: CraftIconStyle.balloon,
+          riderDisplayName: 'Balloon',
+        ),
+        MapOverlayMarker(
+          id: 'craft-recovery-two',
+          point: GeoPoint(latitude: 51.355, longitude: -2.39),
+          label: 'Recovery two · live',
+          craftStyle: CraftIconStyle.fourByFour,
+        ),
+      ];
+      await tester.pump();
       expect(find.byKey(const Key('group-mini-map')), findsNothing);
       expect(find.byKey(const Key('route-progress-panel')), findsNothing);
       expect(find.byKey(const Key('relative-map-title')), findsOneWidget);

--- a/apps/mobile/test/services/device_authority_policy_test.dart
+++ b/apps/mobile/test/services/device_authority_policy_test.dart
@@ -103,6 +103,68 @@ void main() {
     },
   );
 
+  test(
+    'a chase coordinator keeps their operational permissions after assigning Pilot',
+    () async {
+      final policy = DeviceAuthorityPolicy(session);
+      final created = await signed(
+        identity: root,
+        type: RideEventType.rideCreated,
+        payload: const {
+          'role': 'lead',
+          'flightRole': 'pilot',
+          'operationalFlightRole': 'chaseDriver',
+        },
+        minute: 0,
+      );
+      final joined = await signed(
+        identity: crew,
+        type: RideEventType.riderJoined,
+        payload: const {
+          'displayName': 'Actual pilot',
+          'role': 'rider',
+          'flightRole': 'balloonCrew',
+          'requestedFlightRole': 'pilot',
+        },
+        minute: 1,
+      );
+      final offered = await signed(
+        identity: root,
+        type: RideEventType.pilotHandoverOffered,
+        payload: {
+          'transferId': 'transfer-1',
+          'fromDeviceId': root.deviceId,
+          'toDeviceId': crew.deviceId,
+          'expiresAt': DateTime.utc(2026, 8, 24, 12, 12).toIso8601String(),
+        },
+        minute: 2,
+      );
+      final accepted = await signed(
+        identity: crew,
+        type: RideEventType.pilotHandoverAccepted,
+        payload: {
+          'transferId': 'transfer-1',
+          'fromDeviceId': root.deviceId,
+          'toDeviceId': crew.deviceId,
+        },
+        minute: 3,
+      );
+      final chaseAction = await signed(
+        identity: root,
+        type: RideEventType.craftChaseAssigned,
+        payload: const {'craftId': 'recovery-one'},
+        minute: 4,
+      );
+
+      expect(policy.accept(created), isTrue);
+      expect(policy.accept(joined), isTrue);
+      expect(policy.accept(offered), isTrue);
+      expect(policy.accept(accepted), isTrue);
+      expect(policy.pilotDeviceId, crew.deviceId);
+      expect(policy.accept(chaseAction), isTrue);
+    },
+  );
+
   test('pilot revocation makes all later device events inert', () async {
     final events = <RideEvent>[
       await signed(

--- a/docs/tester-release-notes.md
+++ b/docs/tester-release-notes.md
@@ -7,19 +7,20 @@ matched to its changes.
 
 ## Next tester build
 
-- Fixes web-planner codes so the app loads the saved flight through the live
-  relay instead of receiving the planner webpage as an invalid response.
-- Fixes **Open in Balloon Crumbs** for both iOS and Play-installed Android
-  builds by aligning the native link handlers and signed domain association.
-- Restores the same relay path for creating and joining live rides with a
-  six-digit ride code.
-- Adds **Plan a balloon flight** to the home map's More menu and opens the live
-  planner in the iOS/Android in-app browser.
-- Includes the planner's maximum-altitude landing envelope, draggable launch
-  and destination points, wind-route search, and timed altitude profile without
-  maintaining a second forecast implementation in the app.
-- Keeps the planner's Open-Meteo/OpenAIP source labels and advisory safety
-  warning visible.
+- Lets the person creating a flight choose Pilot, balloon crew, chase driver,
+  or chase crew instead of assuming that the creator is the Pilot.
+- Lets a joining balloonist request Pilot, with a deliberate assignment and
+  acceptance step so an invitation cannot silently seize flight authority.
+- Makes reusable crew rooms such as `TUCKER` selectable during flight creation
+  and clearly distinguishes the persistent room name from the fresh private
+  six-digit invitation for each launch.
+- Preserves the creator's selected role and chase-vehicle name when starting a
+  fresh flight in the same crew room.
+- Shows the chase split view immediately in phone landscape: a complete
+  north-up crew/balloon overview on the left and direction-up road guidance on
+  the right, including the waiting state before the first balloon fix.
+- Keeps that landscape presentation aligned with CarPlay, including shared
+  tracks, balloon context, road distance, and travel time.
 
 ## 1.0.1 (Play build 26 / TestFlight build 27) — 21 August 2026
 


### PR DESCRIPTION
## Summary
- let flight creators and joiners choose balloon or chase roles without assuming the creator is Pilot
- preserve reusable crew-room identity while clearly labelling each launch's private invitation code
- expose the north-up/direction-up chase split on phone landscape and retain CarPlay parity

## Verification
- dart format --output=none --set-exit-if-changed lib test
- flutter analyze
- flutter test (1,848 passed; 24 intentional skips)
- flutter build ios --simulator --debug --no-codesign
- flutter build apk --debug