### PR TITLE
Fix reusable crew-room HTTP 500

### DIFF
--- a/apps/server/src/balloon_crumbs_server/service.py
+++ b/apps/server/src/balloon_crumbs_server/service.py
@@ -1305,14 +1305,21 @@ class RelayService:
             )
         except ValueError as error:
             raise RelayServiceError(500, "Crew room record is invalid") from error
-        if not isinstance(value, dict) or set(value) != {
-            "rideId",
-            "rideCode",
-            "inviteSecret",
-            "resolveToken",
-        }:
+        required_fields = {"rideId", "rideCode", "inviteSecret", "resolveToken"}
+        allowed_fields = required_fields | {"authorityRootPublicKey"}
+        if (
+            not isinstance(value, dict)
+            or not required_fields.issubset(value)
+            or not set(value).issubset(allowed_fields)
+        ):
             raise RelayServiceError(500, "Crew room record is invalid")
-        if not all(isinstance(item, str) for item in value.values()):
+        if not all(isinstance(value.get(field), str) for field in required_fields):
+            raise RelayServiceError(500, "Crew room record is invalid")
+        authority_root_public_key = value.get("authorityRootPublicKey")
+        if authority_root_public_key is not None and not (
+            isinstance(authority_root_public_key, str)
+            and re.fullmatch(r"[A-Za-z0-9_-]{43}", authority_root_public_key)
+        ):
             raise RelayServiceError(500, "Crew room record is invalid")
         return {key: value[key] for key in value}
 

--- a/apps/server/tests/test_crew_rooms.py
+++ b/apps/server/tests/test_crew_rooms.py
@@ -119,6 +119,55 @@ def test_private_invite_enrols_a_returning_device_and_qr_operation(client) -> No
     assert reopened.json()["operation"] == _operation()
 
 
+def test_device_authority_round_trips_when_room_starts_a_fresh_operation(client) -> None:
+    authority_root = "A" * 43
+    first_operation = {
+        **_operation(),
+        "authorityRootPublicKey": authority_root,
+    }
+    created_response = client.post(
+        "/api/v1/crew-rooms/create",
+        json={
+            "alias": "TUCKER",
+            "deviceId": "room-device-owner",
+            "displayName": "Oliver",
+            "operation": first_operation,
+        },
+        headers={
+            "authorization": (
+                f"Bearer {ride_token(first_operation['rideId'], first_operation['inviteSecret'])}"
+            )
+        },
+    )
+    assert created_response.status_code == 201
+    created = created_response.json()
+
+    reopened = client.post("/api/v1/crew-rooms/open", json=_auth(created))
+    assert reopened.status_code == 200
+    assert reopened.json()["operation"] == first_operation
+
+    second_operation = {
+        **_operation(
+            ride_id="operation-two",
+            ride_code="654321",
+            secret=SECRET_TWO,
+            resolve_token=RESOLVE_TWO,
+        ),
+        "authorityRootPublicKey": "B" * 43,
+    }
+    restarted = client.post(
+        "/api/v1/crew-rooms/start-operation",
+        json={**_auth(created), "operation": second_operation},
+        headers={
+            "authorization": (
+                f"Bearer {ride_token(second_operation['rideId'], second_operation['inviteSecret'])}"
+            )
+        },
+    )
+    assert restarted.status_code == 200
+    assert restarted.json()["operation"] == second_operation
+
+
 def test_reusing_alias_starts_a_fresh_isolated_operation(client) -> None:
     first = _create(client).json()
     second_operation = _operation(


### PR DESCRIPTION
## Summary
- accept the persisted device-authority public key when reopening crew-room operations
- validate the optional key before returning decrypted room state
- cover reopening and starting a fresh operation with device authority

## Verification
- `uv run pytest` (164 passed)
- `uv run ruff format --check src/balloon_crumbs_server/service.py tests/test_crew_rooms.py`
- `uv run ruff check src/balloon_crumbs_server/service.py tests/test_crew_rooms.py`